### PR TITLE
[codex] trace v1.23 MPBTWIN state handoff

### DIFF
--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -1883,6 +1883,27 @@ The v1.23 binary contains new debug/state-label strings absent from v1.06:
 
 These point to a substantially richer state machine governing the lobby→world→combat transition in v1.23. The v1.06 binary had none of these labels (they appeared as a single hardcoded string `"BattleTech II Version BTOC 1.06"`).
 
+#### MPBTWIN v1.23 state-machine trace
+
+Ghidra revalidation against `C:\MPBT\Mpbtwin.exe` v1.23:
+
+| Function | Role |
+|----------|------|
+| `FUN_00435b20` | Main network/game tick: drains queued COMMEG payloads via `FUN_00401310`, calls `FUN_00435ed0`, then dispatches by `DAT_0047d05c` (`3` = RPS tick, `4` = combat tick). |
+| `FUN_00435ed0` | Mode-packet dispatcher after RPS has started; classifies incoming handshake payloads and routes RPS vs combat transitions. |
+| `FUN_00435ff0` | Initial mode/welcome gate; accepts the first `MMW` welcome, sets RPS state, sends the client version frame, and only permits `MMC` combat entry after the client is already in RPS state. |
+| `FUN_00436340` | Classifies raw welcome strings: `ESC ? MMW Copyright Kesmai Corp. 1991` returns `2`; `ESC ? MMC Copyright Kesmai Corp. 1991` returns `3`; non-handshake data returns `0`. |
+| `FUN_00401d70` | Copies the visible mode name into the global mode descriptor: argument `0` = `"Solaris RPS"`; argument `1` = `"Solaris COMBAT"`. |
+| `FUN_00435db0` | Combat-mode initializer after the `MMC` welcome: tears down RPS UI pieces, loads `scenes.dat`, resets combat globals, and enables the combat simulation state. |
+| `FUN_00435eb0` | Combat tick; runs combat update work and, when music is enabled, calls `FUN_00428370`. |
+| `FUN_00428370` | Combat music/proximity selector. It chooses a requested combat music state from opponent distance/visibility/advantage data and calls `FUN_0042a5f0`. |
+| `FUN_0042a5f0` | Music state request mapper. External request `10` maps to internal state `6`. |
+| `FUN_0042aa10` | KSND/Miles music-state tick. It applies pending state changes and invokes the selected state callback. |
+
+Important correction: `"Transition to combat - even"` is not the COMMEG/server handshake string and does not by itself define a world→combat wire command. It is entry `6` in the music-state label table at `00479b10`, reached by `FUN_00428370 -> FUN_0042a5f0(10) -> internal state 6`, then applied by `FUN_0042aa10`. The protocol-relevant transition remains the `MMW`/`MMC` welcome-string classifier: `MMW` enters `"Solaris RPS"` and `MMC` enters `"Solaris COMBAT"` only after the RPS state has already been established.
+
+Server impact: keep treating combat as a separate connection/session boundary. A future combat prototype should first reproduce the RPS-to-combat handoff by issuing a second `MMC`-style welcome on the combat-side connection after the client is already in RPS, then trace the combat command dispatch that follows. Do not attempt to send `"Transition to combat - even"` as a server payload; it is an internal audio label.
+
 **MPBTWIN.EXE — new runtime behavior:**
 - `GetVersionExA` added: v1.23 performs OS version checks at startup.
 - Two registry keys for bypassing CPU checks: `Software\Kesmai\MultiPlayer Battletech Solaris\NoGameCPUCheck` and `NoSpeechCPUCheck`.
@@ -1919,7 +1940,7 @@ The v1.23 Ghidra project has been created with all three binaries analyzed. Work
 |----------|------|--------|-------|
 | 1 | Re-verify `FUN_10001420` (LOGIN builder) | COMMEG32 v1.23 | Confirm payload layout unchanged; check if `CE_VersionNumber`/`CE_VersionString` exports alter the version field |
 | 2 | Re-verify `Aries_RecvHandler` / case 0 | COMMEG32 v1.23 | §17 was confirmed on v1.06; confirm it still works identically |
