### PR TITLE
feat(M1): load full mech roster from mechdata/*.MEC filenames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ captures
 logs
 play.pcgi
 
+# Game data — must be copied from an original MPBT installation.
+# These files are proprietary to Kesmai/EA and must NOT be distributed.
+mechdata/
+
 # environment / secrets
 .env
 .env.*

--- a/README.md
+++ b/README.md
@@ -20,6 +20,25 @@ This project reverse-engineers the **ARIES** binary protocol used by `MPBTWIN.EX
 
 The client reaches the mech selection screen, allows browsing, and displays a confirmation dialog before issuing a REDIRECT. That's further than any known prior public attempt.
 
+## Game Data
+
+The server reads mech definitions from `mechdata/*.MEC` files at startup.
+**These files are not included in this repository** — they are proprietary assets
+of Kesmai Corporation / Electronic Arts and must not be redistributed.
+
+To run the server, copy the `mechdata/` directory from your own licensed copy of
+**Multiplayer BattleTech: Solaris** into the project root:
+
+```
+mpbt-server/
+  mechdata/
+    ANH-1A.MEC
+    ARC-2K.MEC
+    ... (161 files total)
+```
+
+---
+
 ## Background
 
 MPBT ran on Kesmai's proprietary **ARIES** engine — the same engine that powered Air Warrior and Legends of Kesmai. The client (`MPBTWIN.EXE`) and its companion DLLs (`COMMEG32.DLL`, `INITAR.DLL`) have been extensively analyzed with Ghidra to reconstruct the wire protocol from scratch.

--- a/src/data/mechs.ts
+++ b/src/data/mechs.ts
@@ -1,0 +1,70 @@
+/**
+ * Mech roster loader.
+ *
+ * Scans mechdata/*.MEC at startup and builds a MechEntry array from the
+ * filenames alone.  The variant designation (e.g. "SDR-5V") comes directly
+ * from the filename; the `variant` and `name` fields are left empty so the
+ * client resolves the chassis display name via its own internal lookup
+ * (MechWin_LookupMechName / FUN_00438280).
+ *
+ * No mech names are hardcoded here.  When the .MEC binary format is fully
+ * reverse-engineered (issue #1) this function can be extended to also parse
+ * stats from the file contents.
+ */
+
+import * as fs   from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { type MechEntry } from '../protocol/game.js';
+
+/**
+ * Resolve the mechdata directory relative to the project root.
+ * Works whether the server is run via ts-node (src/) or compiled (dist/).
+ */
+function mechDataDir(): string {
+  // fileURLToPath correctly handles the Windows /C:/... prefix from import.meta.url
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  // src/data/mechs.ts  → ../../mechdata   (ts-node)
+  // dist/data/mechs.js → ../../mechdata   (compiled)
+  return path.resolve(__dirname, '../../mechdata');
+}
+
+/**
+ * Load the mech roster from mechdata/*.MEC filenames.
+ *
+ * Each .MEC file corresponds to one mech variant.  The filename (minus the
+ * extension) is used directly as the typeString sent to the client in cmd 26.
+ * The client's FUN_00438280 maps typeString → chassis display name, so we
+ * do not need to store or transmit that mapping ourselves.
+ *
+ * @returns Sorted array of MechEntry objects, one per .MEC file found.
+ * @throws  If the mechdata directory does not exist.
+ */
+export function loadMechs(): MechEntry[] {
+  const dir = mechDataDir();
+
+  if (!fs.existsSync(dir)) {
+    throw new Error(
+      `mechdata directory not found at ${dir}.\n` +
+      'Copy mechdata/ from your licensed MPBT installation into the project root.',
+    );
+  }
+
+  const entries = fs.readdirSync(dir)
+    .filter(f => f.toUpperCase().endsWith('.MEC'))
+    .sort()
+    .map<MechEntry>((filename, index) => ({
+      id:         index + 1,
+      mechType:   0,
+      slot:       index,
+      typeString: filename.slice(0, -4),   // strip ".MEC"
+      variant:    '',                       // empty → client calls MechWin_LookupMechName
+      name:       '',                       // empty → no pilot name shown
+    }));
+
+  if (entries.length === 0) {
+    throw new Error(`No .MEC files found in ${dir}.`);
+  }
+
+  return entries;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,6 +24,7 @@ import { ARIES_PORT, Msg } from './protocol/constants.js';
 import { PacketParser, buildPacket, hexDump } from './protocol/aries.js';
 import { parseLoginPayload, buildLoginRequest, buildSyncAck, buildWelcomePacket } from './protocol/auth.js';
 import { buildMechListPacket, buildMenuDialogPacket, buildRedirectPacket, parseClientCmd7, type MechEntry } from './protocol/game.js';
+import { loadMechs } from './data/mechs.js';
 import { PlayerRegistry, ClientSession } from './state/players.js';
 import { Logger } from './util/logger.js';
 import { CaptureLogger } from './util/capture.js';
@@ -215,16 +216,10 @@ function handleLogin(
 const CONFIRM_DIALOG_ID = 2;
 
 // Sample mech roster — one Shadowhawk entry so the UI has something to show.
-const SAMPLE_MECHS: MechEntry[] = [
-  {
-    id:         1,
-    mechType:   0,
-    slot:       0,
-    typeString: 'SHD-2H',
-    variant:    'Shadowhawk',
-    name:       '',   // empty → looked up by FUN_00438280
-  },
-];
+// Mech roster loaded from mechdata/*.MEC at startup.
+// See src/data/mechs.ts — no names are hardcoded; the client resolves chassis
+// display names internally via MechWin_LookupMechName (FUN_00438280).
+const MECHS: MechEntry[] = loadMechs();
 
 /**
  * Advance and return the server's outgoing sequence number.
@@ -275,8 +270,8 @@ function handleGameData(
   if (cmdIdx === 3 && !session.mechListSent) {
     // cmd 3 = client-ready (FUN_0040d3c0): send mech list exactly once.
     // FUN_0043A370 reads it → FUN_00439f70 creates the mech-selection window.
-    connLog.info('[game] client-ready → sending MECH LIST (cmd 26) — %d mechs', SAMPLE_MECHS.length);
-    const mechPkt = buildMechListPacket(SAMPLE_MECHS, 0, '', nextSeq(session));
+    connLog.info('[game] client-ready → sending MECH LIST (cmd 26) — %d mechs', MECHS.length);
+    const mechPkt = buildMechListPacket(MECHS, 0, '', nextSeq(session));
     send(session.socket, mechPkt, capture, 'MECH_LIST');
     session.mechListSent = true;
 


### PR DESCRIPTION
## Summary

Replaces the single hardcoded `SAMPLE_MECHS` entry with a real roster loaded from disk at startup.

## Changes

### `src/data/mechs.ts` (new)
- `loadMechs()` scans `mechdata/*.MEC` at startup and returns a `MechEntry[]` sorted by filename
- No mech chassis names are hardcoded — `variant` and `name` fields are sent empty; the client resolves display names internally via `MechWin_LookupMechName` (`FUN_00438280`)
- Uses `fileURLToPath(import.meta.url)` for correct path resolution on Windows (ESM safe)
- Clear error message if `mechdata/` is missing

### `src/server.ts`
- Adds `import { loadMechs }` from `./data/mechs.js`
- Replaces `SAMPLE_MECHS` constant with `const MECHS = loadMechs()`

### `.gitignore`
- Adds `mechdata/` — files are proprietary Kesmai/EA IP and must not be distributed

### `README.md`
- Adds **Game Data** section explaining how to obtain and place `mechdata/`

## Testing

```
npm run build   # zero errors
node -e "import('./dist/data/mechs.js').then(m => console.log(m.loadMechs().length))"
# → 161
```

## Notes

- This does not yet parse the binary content of each `.MEC` file (blocked on issue #1)
- Once issue #1 (RE of the .MEC format) is complete, `loadMechs()` can be extended to also read stat data without changing any call sites

Closes #2