### PR TITLE
feat(M6): handle combat control frames in world modules

### DIFF
--- a/src/data/mechs.ts
+++ b/src/data/mechs.ts
@@ -77,21 +77,27 @@ function decryptMec(buf: Buffer, nameLower: string): void {
 }
 
 /**
- * Read and decrypt a .MEC file, returning the signed 16-bit extraCritCount
- * at offset 0x3c.
+ * Decrypt a .MEC file and return combat bootstrap/runtime fields in one pass.
+ *
+ * mec_speed is confirmed by RE of Combat_InitActorRuntimeFromMec_v123 @
+ * 0x00433910: max forward speed register = mec_speed * 450.
+ * extraCritCount is confirmed by RE of Combat_ReadLocalActorMechState_v123 @
+ * 0x004456c0.
  *
  * @param mecPath   Absolute path to the .MEC file.
  * @param nameLower Lowercase mech name WITHOUT extension (e.g. "anh-1a").
- * @returns Signed 16-bit extraCritCount (can be negative).
  */
-function readMecExtraCritCount(mecPath: string, nameLower: string): number {
+function readMecFields(mecPath: string, nameLower: string): { mecSpeed: number; extraCritCount: number } {
   const raw = fs.readFileSync(mecPath);
   if (raw.length < 0x3e) {
-    throw new Error(`${mecPath}: too short for extraCritCount (${raw.length} < 0x3e)`);
+    throw new Error(`${mecPath}: too short for mec fields (${raw.length} < 0x3e)`);
   }
   const buf = Buffer.from(raw); // mutable copy
   decryptMec(buf, nameLower);
-  return buf.readInt16LE(0x3c);
+  return {
+    mecSpeed:       buf.readInt16LE(0x16),
+    extraCritCount: buf.readInt16LE(0x3c),
+  };
 }
 
 // ── MPBT.MSG variant table ────────────────────────────────────────────────────
@@ -166,6 +172,8 @@ export function loadMechs(): MechEntry[] {
           'verify MPBT.MSG matches the mechdata/ installation.',
         );
       }
+      const mecPath = path.join(mechDir, filename);
+      const { mecSpeed, extraCritCount } = readMecFields(mecPath, typeString.toLowerCase());
       return {
         id,
         mechType: 0,
@@ -173,10 +181,8 @@ export function loadMechs(): MechEntry[] {
         typeString,
         variant: '', // empty → client uses its own display logic
         name:    '', // empty → client calls MechWin_LookupMechName(id)
-        extraCritCount: readMecExtraCritCount(
-          path.join(mechDir, filename),
-          typeString.toLowerCase(),
-        ),
+        maxSpeedMag: mecSpeed * 450,
+        extraCritCount,
       };
     });
 

--- a/src/data/mechs.ts
+++ b/src/data/mechs.ts
@@ -95,7 +95,7 @@ function readMecFields(mecPath: string, nameLower: string): { mecSpeed: number; 
   const buf = Buffer.from(raw); // mutable copy
   decryptMec(buf, nameLower);
   return {
-    mecSpeed:       buf.readInt16LE(0x16),
+    mecSpeed:       buf.readUInt16LE(0x16),
     extraCritCount: buf.readInt16LE(0x3c),
   };
 }