-| 3 | Trace new state machine in `MPBTWIN` | MPBTWIN v1.23 | Find the handler for `"Solaris RPS"` → `"Transition to combat - even"` → `"Solaris COMBAT"` — this defines the world→combat REDIRECT flow |
+| 3 | Trace new state machine in `MPBTWIN` | MPBTWIN v1.23 | Partially revalidated above: `Solaris RPS`/`Solaris COMBAT` are protocol mode names selected by the `MMW`/`MMC` welcome classifier; `"Transition to combat - even"` is an internal music state, not a server payload. |
 | 4 | Re-verify world command dispatch table | MPBTWIN v1.23 | §18 addresses will have shifted; new entries may exist in v1.23 |
 | 5 | Trace `INITAR.DLL` launcher changes | INITAR v1.23 | Win32 API surface identical to v1.06 (confirmed by string extraction). Deeper RE needed to confirm pcgi field format is unchanged given +12 KB growth. |
 | 6 | Check `Speech32.dll` integration | MPBTWIN v1.23 | What events trigger speech? Any new server→client commands? |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -193,6 +193,7 @@ The world uses two distinct room types: **bar** (social spaces, Tier Ranking ter
 | RE torso/leg independence | 🔬 | Legs = heading (KP4/6/2/8); torso = facing (WASD); server must track both; compass shows both simultaneously |
 | RE turn timer / match end | 🔬 | 15-minute server-enforced limit; how does server signal mech destruction / match end? |
 | RE physical combat | 🔬 | Death-from-above (DFA) and alpha strike — dedicated commands or derived from positional data? |
+| RE v1.23 RPS→combat state handoff | 🔬 | `MMW` welcome enters `"Solaris RPS"`; later `MMC` welcome enters `"Solaris COMBAT"` only after RPS is established. `"Transition to combat - even"` is an internal music state, not a server payload. |
 | Implement `src/protocol/combat.ts` | ❌ | All combat packet builders and parsers |
 | Scripted dummy opponent | ❌ | Server-controlled bot mech that fires back, for single-player testing |
 

--- a/symbols.json
+++ b/symbols.json
@@ -90,5 +90,28 @@
       "g_mechWin_ShowExtButtons":{ "binary": "DAT_004dbd84",    "role": "Non-zero when typeFlag triggers extended button display" },
       "g_mechWin_HighlightIdx":  { "binary": "DAT_004dbd80",    "role": "Index of currently highlighted mech slot" }
     }
