### PR TITLE
chore: add Test Plan issue template and type: testing label

### DIFF
--- a/.github/ISSUE_TEMPLATE/test_plan.yml
+++ b/.github/ISSUE_TEMPLATE/test_plan.yml
@@ -1,0 +1,69 @@
+name: Test Plan
+description: A structured manual or automated test pass to verify milestone completeness.
+labels: ["type: testing", "status: needs-triage"]
+body:
+  - type: input
+    id: milestone
+    attributes:
+      label: Milestone / Scope
+      description: Which milestone or feature set does this test plan cover?
+      placeholder: "e.g. M1 — Lobby Completeness"
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment Setup
+      description: Steps required to prepare the test environment before running cases.
+      placeholder: |
+        1. Copy mechdata/ (161 .MEC files) to mpbt-server/
+        2. Copy MPBT.MSG to mpbt-server/
+        3. `npm run build`
+        4. `node dist/server.js`
+        5. Run `npm run gen-pcgi`, then launch MPBTWIN.EXE via MPBT.bat
+    validations:
+      required: true
+
+  - type: textarea
+    id: test_cases
+    attributes:
+      label: Test Cases
+      description: |
+        One checkbox per test case. Format each line as:
+        `- [ ] **T#** — description: expected result`
+      placeholder: |
+        - [ ] **T1** — Server loads correctly: log shows "Loaded 161 mechs"
+        - [ ] **T2** — Auth handshake: mech selection window renders
+    validations:
+      required: true
+
+  - type: textarea
+    id: skipped
+    attributes:
+      label: Known Skipped / Out-of-Scope Tests
+      description: List any tests that are intentionally skipped and why (link issues where applicable).
+      placeholder: |
+        - **T7b** Cmd 20 examine stats (X key) — server noop, tracked in #3 and #4
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - "Low — nice to have"
+        - "Medium — would meaningfully improve the project"
+        - "High — important for core functionality"
+        - "Critical — blocking other work"
+    validations:
+      required: true
+
+  - type: textarea
+    id: results
+    attributes:
+      label: Test Results
+      description: Fill this in after running the tests. Leave blank when opening.
+      placeholder: |
+        | # | Test | Result | Notes |
+        |---|------|--------|-------|
+        | T1 | Server loads | PASS | |

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -19,6 +19,10 @@
   color: "e4e669"
   description: "Maintenance, dependencies, CI"
 
+- name: "type: testing"
+  color: "c5def5"
+  description: "Test plan, QA verification, or manual test pass"
+
 # ── Priority ──────────────────────────────────────────────────────────────────
 - name: "priority: critical"
   color: "b60205"

--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -33,7 +33,7 @@ jobs:
             const isMaintainer = ['admin', 'write'].includes(perm.permission);
             if (isMaintainer) return;
 
-            // All four templates require multiple "### Heading" sections.
+            // All five templates require multiple "### Heading" sections.
             // A bare/blank issue won't have these.
             const hasStructure = /###\s+\S/.test(body);
             const hasContent   = body.trim().length >= 100;
@@ -50,10 +50,11 @@ jobs:
                 'Thank you for opening an issue! This one has been closed because it does not use one of the required templates.',
                 '',
                 '**Please resubmit using one of the available templates:**',
-                '- ��� **Bug Report** — something broken or behaving unexpectedly',
+                '🐛 **Bug Report** — something broken or behaving unexpectedly',
                 '- ✨ **Feature Request** — a new feature or enhancement',
-                '- ��� **Research Finding** — a reverse engineering discovery',
-                '- ��� **Documentation** — missing or incorrect documentation',
+                '🔬 **Research Finding** — a reverse engineering discovery',
+                '📖 **Documentation** — missing or incorrect documentation',
+                '🧪 **Test Plan** — milestone verification or manual test pass',
                 '',
                 `Open a new issue: https://github.com/${context.repo.owner}/${context.repo.repo}/issues/new/choose`,
                 '',


### PR DESCRIPTION
## Summary

Adds infrastructure for tracking manual test passes as GitHub issues.

## Changes

- **`.github/labels.yml`** — new `type: testing` label (light blue `c5def5`)
- **`.github/ISSUE_TEMPLATE/test_plan.yml`** — new template with fields:
  - Milestone / Scope
  - Environment Setup
  - Test Cases (checkbox list)
  - Known Skipped / Out-of-Scope Tests
  - Priority
  - Test Results (table, filled in after running)
- **`.github/workflows/validate-template.yml`** — update count comment (four → five), add Test Plan to the re-submit guidance message, fix pre-existing corrupted emoji bytes in Bug Report / Research Finding / Documentation lines

## Motivation

The M1 testing plan (T1–T10) was defined but there was no template to track it as an issue. This adds the missing type so testing issues get consistent structure, labels, and project board placement.

## Checklist
- [x] Template follows same structure as existing templates
- [x] Label is in labels.yml so sync-labels workflow applies it
- [x] validate-template count updated
- [x] No hardcoded logic in workflows — type: testing flows through the same label/project automation as other types

Closes N/A — this is infrastructure, not tied to a feature issue.