--- a/src/protocol/combat.ts
+++ b/src/protocol/combat.ts
@@ -42,7 +42,7 @@ import {
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 /** World-coordinate bias added before type3 encoding. CONFIRMED §19.6.1. */
-const COORD_BIAS = 0x18e4258; // 26,100,312
+export const COORD_BIAS = 0x18e4258; // 26,100,312
 
 /** Neutral-point bias for type1 velocity/motion fields. CONFIRMED §19.2. */
 export const MOTION_NEUTRAL = 0x0e1c; // 3,612
@@ -54,7 +54,7 @@ export const MOTION_NEUTRAL = 0x0e1c; // 3,612
 const FACING_BASE = 0x0dc2; // 3,522
 
 /** Divisor shared by all motion accumulator fields. CONFIRMED §19.2. */
-const MOTION_DIV = 0xb6; // 182
+export const MOTION_DIV = 0xb6; // 182
 
 // ── Internal helpers ──────────────────────────────────────────────────────────
 

--- a/src/protocol/game.ts
+++ b/src/protocol/game.ts
@@ -274,6 +274,12 @@ export interface MechEntry {
    * CONFIRMED via RE of Combat_ReadLocalActorMechState_v123 @ 0x004456c0.
    */
   extraCritCount: number;
+  /**
+   * Maximum forward speed magnitude derived from mec_speed at offset 0x16:
+   *   maxSpeedMag = mec_speed * 450
+   * CONFIRMED by RE of Combat_InitActorRuntimeFromMec_v123 @ 0x00433910.
+   */
+  maxSpeedMag: number;
 }
 
 /**
@@ -338,6 +344,29 @@ export function decodeArgType1(buf: Buffer, offset: number): [val: number, next:
   const d0 = buf[offset]     - 0x21;
   const d1 = buf[offset + 1] - 0x21;
   return [d0 * 85 + d1, offset + 2];
+}
+
+/**
+ * Decode 3-byte type-2 value from client args buffer at given offset.
+ * Encoding: FUN_00402be0(2, v) → 3 bytes, big-endian base-85.
+ */
+export function decodeArgType2(buf: Buffer, offset: number): [val: number, next: number] {
+  const d0 = buf[offset]     - 0x21;
+  const d1 = buf[offset + 1] - 0x21;
+  const d2 = buf[offset + 2] - 0x21;
+  return [d0 * 85 * 85 + d1 * 85 + d2, offset + 3];
+}
+
+/**
+ * Decode 4-byte type-3 value from client args buffer at given offset.
+ * Encoding: FUN_00402be0(3, v) → 4 bytes, big-endian base-85.
+ */
+export function decodeArgType3(buf: Buffer, offset: number): [val: number, next: number] {
+  const d0 = buf[offset]     - 0x21;
+  const d1 = buf[offset + 1] - 0x21;
+  const d2 = buf[offset + 2] - 0x21;
+  const d3 = buf[offset + 3] - 0x21;
+  return [d0 * 85 ** 3 + d1 * 85 ** 2 + d2 * 85 + d3, offset + 4];
 }
 
 /**
@@ -458,8 +487,118 @@ export function parseClientCmd23LocationAction(
   };
 }
 
+// ── Combat client frames (cmd8 / cmd9 / cmd10 / cmd12) ───────────────────────
+
+/** Raw decoded fields from client cmd8 (coasting: no throttle and no turning). */
+export interface ClientCmd8Coasting {
+  seq: number;
+  xRaw: number;
+  yRaw: number;
+  headingRaw: number;
+  turnMomRaw: number;
+  rotationRaw: number;
+}
+
+/** Raw decoded fields from client cmd9 (moving: throttle or turning active). */
+export interface ClientCmd9Moving extends ClientCmd8Coasting {
+  neutralRaw: number;
+  throttleRaw: number;
+  legVelRaw: number;
+}
+
+/** Raw decoded fields from client cmd10 weapon-fire geometry. */
+export interface ClientCmd10WeaponFire {
+  seq: number;
+  targetRaw: number;
+  weaponSlot: number;
+  flag: number;
+  angleSeedA: number;
+  angleSeedB: number;
+  impactXRaw: number;
+  impactYRaw: number;
+  impactZ: number;
+}
+
+/** Raw decoded fields from client cmd12 combat action. */
+export interface ClientCmd12Action {
+  seq: number;
+  action: number;
+}
+
+/** Parse a client-sent combat cmd8 coasting movement frame. */
+export function parseClientCmd8Coasting(payload: Buffer): ClientCmd8Coasting | null {
+  if (payload.length < 21 || payload[0] !== 0x1B) return null;
+  if (payload[2] - 0x21 !== 8) return null;
+  let off = 3;
+  let xRaw: number, yRaw: number, headingRaw: number, turnMomRaw: number, rotationRaw: number;
+  [xRaw,       off] = decodeArgType3(payload, off);
+  [yRaw,       off] = decodeArgType3(payload, off);
+  [headingRaw, off] = decodeArgType2(payload, off);
+  [turnMomRaw, off] = decodeArgType1(payload, off);
+  [rotationRaw,   ] = decodeArgType1(payload, off);
+  return { seq: payload[1] - 0x21, xRaw, yRaw, headingRaw, turnMomRaw, rotationRaw };
+}
+
+/** Parse a client-sent combat cmd9 moving frame. */
+export function parseClientCmd9Moving(payload: Buffer): ClientCmd9Moving | null {
+  if (payload.length < 27 || payload[0] !== 0x1B) return null;
+  if (payload[2] - 0x21 !== 9) return null;
+  let off = 3;
+  let xRaw: number, yRaw: number, headingRaw: number;
+  let turnMomRaw: number, neutralRaw: number, throttleRaw: number, legVelRaw: number, rotationRaw: number;
+  [xRaw,        off] = decodeArgType3(payload, off);
+  [yRaw,        off] = decodeArgType3(payload, off);
+  [headingRaw,  off] = decodeArgType2(payload, off);
+  [turnMomRaw,  off] = decodeArgType1(payload, off);
+  [neutralRaw,  off] = decodeArgType1(payload, off);
+  [throttleRaw, off] = decodeArgType1(payload, off);
+  [legVelRaw,   off] = decodeArgType1(payload, off);
+  [rotationRaw,    ] = decodeArgType1(payload, off);
+  return {
+    seq: payload[1] - 0x21,
+    xRaw, yRaw, headingRaw,
+    turnMomRaw, neutralRaw, throttleRaw, legVelRaw, rotationRaw,
+  };
+}
+
+/** Parse a client-sent combat cmd10 weapon-fire frame. */
+export function parseClientCmd10WeaponFire(payload: Buffer): ClientCmd10WeaponFire | null {
+  if (payload.length < 24 || payload[0] !== 0x1B) return null;
+  if (payload[2] - 0x21 !== 10) return null;
+  let off = 3;
+  const targetRaw = payload[off] - 0x21; off += 1;
+  const weaponSlot = Math.max(0, payload[off] - 0x22); off += 1;
+  const flag = payload[off] - 0x22; off += 1;
+  let angleSeedA: number, angleSeedB: number, impactXRaw: number, impactYRaw: number, impactZ: number;
+  [angleSeedA, off] = decodeArgType1(payload, off);
+  [angleSeedB, off] = decodeArgType1(payload, off);
+  [impactXRaw, off] = decodeArgType3(payload, off);
+  [impactYRaw, off] = decodeArgType3(payload, off);
+  [impactZ,       ] = decodeArgType2(payload, off);
+  return {
+    seq: payload[1] - 0x21,
+    targetRaw,
+    weaponSlot,
+    flag,
+    angleSeedA,
+    angleSeedB,
+    impactXRaw,
+    impactYRaw,
+    impactZ,
+  };
+}
+
+/** Parse a client-sent combat cmd12 action frame. */
+export function parseClientCmd12Action(payload: Buffer): ClientCmd12Action | null {
+  if (payload.length < 7 || payload[0] !== 0x1B) return null;
+  if (payload[2] - 0x21 !== 12) return null;
+  return {
+    seq: payload[1] - 0x21,
+    action: payload[3] - 0x21,
+  };
+}
+
 /**
- * Parse a client-sent cmd-9 character creation reply.
  *
  * CONFIRMED from MPBTWIN.EXE FUN_0042dbf0 -> FUN_0040d400:
  *   [subcmd byte == 1] [encodeString typed_name] [selected-index byte]

--- a/src/server-world.ts
+++ b/src/server-world.ts
@@ -95,6 +95,10 @@ import {
   sendCombatBootstrapSequence,
   notifyRoomArrival,
   notifyRoomDeparture,
+  handleCombatMovementFrame,
+  handleCombatWeaponFireFrame,
+  handleCombatActionFrame,
+  handleMechPickerCmd7,
 } from './world/world-handlers.js';
 
 const WELCOME_TEXT = 'Welcome to the game world.';
@@ -336,6 +340,10 @@ function handleWorldGameData(
     connLog.warn('[world] cmd-5 unsupported scene action type=%d', parsed.actionType);
 
   } else if (cmdIdx === 10) {
+    if (session.phase === 'combat') {
+      handleCombatWeaponFireFrame(session, payload, connLog, capture);
+      return;
+    }
     if (session.phase !== 'world') {
       connLog.debug('[world] cmd-10 ignored outside world phase: phase=%s', session.phase);
       return;
@@ -375,6 +383,11 @@ function handleWorldGameData(
     }
 
     connLog.info('[world] cmd-7 menu reply: listId=%d selection=%d', parsed.listId, parsed.selection);
+
+    if (handleMechPickerCmd7(players, session, parsed.listId, parsed.selection, connLog, capture)) {
+      return;
+    }
+
     if (parsed.listId === 3) {
       handleRoomMenuSelection(players, session, parsed.selection, connLog, capture);
       return;
@@ -444,15 +457,17 @@ function handleWorldGameData(
     connLog.debug('[world] cmd-7 ignored: unsupported listId=%d', parsed.listId);
   } else if (session.phase === 'combat') {
     // Combat-mode inbound frame (client sends Cmd8/Cmd9 for movement/fire).
-    if (cmdIdx === 20) {
+    if (cmdIdx === 8 || cmdIdx === 9) {
+      handleCombatMovementFrame(session, payload, connLog, capture);
+    } else if (cmdIdx === 12) {
+      handleCombatActionFrame(session, payload, connLog, capture);
+    } else if (cmdIdx === 20) {
       // Cmd20 — "examine self": correct combat-mode response is unconfirmed.
       // Sending the lobby-phase buildCmd20Packet here (world CRC seed) caused
       // the client to dispatch a garbage byte as "command 13 not handled".
       // Drop silently until the combat-specific response format is captured.
       connLog.debug('[world/combat] cmd-20 examine-self — no response (combat response unconfirmed)');
     } else {
-      // Exact encoding of combat client→server cmd indices is unconfirmed
-      // (live capture needed for Cmd8/9 movement); log and drop.
       connLog.debug('[world/combat] inbound combat cmd=%d len=%d — not yet handled', cmdIdx, payload.length);
     }
   } else {

--- a/src/server-world.ts
+++ b/src/server-world.ts
@@ -85,6 +85,7 @@ import {
   sendAllRosterList,
   sendSolarisTravelMap,
   currentRoomPresenceEntries,
+  sendMechClassPicker,
 } from './world/world-scene.js';
 import {
   handleComstarTextReply,
@@ -335,6 +336,15 @@ function handleWorldGameData(
         connLog.debug('[world] cmd-5 Fight ignored: combatInitialized=%s phase=%s',
           session.combatInitialized, session.phase);
       }
+      return;
+    }
+    if (parsed.actionType === 6) {
+      // "Mech Bay" button — open the 3-step mech picker.
+      if (session.phase !== 'world') {
+        connLog.warn('[world] cmd-5 mech bay ignored outside world phase: phase=%s', session.phase);
+        return;
+      }
+      sendMechClassPicker(session, connLog, capture);
       return;
     }
     connLog.warn('[world] cmd-5 unsupported scene action type=%d', parsed.actionType);

--- a/src/server-world.ts
+++ b/src/server-world.ts
@@ -466,7 +466,7 @@ function handleWorldGameData(
 
     connLog.debug('[world] cmd-7 ignored: unsupported listId=%d', parsed.listId);
   } else if (session.phase === 'combat') {
-    // Combat-mode inbound frame (client sends Cmd8/Cmd9 for movement/fire).
+    // Combat-mode inbound frame (client sends Cmd8/Cmd9 for movement; weapon fire uses Cmd10).
     if (cmdIdx === 8 || cmdIdx === 9) {
       handleCombatMovementFrame(session, payload, connLog, capture);
     } else if (cmdIdx === 12) {

--- a/src/state/players.ts
+++ b/src/state/players.ts
@@ -58,6 +58,8 @@ export interface ClientSession {
   combatInitialized?: boolean;
   /** Repeating setInterval that sends bot position updates during combat. */
   botPositionTimer?: ReturnType<typeof setInterval>;
+  /** Scripted bot hit points for the current single-client combat prototype. */
+  botHealth?: number;
   /**
    * Stable per-connection roster identifier used by world presence packets
    * (Cmd10/Cmd11/Cmd12/Cmd13). This is distinct from accountId and only needs to be
@@ -115,6 +117,28 @@ export interface ClientSession {
    * player confirms their selection (cmd-7 confirm reply).
    */
   pendingMechSlot?: number;
+
+  // ── Combat positional state (updated by Cmd8/9 movement frames) ──────────
+
+  /** Last decoded world X coordinate from client Cmd8/9. */
+  combatX?: number;
+  /** Last decoded world Y coordinate from client Cmd8/9. */
+  combatY?: number;
+  /** Last raw heading value from client Cmd8/9. */
+  combatHeadingRaw?: number;
+  /** Current speedMag echoed in Cmd65 responses. */
+  combatSpeedMag?: number;
+  /** Per-mech speedMag cap (mec_speed * 450), set at combat bootstrap. */
+  combatMaxSpeedMag?: number;
+
+  // ── 3-step mech picker state ──────────────────────────────────────────────
+
+  /** Which step of the mech-picker dialog the player is on. */
+  mechPickerStep?: 'class' | 'chassis' | 'variant';
+  /** Weight-class index (0=Light, 1=Medium, 2=Heavy, 3=Assault) chosen in step 1. */
+  mechPickerClass?: number;
+  /** Chassis name (e.g. "Jenner") chosen in step 2. */
+  mechPickerChassis?: string;
 
   // ── Persistence fields (set after DB lookup / character creation) ─────────
 

--- a/src/state/players.ts
+++ b/src/state/players.ts
@@ -126,6 +126,10 @@ export interface ClientSession {
   combatY?: number;
   /** Last raw heading value from client Cmd8/9. */
   combatHeadingRaw?: number;
+  /** Last decoded throttle velocity echoed in Cmd65 responses. */
+  combatThrottle?: number;
+  /** Last decoded leg velocity echoed in Cmd65 responses. */
+  combatLegVel?: number;
   /** Current speedMag echoed in Cmd65 responses. */
   combatSpeedMag?: number;
   /** Per-mech speedMag cap (mec_speed * 450), set at combat bootstrap. */

--- a/src/world/world-data.ts
+++ b/src/world/world-data.ts
@@ -8,12 +8,13 @@
 
 import { loadMechs }                                                   from '../data/mechs.js';
 import { loadSolarisRooms, WorldRoom, loadWorldMap, WorldMapRoom }     from '../data/maps.js';
+import { MECH_STATS }                                                  from '../data/mech-stats.js';
 import { CaptureLogger }                                               from '../util/capture.js';
 
 // ── Shared mech catalog ───────────────────────────────────────────────────────
 // Loaded once at module import time.  Provides a fallback when a player's
 // launch record is absent (e.g. direct connection to world port in tests).
-let WORLD_MECHS: ReturnType<typeof loadMechs>;
+export let WORLD_MECHS: ReturnType<typeof loadMechs>;
 try {
   WORLD_MECHS = loadMechs();
 } catch (err) {
@@ -219,6 +220,69 @@ export function getSolarisRoomIcon(roomId: number): number {
   const mapRoom = worldMapByRoomId.get(roomId);
   if (mapRoom?.icon !== null && mapRoom?.icon !== undefined) return mapRoom.icon;
   return getSolarisSceneIndex(roomId);
+}
+
+// ── Mech picker constants ─────────────────────────────────────────────────────
+
+/** Cmd26 listId for the weight-class picker (step 1). */
+export const MECH_CLASS_LIST_ID   = 0x20;
+/** Cmd26 listId for the chassis picker (step 2). */
+export const MECH_CHASSIS_LIST_ID = 0x3e;
+
+/** Display labels for each weight class (slot 0..3). */
+export const CLASS_LABELS = ['Light', 'Medium', 'Heavy', 'Assault'] as const;
+/** Uppercase keys used to filter MECH_STATS by weight class. */
+export const CLASS_KEYS   = ['LIGHT', 'MEDIUM', 'HEAVY', 'ASSAULT'] as const;
+
+/** Static fallback chassis name map for mechs that may not appear in MECH_STATS. */
+export const CHASSIS_BY_PREFIX: Record<string, string> = {
+  ACM: 'Arachne', ADR: 'Adder', ANH: 'Annihilator', AS7: 'Atlas',
+  BLR: 'BattleMaster', BNC: 'Banshee', BS1: 'Black Hawk',
+  BT:  'BattleMaster', C3I: 'C3I Upgrade', CAT: 'Catapult',
+  CBR: 'Cobra', CLN: 'Clan Nova', CLR: 'Clint', CN9: 'Centurion',
+  COM: 'Commando', CPN: 'Capellan', CTF: 'Cataphract', CTS: 'Centurion',
+  DRG: 'Dragon', DV8: 'Dervish', DW: 'Dire Wolf', EBJ: 'Ebon Jaguar',
+  ENF: 'Enforcer', EXC: 'Excalibur', FLS: 'Flashman', FRB: 'Firebee',
+  GHR: 'Grasshopper', GLG: 'Galahad', GRF: 'Griffin', HBK: 'Hunchback',
+  HCT: 'Hatchetman', HGN: 'Highlander', HM:  'Hammer', HNT: 'Huntsman',
+  HPT: 'Hellspawn', HSN: 'Hussar', HTM: 'Hatamoto', HVT: 'Heavy',
+  IIC: 'IIC', JM6: 'Jagermech', JR7: 'Jenner', JVN: 'Javelin',
+  KGC: 'King Crab', KTO: 'Kintaro', LCT: 'Locust', LGB: 'Longbow',
+  MAD: 'Marauder', MDG: 'Mad Dog', MDD: 'Mad Dog', MLX: 'Mist Lynx',
+  MNS: 'Mauler', MNT: 'Mantis', MON: 'Mongoose', MRM: 'Marauder IIC',
+  NVA: 'Nova', ONI: 'Ontos', OSR: 'Osiris', PNT: 'Panther',
+  PPC: 'PPCer', PRT: 'Praetorian', PTR: 'Penetrator', RFL: 'Rifleman',
+  RGR: 'Ranger', RJX: 'Rjin', RVN: 'Raven', SDR: 'Spider',
+  SHD: 'Shadow Hawk', SHK: 'Shrike', SMN: 'Summoner', SRM: 'Srm',
+  STK: 'Stalker', STO: 'Stormcrow', STR: 'Striker', SVN: 'Savannah Master',
+  TBT: 'Trebuchet', THG: 'Thug', TIM: 'Timber Wolf', TOR: 'Talon',
+  UM:  'Urbanmech', VLK: 'Vulkan', VMN: 'Vulcan', VND: 'Vindicator',
+  VPR: 'Viper', VP:  'Viper', WAR: 'Warhammer', WHM: 'Warhammer',
+  WLF: 'Wolf Trap', WOL: 'Wolfhound', WSP: 'Wasp', YMN: 'Yeoman',
+  ZZZ: 'Test Mech',
+};
+
+export const PREFIX_TO_CHASSIS = new Map<string, string>();
+for (const [typeString, stat] of MECH_STATS.entries()) {
+  if (stat.disabled) continue;
+  const prefix = typeString.slice(0, typeString.indexOf('-'));
+  if (prefix && !PREFIX_TO_CHASSIS.has(prefix)) {
+    PREFIX_TO_CHASSIS.set(prefix, stat.name);
+  }
+}
+
+/** Return the canonical chassis name for a mech typeString, e.g. "JR7-1X" -> "Jenner". */
+export function getMechChassis(typeString: string): string {
+  const stat = MECH_STATS.get(typeString);
+  if (stat && !stat.disabled) return stat.name;
+  const hyphen = typeString.indexOf('-');
+  const prefix = hyphen > 0 ? typeString.slice(0, hyphen) : typeString;
+  return PREFIX_TO_CHASSIS.get(prefix) ?? CHASSIS_BY_PREFIX[prefix] ?? prefix;
+}
+
+/** Convert maxSpeedMag back to displayed kph, matching the client's mec_speed scale. */
+export function mechKph(maxSpeedMag: number): number {
+  return Math.round(maxSpeedMag * 16.2 / 450);
 }
 
 // ── Per-session world position ────────────────────────────────────────────────

--- a/src/world/world-handlers.ts
+++ b/src/world/world-handlers.ts
@@ -9,16 +9,29 @@
 import {
   buildCmd3BroadcastPacket,
   buildCmd4SceneInitPacket,
+  buildCmd5CursorNormalPacket,
   buildCmd11PlayerEventPacket,
   buildCmd13PlayerArrivalPacket,
 } from '../protocol/world.js';
-import { buildCmd36MessageViewPacket } from '../protocol/game.js';
+import {
+  buildCmd36MessageViewPacket,
+  parseClientCmd10WeaponFire,
+  parseClientCmd12Action,
+  parseClientCmd8Coasting,
+  parseClientCmd9Moving,
+} from '../protocol/game.js';
 import { buildCombatWelcomePacket }    from '../protocol/auth.js';
 import {
   buildCmd62CombatStartPacket,
   buildCmd64RemoteActorPacket,
   buildCmd72LocalBootstrapPacket,
   buildCmd65PositionSyncPacket,
+  buildCmd66ActorDamagePacket,
+  buildCmd68ProjectileSpawnPacket,
+  buildCmd70ActorTransitionPacket,
+  buildCmd71ResetEffectStatePacket,
+  COORD_BIAS,
+  MOTION_DIV,
   MOTION_NEUTRAL,
 } from '../protocol/combat.js';
 import { PlayerRegistry, ClientSession } from '../state/players.js';
@@ -29,6 +42,7 @@ import { CaptureLogger } from '../util/capture.js';
 import {
   FALLBACK_MECH_ID,
   WORLD_MECH_BY_ID,
+  WORLD_MECHS,
   DEFAULT_MAP_ROOM_ID,
   DEFAULT_SCENE_NAME,
   SOLARIS_ROOM_BY_ID,
@@ -36,6 +50,10 @@ import {
   getSolarisRoomExits,
   getSolarisRoomName,
   setSessionRoomPosition,
+  CLASS_KEYS,
+  getMechChassis,
+  MECH_CLASS_LIST_ID,
+  MECH_CHASSIS_LIST_ID,
 } from './world-data.js';
 import {
   send,
@@ -50,7 +68,15 @@ import {
   sendSceneRefresh,
   sendAllRosterList,
   sendSolarisTravelMap,
+  sendMechClassPicker,
+  sendMechChassisPicker,
+  sendMechVariantPicker,
 } from './world-scene.js';
+
+/** Server-side HP counter for the scripted single-client bot opponent. */
+const BOT_INITIAL_HEALTH = 100;
+/** Prototype damage applied to the scripted bot for each cmd10 fire frame. */
+const BOT_DAMAGE_PER_HIT = 20;
 
 // ── ComStar messaging ─────────────────────────────────────────────────────────
 
@@ -291,6 +317,10 @@ export function sendCombatBootstrapSequence(
   const extraCritCount  = mechEntry?.extraCritCount ?? 0;
   const critBytes       = Math.max(0, extraCritCount + 21);
 
+  // Store per-mech speedMag cap so Cmd8/9 handlers can apply it.
+  session.combatMaxSpeedMag = mechEntry?.maxSpeedMag ?? 0;
+  session.botHealth = BOT_INITIAL_HEALTH;
+
   // 1. MMC SYNC — plain ARIES packet; no game-frame CRC.
   send(socket, buildCombatWelcomePacket(), capture, 'COMBAT_WELCOME_MMC');
 
@@ -420,6 +450,11 @@ export function handleWorldTextCommand(
 
   if (clean.toLowerCase() === '/map' || clean.toLowerCase() === '/travel') {
     sendSolarisTravelMap(session, connLog, capture);
+    return;
+  }
+
+  if (clean.toLowerCase() === '/mechbay' || clean.toLowerCase() === '/mechs') {
+    sendMechClassPicker(session, connLog, capture);
     return;
   }
 
@@ -660,4 +695,237 @@ export function notifyRoomDeparture(
     );
   }
   connLog.info('[world] notified room of departure: rosterId=%d callsign="%s"', session.worldRosterId, callsign);
+}
+
+// ── Combat movement / action frames ───────────────────────────────────────────
+
+export function handleCombatMovementFrame(
+  session: ClientSession,
+  payload: Buffer,
+  connLog: Logger,
+  capture: CaptureLogger,
+): void {
+  const cmd = payload[2] - 0x21;
+
+  if (cmd === 8) {
+    const frame = parseClientCmd8Coasting(payload);
+    if (!frame) return;
+    session.combatX          = frame.xRaw - COORD_BIAS;
+    session.combatY          = frame.yRaw - COORD_BIAS;
+    session.combatHeadingRaw = frame.headingRaw;
+    connLog.debug('[world/combat] cmd8 coasting: x=%d y=%d heading=%d', session.combatX, session.combatY, frame.headingRaw);
+    return;
+  }
+
+  if (cmd === 9) {
+    const frame = parseClientCmd9Moving(payload);
+    if (!frame) return;
+    session.combatX          = frame.xRaw - COORD_BIAS;
+    session.combatY          = frame.yRaw - COORD_BIAS;
+    session.combatHeadingRaw = frame.headingRaw;
+
+    const maxSpeedMag = session.combatMaxSpeedMag ?? 0;
+    const throttlePct = frame.throttleRaw - MOTION_NEUTRAL; // negative = forward
+    const signedSpeedMag = maxSpeedMag > 0
+      ? Math.round(-throttlePct * maxSpeedMag / 45)
+      : 0;
+    session.combatSpeedMag = signedSpeedMag;
+
+    connLog.debug(
+      '[world/combat] cmd9 moving: throttlePct=%d maxSpeedMag=%d signedSpeedMag=%d',
+      throttlePct, maxSpeedMag, signedSpeedMag,
+    );
+
+    send(
+      session.socket,
+      buildCmd65PositionSyncPacket(
+        {
+          slot:     0,
+          x:        session.combatX,
+          y:        session.combatY,
+          z:        0,
+          facing:   (frame.headingRaw - MOTION_NEUTRAL) * MOTION_DIV,
+          throttle: 0,
+          legVel:   0,
+          speedMag: signedSpeedMag,
+        },
+        nextSeq(session),
+      ),
+      capture,
+      'CMD65_MOVEMENT',
+    );
+  }
+}
+
+export function handleCombatWeaponFireFrame(
+  session: ClientSession,
+  payload: Buffer,
+  connLog: Logger,
+  capture: CaptureLogger,
+): void {
+  const shot = parseClientCmd10WeaponFire(payload);
+  if (!shot) {
+    connLog.warn('[world/combat] cmd-10 weapon fire parse failed (len=%d)', payload.length);
+    return;
+  }
+
+  if (session.botHealth === undefined) {
+    session.botHealth = BOT_INITIAL_HEALTH;
+  }
+  if (session.botHealth <= 0) {
+    connLog.debug('[world/combat] cmd-10 shot ignored — bot already destroyed');
+    return;
+  }
+
+  session.botHealth = Math.max(0, session.botHealth - BOT_DAMAGE_PER_HIT);
+  connLog.info(
+    '[world/combat] cmd-10 weapon fire: targetRaw=%d weaponSlot=%d flag=%d botHealth=%d',
+    shot.targetRaw,
+    shot.weaponSlot,
+    shot.flag,
+    session.botHealth,
+  );
+
+  send(session.socket, buildCmd71ResetEffectStatePacket(nextSeq(session)), capture, 'CMD71_RESET');
+  send(
+    session.socket,
+    buildCmd68ProjectileSpawnPacket(
+      {
+        sourceSlot:   0,
+        weaponSlot:   shot.weaponSlot,
+        targetRaw:    2, // bot actor slot 1 encoded as slot + 1
+        targetAttach: 0,
+        angleSeedA:   shot.angleSeedA,
+        angleSeedB:   shot.angleSeedB,
+        impactX:      shot.impactXRaw - COORD_BIAS,
+        impactY:      shot.impactYRaw - COORD_BIAS,
+        impactZ:      shot.impactZ,
+      },
+      nextSeq(session),
+    ),
+    capture,
+    'CMD68_PROJECTILE',
+  );
+  send(
+    session.socket,
+    buildCmd66ActorDamagePacket(1, 1, BOT_DAMAGE_PER_HIT, nextSeq(session)),
+    capture,
+    'CMD66_BOT_DAMAGE',
+  );
+  send(session.socket, buildCmd71ResetEffectStatePacket(nextSeq(session)), capture, 'CMD71_CLOSE');
+
+  if (session.botHealth <= 0) {
+    connLog.info('[world/combat] bot destroyed — sending Cmd70 death animation');
+    send(
+      session.socket,
+      buildCmd70ActorTransitionPacket(1, 4, nextSeq(session)),
+      capture,
+      'CMD70_BOT_DEATH',
+    );
+    if (session.botPositionTimer !== undefined) {
+      clearInterval(session.botPositionTimer);
+      session.botPositionTimer = undefined;
+    }
+  }
+}
+
+export function handleCombatActionFrame(
+  session: ClientSession,
+  payload: Buffer,
+  connLog: Logger,
+  _capture: CaptureLogger,
+): void {
+  const action = parseClientCmd12Action(payload);
+  if (!action) {
+    connLog.warn('[world/combat] cmd-12 action parse failed (len=%d)', payload.length);
+    return;
+  }
+  connLog.debug('[world/combat] cmd-12 combat action=%d — no response', action.action);
+}
+
+// ── 3-step mech picker — Cmd7 routing ─────────────────────────────────────────
+
+export function handleMechPickerCmd7(
+  players: PlayerRegistry,
+  session: ClientSession,
+  listId: number,
+  selection: number,
+  connLog: Logger,
+  capture: CaptureLogger,
+): boolean {
+  const step = session.mechPickerStep;
+
+  if (step === 'class' && listId === MECH_CLASS_LIST_ID) {
+    if (selection === 0) {
+      session.mechPickerStep = undefined;
+      return true;
+    }
+    const classIndex = selection - 1;
+    if (classIndex < 0 || classIndex >= CLASS_KEYS.length) return true;
+    sendMechChassisPicker(session, classIndex, connLog, capture);
+    return true;
+  }
+
+  if (step === 'chassis' && listId === MECH_CHASSIS_LIST_ID) {
+    if (selection === 0) {
+      sendMechClassPicker(session, connLog, capture);
+      return true;
+    }
+    const seenChassis = new Set<string>();
+    const chassisList: string[] = [];
+    for (const mech of WORLD_MECHS) {
+      const chassis = getMechChassis(mech.typeString);
+      if (!seenChassis.has(chassis)) {
+        seenChassis.add(chassis);
+        chassisList.push(chassis);
+      }
+    }
+    chassisList.sort((a, b) => a.localeCompare(b));
+    const chassis = chassisList[selection - 1];
+    if (!chassis) {
+      sendMechClassPicker(session, connLog, capture);
+      return true;
+    }
+    sendMechVariantPicker(session, chassis, connLog, capture);
+    return true;
+  }
+
+  if (step === 'variant' && listId === MECH_CLASS_LIST_ID) {
+    if (selection === 0) {
+      sendMechChassisPicker(session, session.mechPickerClass ?? 0, connLog, capture);
+      return true;
+    }
+    const chassis = session.mechPickerChassis ?? '';
+    const variants = WORLD_MECHS.filter(mech => getMechChassis(mech.typeString) === chassis);
+    const chosen = variants[selection - 1];
+    if (!chosen) {
+      send(
+        session.socket,
+        buildCmd3BroadcastPacket('Mech selection invalid. Please try again.', nextSeq(session)),
+        capture,
+        'CMD3_MECH_SELECT_ERR',
+      );
+      sendMechClassPicker(session, connLog, capture);
+      return true;
+    }
+
+    session.selectedMechSlot  = chosen.slot;
+    session.selectedMechId    = chosen.id;
+    session.mechPickerStep    = undefined;
+    session.mechPickerClass   = undefined;
+    session.mechPickerChassis = undefined;
+
+    connLog.info('[world] mech selected: callsign="%s" slot=%d id=%d typeString=%s',
+      getDisplayName(session), chosen.slot, chosen.id, chosen.typeString);
+    send(
+      session.socket,
+      buildCmd3BroadcastPacket(`Mech selected: ${chosen.typeString}`, nextSeq(session)),
+      capture,
+      'CMD3_MECH_SELECTED',
+    );
+    send(session.socket, buildCmd5CursorNormalPacket(nextSeq(session)), capture, 'CMD5_NORMAL');
+    return true;
+  }
+
+  return false;
 }

--- a/src/world/world-handlers.ts
+++ b/src/world/world-handlers.ts
@@ -713,7 +713,32 @@ export function handleCombatMovementFrame(
     session.combatX          = frame.xRaw - COORD_BIAS;
     session.combatY          = frame.yRaw - COORD_BIAS;
     session.combatHeadingRaw = frame.headingRaw;
-    connLog.debug('[world/combat] cmd8 coasting: x=%d y=%d heading=%d', session.combatX, session.combatY, frame.headingRaw);
+    const throttle = session.combatThrottle ?? 0;
+    const legVel = session.combatLegVel ?? 0;
+    const speedMag = session.combatSpeedMag ?? 0;
+    connLog.debug(
+      '[world/combat] cmd8 coasting: x=%d y=%d heading=%d throttle=%d legVel=%d speedMag=%d',
+      session.combatX, session.combatY, frame.headingRaw, throttle, legVel, speedMag,
+    );
+
+    send(
+      session.socket,
+      buildCmd65PositionSyncPacket(
+        {
+          slot:     0,
+          x:        session.combatX,
+          y:        session.combatY,
+          z:        0,
+          facing:   (frame.headingRaw - MOTION_NEUTRAL) * MOTION_DIV,
+          throttle,
+          legVel,
+          speedMag,
+        },
+        nextSeq(session),
+      ),
+      capture,
+      'CMD65_MOVEMENT',
+    );
     return;
   }
 
@@ -729,11 +754,15 @@ export function handleCombatMovementFrame(
     const signedSpeedMag = maxSpeedMag > 0
       ? Math.round(-throttlePct * maxSpeedMag / 45)
       : 0;
+    const throttle = (frame.throttleRaw - MOTION_NEUTRAL) * MOTION_DIV;
+    const legVel = (frame.legVelRaw - MOTION_NEUTRAL) * MOTION_DIV;
+    session.combatThrottle = throttle;
+    session.combatLegVel = legVel;
     session.combatSpeedMag = signedSpeedMag;
 
     connLog.debug(
-      '[world/combat] cmd9 moving: throttlePct=%d maxSpeedMag=%d signedSpeedMag=%d',
-      throttlePct, maxSpeedMag, signedSpeedMag,
+      '[world/combat] cmd9 moving: throttlePct=%d throttle=%d legVel=%d maxSpeedMag=%d signedSpeedMag=%d',
+      throttlePct, throttle, legVel, maxSpeedMag, signedSpeedMag,
     );
 
     send(
@@ -745,8 +774,8 @@ export function handleCombatMovementFrame(
           y:        session.combatY,
           z:        0,
           facing:   (frame.headingRaw - MOTION_NEUTRAL) * MOTION_DIV,
-          throttle: 0,
-          legVel:   0,
+          throttle,
+          legVel,
           speedMag: signedSpeedMag,
         },
         nextSeq(session),

--- a/src/world/world-scene.ts
+++ b/src/world/world-scene.ts
@@ -18,10 +18,11 @@ import {
   buildCmd43SolarisMapPacket,
   buildCmd48KeyedTripleStringListPacket,
 } from '../protocol/world.js';
-import { buildMenuDialogPacket } from '../protocol/game.js';
+import { buildMenuDialogPacket, buildMechListPacket } from '../protocol/game.js';
 import { PlayerRegistry, ClientSession } from '../state/players.js';
 import { Logger }         from '../util/logger.js';
 import { CaptureLogger }  from '../util/capture.js';
+import { MECH_STATS }     from '../data/mech-stats.js';
 
 import {
   worldCaptures,
@@ -36,6 +37,13 @@ import {
   getSolarisSceneIndex,
   getSolarisRoomName,
   getSolarisRoomIcon,
+  WORLD_MECHS,
+  getMechChassis,
+  CLASS_LABELS,
+  CLASS_KEYS,
+  MECH_CLASS_LIST_ID,
+  MECH_CHASSIS_LIST_ID,
+  mechKph,
 } from './world-data.js';
 
 // ── Low-level send helpers ────────────────────────────────────────────────────
@@ -412,3 +420,109 @@ export function sendPersonnelRecord(
 // Re-export PERSONNEL_LIST_ID so the dispatch handler can reference it without
 // importing from world-data directly (it already imports this module wholesale).
 export { PERSONNEL_LIST_ID };
+
+// ── 3-step mech picker ────────────────────────────────────────────────────────
+
+/** Step 1 — send the weight-class picker (Light / Medium / Heavy / Assault). */
+export function sendMechClassPicker(
+  session: ClientSession,
+  connLog: Logger,
+  capture: CaptureLogger,
+): void {
+  session.mechPickerStep = 'class';
+  const entries = CLASS_LABELS.map((label, slot) => ({
+    id:         0,
+    mechType:   0,
+    slot,
+    typeString: '',
+    variant:    '',
+    name:       label,
+    maxSpeedMag: 0,
+    extraCritCount: 0,
+  }));
+  connLog.info('[world] sending mech class picker');
+  send(
+    session.socket,
+    buildMechListPacket(entries, MECH_CLASS_LIST_ID, '', nextSeq(session)),
+    capture,
+    'CMD26_MECH_CLASS_PICKER',
+  );
+  send(session.socket, buildCmd5CursorNormalPacket(nextSeq(session)), capture, 'CMD5_NORMAL');
+}
+
+/** Step 2 — send the chassis picker for the chosen weight class. */
+export function sendMechChassisPicker(
+  session: ClientSession,
+  classIndex: number,
+  connLog: Logger,
+  capture: CaptureLogger,
+): void {
+  session.mechPickerStep   = 'chassis';
+  session.mechPickerClass  = classIndex;
+
+  const classKey = CLASS_KEYS[classIndex] as string | undefined;
+  const seenChassis = new Set<string>();
+  const rawEntries: Array<{ chassis: string }> = [];
+  for (const mech of WORLD_MECHS) {
+    const stat = MECH_STATS.get(mech.typeString);
+    if (classKey && stat && !stat.disabled && stat.weightClass.toUpperCase() !== classKey) continue;
+    const chassis = getMechChassis(mech.typeString);
+    if (!seenChassis.has(chassis)) {
+      seenChassis.add(chassis);
+      rawEntries.push({ chassis });
+    }
+  }
+  rawEntries.sort((a, b) => a.chassis.localeCompare(b.chassis));
+
+  const entries = rawEntries.map(({ chassis }, slot) => ({
+    id:         0,
+    mechType:   0,
+    slot,
+    typeString: '',
+    variant:    '',
+    name:       chassis,
+    maxSpeedMag: 0,
+    extraCritCount: 0,
+  }));
+
+  connLog.info('[world] sending mech chassis picker: class=%s entries=%d', classKey ?? classIndex, entries.length);
+  send(
+    session.socket,
+    buildMechListPacket(entries, MECH_CHASSIS_LIST_ID, '', nextSeq(session)),
+    capture,
+    'CMD26_MECH_CHASSIS_PICKER',
+  );
+  send(session.socket, buildCmd5CursorNormalPacket(nextSeq(session)), capture, 'CMD5_NORMAL');
+}
+
+/** Step 3 — send the variant picker for the chosen chassis. */
+export function sendMechVariantPicker(
+  session: ClientSession,
+  chassis: string,
+  connLog: Logger,
+  capture: CaptureLogger,
+): void {
+  session.mechPickerStep    = 'variant';
+  session.mechPickerChassis = chassis;
+
+  const variants = WORLD_MECHS.filter(mech => getMechChassis(mech.typeString) === chassis);
+  const entries = variants.map(mech => ({
+    id:         mech.id,
+    mechType:   mech.mechType,
+    slot:       mech.slot,
+    typeString: mech.typeString,
+    variant:    `${mechKph(mech.maxSpeedMag)} kph`,
+    name:       mech.typeString,
+    maxSpeedMag: mech.maxSpeedMag,
+    extraCritCount: mech.extraCritCount,
+  }));
+
+  connLog.info('[world] sending mech variant picker: chassis="%s" entries=%d', chassis, entries.length);
+  send(
+    session.socket,
+    buildMechListPacket(entries, MECH_CLASS_LIST_ID, '', nextSeq(session)),
+    capture,
+    'CMD26_MECH_VARIANT_PICKER',
+  );
+  send(session.socket, buildCmd5CursorNormalPacket(nextSeq(session)), capture, 'CMD5_NORMAL');
+}

--- a/src/world/world-scene.ts
+++ b/src/world/world-scene.ts
@@ -247,11 +247,13 @@ export function buildSceneInitForSession(session: ClientSession) {
   // Room-type-aware action buttons.
   // actionType 4 → "Travel" (opens Cmd43 travel map).
   // actionType 5 → "Fight"  (enter combat; handled by cmd-5 dispatch in server-world.ts).
+  // actionType 6 → "Mech Bay" (opens the 3-step mech picker).
   // The client hard-codes actionType 0 (0x100 wire) as the local Help button.
   const isArena = mapRoom?.type === 'arena';
   const arenaOptions: Array<{ type: number; label: string }> = [
     { type: 0, label: 'Help' },
     { type: 4, label: 'Travel' },
+    { type: 6, label: 'Mech Bay' },
   ];
   if (isArena) {
     arenaOptions.push({ type: 5, label: 'Fight' });


### PR DESCRIPTION
## Summary

Ports the M6 combat-control work onto Ken's current `src/world/*` architecture without replacing the upstream room/navigation organization.

This PR adds combat-mode decoding and handling for:

- client `cmd 8` / `cmd 9` movement frames, including per-mech `maxSpeedMag` derived from decrypted `.MEC` data;
- client `cmd 10` weapon-fire geometry, with prototype dummy-bot feedback via `Cmd71 -> Cmd68 -> Cmd66 -> Cmd71` and `Cmd70` on bot destruction;
- client `cmd 12` combat action frames, currently decoded/logged while capture work continues;
- a `/mechbay` three-step picker so a world-session player can choose class -> chassis -> variant before entering combat.

It intentionally preserves Ken's current arena Fight button, generated-room handling, `setSessionRoomPosition()` world bookkeeping, and the refactored `src/world/*` module split.

## Related Issue

Closes #76

## Type of Change

- [ ] Bug fix
- [x] Feature / enhancement
- [x] Research finding / protocol update
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Chore (dependencies, CI, config)

## Implementation Notes

The protocol layout and constants are already documented in `RESEARCH.md` / `ROADMAP.md`, especially the M6 sections for client `cmd 8` / `cmd 9`, `cmd 10`, `cmd 12`, and server `Cmd65` / `Cmd66` / `Cmd68` / `Cmd70` / `Cmd71`.

Implementation choices:

- `src/protocol/game.ts` now exposes typed parsers for the combat client frames rather than parsing offsets inside the world dispatcher.
- `src/data/mechs.ts` reads `.MEC` offset `0x16` in the same decrypt pass used for `extraCritCount`, giving combat movement a server-side `maxSpeedMag` cap.
- `src/world/world-handlers.ts` owns combat movement, fire, action, and mech-picker routing so `src/server-world.ts` stays as the high-level command dispatcher.
- Combat `cmd 10` is routed before the world map `cmd 10` parser so combat shot geometry is not misread as a travel-map reply.
- The dummy-bot damage loop is still a prototype: each accepted `cmd 10` is treated as a hit until the remaining hit/miss semantics are captured.

## Testing

- `npm run build` passes locally on this branch.
- I did not run a fresh live MPBTWIN.EXE GUI pass for this PR branch. The implementation is based on the already-documented RE/capture findings and keeps runtime behavior narrowly scoped to combat phase or explicit `/mechbay` use.

## Checklist

- [x] Branch is based on `master`
- [x] Commit messages follow `type: description` convention (e.g. `fix: correct CRC seed`)
- [x] TypeScript builds cleanly (`npm run build`)
- [x] No debug `console.log` left in production code paths
- [x] `RESEARCH.md` updated if this reflects a new RE finding — existing M6 research sections already document these wire formats; this PR implements them in the current architecture
- [x] `symbols.json` updated if new canonical names were introduced — no new canonical symbols introduced
- [x] This PR is ready for review (not a draft)