+  },
+  "MPBTWIN.EXE v1.23": {
+    "functions": {
+      "Main_NetQueueTick_v123":        { "binary": "FUN_00435b20", "role": "Drains queued COMMEG payloads, dispatches mode packets, then ticks RPS state 3 or combat state 4" },
+      "Main_ModePacketDispatch_v123":  { "binary": "FUN_00435ed0", "role": "Classifies queued payloads after RPS start; routes later MMW/MMC handshakes or normal text-frame parsing" },
+      "Main_InitialModeGate_v123":     { "binary": "FUN_00435ff0", "role": "Initial MMW/MMC welcome gate; MMW enters RPS, MMC is only valid after RPS state is established" },
+      "Main_ModeWelcomeClassify_v123": { "binary": "FUN_00436340", "role": "Returns 2 for ESC?MMW welcome, 3 for ESC?MMC welcome, 0 for non-handshake data" },
+      "Main_SetModeName_v123":         { "binary": "FUN_00401d70", "role": "Argument 0 copies \"Solaris RPS\"; argument 1 copies \"Solaris COMBAT\"" },
+      "Combat_InitMode_v123":          { "binary": "FUN_00435db0", "role": "Combat-mode initializer after MMC welcome; tears down RPS UI, loads scenes.dat, resets combat globals" },
+      "Combat_Tick_v123":              { "binary": "FUN_00435eb0", "role": "Per-frame combat tick; runs combat update and calls combat music selector when music is enabled" },
+      "Audio_CombatMusicSelect_v123":  { "binary": "FUN_00428370", "role": "Chooses requested combat music state from target distance/visibility/advantage, then calls Audio_RequestMusicState_v123" },
+      "Audio_RequestMusicState_v123":  { "binary": "FUN_0042a5f0", "role": "Maps external music request ids to internal state ids; request 10 maps to internal state 6" },
+      "Audio_TickMusicState_v123":     { "binary": "FUN_0042aa10", "role": "Applies pending KSND/Miles music state transitions and invokes selected state callback" }
+    },
+    "data": {
+      "g_modeState_v123":              { "binary": "DAT_0047d05c", "role": "Mode state: 3 = Solaris RPS tick, 4 = Solaris COMBAT tick" },
+      "g_modeRpsActive_v123":          { "binary": "DAT_0047a7f0", "role": "Set after the MMW/RPS welcome path starts" },
+      "g_musicStateCurrent_v123":      { "binary": "DAT_00479b00", "role": "Current internal music state id" },
+      "g_musicStateRequested_v123":    { "binary": "DAT_004da2ec", "role": "Pending internal music state id requested by Audio_RequestMusicState_v123" },
+      "g_musicStateNames_v123":        { "binary": "00479b10", "role": "Pointer table of 21 music-state labels; index 6 is \"Transition to combat - even\"" },
+      "g_welcomeStrMMC_v123":          { "binary": "0047d240", "role": "Literal ESC?MMC Copyright Kesmai Corp. 1991" },
+      "g_welcomeStrMMW_v123":          { "binary": "0047d264", "role": "Literal ESC?MMW Copyright Kesmai Corp. 1991" }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Documents a v1.23 `MPBTWIN.EXE` Ghidra trace of the `Solaris RPS` -> `Transition to combat - even` -> `Solaris COMBAT` state-machine strings.

The key correction is that `Solaris RPS` and `Solaris COMBAT` are protocol mode names selected by the `MMW`/`MMC` welcome-string classifier, while `Transition to combat - even` is an internal KSND/Miles music-state label. This means the combat handoff should be modeled as a later `MMC`-style combat welcome after RPS is established, not by sending the `Transition to combat - even` text as a server payload.

## Related Issue

Closes #53

## Type of Change

- [ ] Bug fix
- [ ] Feature / enhancement
- [x] Research finding / protocol update
- [x] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Chore (dependencies, CI, config)

## Implementation Notes

Adds a `MPBTWIN v1.23 state-machine trace` subsection to `RESEARCH.md`, a corresponding M6 roadmap note, and v1.23-only symbol dictionary entries for the traced functions/data.

Relevant Ghidra anchors:

- `FUN_00435ff0`: initial mode/welcome gate
- `FUN_00436340`: `MMW`/`MMC` welcome classifier
- `FUN_00401d70`: mode-name setter for `Solaris RPS` / `Solaris COMBAT`
- `FUN_00428370 -> FUN_0042a5f0(10) -> FUN_0042aa10`: internal music path for `Transition to combat - even`

## Testing

- `symbols.json` parsed successfully with Node.
- `git diff --check` passed.
- `npm run build` passed.
- Ghidra `Mpbtwin.exe` v1.23 database was saved with the new local function names.

## Checklist

- [x] Branch is based on `master`
- [x] Commit messages follow `type: description` convention (e.g. `fix: correct CRC seed`)
- [x] TypeScript builds cleanly (`npm run build`)
- [x] No debug `console.log` left in production code paths
- [x] `RESEARCH.md` updated if this reflects a new RE finding
- [x] `symbols.json` updated if new canonical names were introduced
- [x] This PR is ready for review (not a draft)
