### PR TITLE
feat(M6): mech picker pagination, walk/run speed split, physics equilibrium docs

### DIFF
--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -3434,3 +3434,90 @@ Live packet capture is needed to confirm the exact IS component threshold and de
 | `Combat_ISBarRender` | `0x00449330` | Renders IS component bars on results screen |
 | `Combat_ActiveRound` | `0x004466c0` | Per-tick render: radar blips, range text, heading lines |
 | `Combat_Init` | `0x00446060` | Combat init: sets `g_combatMode = 3`, `g_roundState = 1` |
+
+---
+
+## 24. In-Arena Movement Physics — Walk/Run Speed and Physics Equilibrium
+
+### §24.1 — Walk vs Run Speed Split
+
+The mech `mec_speed` value (uint16 at .MEC offset 0x16) maps to two separate
+in-arena speed registers in `Combat_InitActorRuntimeFromMec_v123` (0x00433910):
+
+| Register | Formula | Notes |
+|----------|---------|-------|
+| Walk speed | `mec_speed × 300` | Confirmed by RE of `0x00433910` |
+| Run/max speed | `round(mec_speed × 1.5) × 300` | Confirmed by RE of `0x00433910` |
+
+Example — ANH-1A (`mec_speed = 2`):
+- Walk: `2 × 300 = 600` → **21.6 kph**
+- Run:  `round(3) × 300 = 900` → **32.4 kph**
+
+Example — AS7-D Atlas (`mec_speed = 3`):
+- Walk: `3 × 300 = 900` → **32.4 kph**
+- Run:  `round(4.5) × 300 = 1500` → **54 kph**
+
+> **NOTE:** The prior server-side formula `mec_speed × 450` was incorrect for
+> odd `mec_speed` values (e.g., Atlas: 1350 vs correct 1500).
+
+### §24.2 — Throttle Accumulator Scale (Cmd9 THROTTLE_RUN_SCALE)
+
+The client's KP8 (throttle up) key sends Cmd9 frames with a `sVar2` throttle
+accumulator that peaks at approximately **20** at full-forward input.  The
+server must divide `throttleRaw - MOTION_NEUTRAL` by 20 (`THROTTLE_RUN_SCALE`)
+to map full-throttle input to `maxSpeedMag`.
+
+Using a divisor of 45 (the prior value) capped forward movement at approximately
+walk speed (~21 kph for ANH-1A) because `20 × maxSpeedMag / 45 ≈ walkSpeedMag`.
+
+### §24.3 — Physics Equilibrium and the `globalA` Constant (DAT_004f56b4)
+
+**RE source:** Static analysis of `MPBTWIN.EXE` v1.23.
+
+The Cmd72 bootstrap packet includes a constant `globalA` (wire field name) which
+the client stores in `DAT_004f56b4`.  Ghidra analysis identified two functions
+that use this constant at every physics tick:
+
+**`FUN_0042c830` — velocity integrator (impulse source):**
+```
+  applied_accel = speed_target × 980 / D
+  governor_factor = (100 - throttle_pct / 5) / 100   → 0.80 at 100% throttle
+  net_impulse  = applied_accel × governor_factor
+```
+
+**`FUN_0042cd20` — ground drag (always active, proportional to speed):**
+```
+  decel = |v| × D / 10000
+```
+
+**Equilibrium condition** (net_impulse = decel):
+```
+  0.80 × speed_target × 980 / D = |v_eq| × D / 10000
+  ↓ (at equilibrium |v_eq| = speed_target)
+  0.80 × 980 / D = D / 10000
+  D² = 0.80 × 980 × 10000 = 7,840,000
+  D  = 2800
+```
+
+**Confirmation table:**
+
+| D value | Forward eq speed | Observed limit |
+|---------|-----------------|----------------|
+| 3612 (prior) | `900 × 0.80 × 980 / 3612 × 10000 / 3612 ≈ 552` | ~21 kph ✓ |
+| 2800 (fixed) | `900 × 0.80 × 980 / 2800 × 10000 / 2800 = 900` | ~32 kph ✓ |
+
+The value `D = 3612 = 0x0E1C = MOTION_NEUTRAL` was a copy/paste mistake — the
+field was initialised from the motion-bias constant rather than the physics
+parameter.  Setting `globalA = 2800` in the Cmd72 payload makes equilibrium
+speed exactly equal `speed_target` for any throttle setting.
+
+**Function cross-reference:**
+
+| Function | Address | Role |
+|----------|---------|------|
+| `Combat_InitActorRuntimeFromMec_v123` | `0x00433910` | Reads .MEC fields; sets walk/run speed registers |
+| `FUN_0042c830` | `0x0042c830` | Velocity integrator; uses `DAT_004f56b4` (globalA) |
+| `FUN_0042cd20` | `0x0042cd20` | Ground drag; uses `DAT_004f56b4` (globalA) |
+| `FUN_004229a0` | `0x004229a0` | Client-local throttle target update (KP8/KP2 path) |
+
+

--- a/src/data/mechs.ts
+++ b/src/data/mechs.ts
@@ -80,7 +80,9 @@ function decryptMec(buf: Buffer, nameLower: string): void {
  * Decrypt a .MEC file and return combat bootstrap/runtime fields in one pass.
  *
  * mec_speed is confirmed by RE of Combat_InitActorRuntimeFromMec_v123 @
- * 0x00433910: max forward speed register = mec_speed * 450.
+ * 0x00433910:
+ *   walk speed register     = mec_speed * 300
+ *   run/max forward speed   = round(mec_speed * 1.5) * 300
  * extraCritCount is confirmed by RE of Combat_ReadLocalActorMechState_v123 @
  * 0x004456c0.
  *
@@ -99,6 +101,16 @@ function readMecFields(mecPath: string, nameLower: string): { mecSpeed: number; 
     tonnage:        buf.readUInt16LE(0x18),
     extraCritCount: buf.readInt16LE(0x3c),
   };
+}
+
+function walkSpeedMagFromMecSpeed(mecSpeed: number): number {
+  return mecSpeed * 300;
+}
+
+function maxSpeedMagFromMecSpeed(mecSpeed: number): number {
+  const runMpTimes10 = mecSpeed * 15;
+  const runMp = Math.floor(runMpTimes10 / 10) + (runMpTimes10 % 10 < 5 ? 0 : 1);
+  return runMp * 300;
 }
 
 // ── Internal Structure lookup table ──────────────────────────────────────────
@@ -231,7 +243,8 @@ export function loadMechs(): MechEntry[] {
         typeString,
         variant: '', // empty → client uses its own display logic
         name:    '', // empty → client calls MechWin_LookupMechName(id)
-        maxSpeedMag: mecSpeed * 450,
+        walkSpeedMag: walkSpeedMagFromMecSpeed(mecSpeed),
+        maxSpeedMag:  maxSpeedMagFromMecSpeed(mecSpeed),
         extraCritCount,
         tonnage,
       };

--- a/src/protocol/game.ts
+++ b/src/protocol/game.ts
@@ -275,8 +275,14 @@ export interface MechEntry {
    */
   extraCritCount: number;
   /**
+   * Walk speed magnitude derived from mec_speed at offset 0x16:
+   *   walkSpeedMag = mec_speed * 300
+   * CONFIRMED by RE of Combat_InitActorRuntimeFromMec_v123 @ 0x00433910.
+   */
+  walkSpeedMag: number;
+  /**
    * Maximum forward speed magnitude derived from mec_speed at offset 0x16:
-   *   maxSpeedMag = mec_speed * 450
+   *   maxSpeedMag = round(mec_speed * 1.5) * 300
    * CONFIRMED by RE of Combat_InitActorRuntimeFromMec_v123 @ 0x00433910.
    */
   maxSpeedMag: number;

--- a/src/state/players.ts
+++ b/src/state/players.ts
@@ -140,8 +140,10 @@ export interface ClientSession {
   combatLegVel?: number;
   /** Current speedMag echoed in Cmd65 responses. */
   combatSpeedMag?: number;
-  /** Per-mech speedMag cap (mec_speed * 450), set at combat bootstrap. */
+  /** Per-mech run/max speedMag cap (round(mec_speed * 1.5) * 300), set at combat bootstrap. */
   combatMaxSpeedMag?: number;
+  /** Per-mech walk speedMag (mec_speed * 300), set at combat bootstrap. */
+  combatWalkSpeedMag?: number;
 
   // ── 3-step mech picker state ──────────────────────────────────────────────
 
@@ -151,6 +153,8 @@ export interface ClientSession {
   mechPickerClass?: number;
   /** Chassis name (e.g. "Jenner") chosen in step 2. */
   mechPickerChassis?: string;
+  /** Page offset for the chassis picker when a weight class has more than 19 rows. */
+  mechPickerChassisPage?: number;
 
   // ── Persistence fields (set after DB lookup / character creation) ─────────
 

--- a/src/world/world-data.ts
+++ b/src/world/world-data.ts
@@ -228,6 +228,8 @@ export function getSolarisRoomIcon(roomId: number): number {
 export const MECH_CLASS_LIST_ID   = 0x20;
 /** Cmd26 listId for the chassis picker (step 2). */
 export const MECH_CHASSIS_LIST_ID = 0x3e;
+/** Cmd26 can safely carry at most 20 rows; reserve one row for the "More…" pagination entry. */
+export const MECH_CHASSIS_PAGE_SIZE = 19;
 
 /** Display labels for each weight class (slot 0..3). */
 export const CLASS_LABELS = ['Light', 'Medium', 'Heavy', 'Assault'] as const;
@@ -278,6 +280,24 @@ export function getMechChassis(typeString: string): string {
   const hyphen = typeString.indexOf('-');
   const prefix = hyphen > 0 ? typeString.slice(0, hyphen) : typeString;
   return PREFIX_TO_CHASSIS.get(prefix) ?? CHASSIS_BY_PREFIX[prefix] ?? prefix;
+}
+
+/** Return sorted chassis names for the chosen weight-class index. */
+export function getMechChassisListForClass(classIndex: number): string[] {
+  const classKey = CLASS_KEYS[classIndex] as string | undefined;
+  const seenChassis = new Set<string>();
+  const chassisList: string[] = [];
+  for (const mech of WORLD_MECHS) {
+    const stat = MECH_STATS.get(mech.typeString);
+    if (classKey && stat && !stat.disabled && stat.weightClass.toUpperCase() !== classKey) continue;
+    const chassis = getMechChassis(mech.typeString);
+    if (!seenChassis.has(chassis)) {
+      seenChassis.add(chassis);
+      chassisList.push(chassis);
+    }
+  }
+  chassisList.sort((a, b) => a.localeCompare(b));
+  return chassisList;
 }
 
 /** Convert maxSpeedMag back to displayed kph, matching the client's mec_speed scale. */

--- a/src/world/world-handlers.ts
+++ b/src/world/world-handlers.ts
@@ -54,8 +54,10 @@ import {
   setSessionRoomPosition,
   CLASS_KEYS,
   getMechChassis,
+  getMechChassisListForClass,
   MECH_CLASS_LIST_ID,
   MECH_CHASSIS_LIST_ID,
+  MECH_CHASSIS_PAGE_SIZE,
 } from './world-data.js';
 import {
   send,
@@ -83,6 +85,11 @@ const BOT_DAMAGE_PER_HIT = 20;
 const BOT_FIRE_INTERVAL_MS = 3_000;
 /** Prototype damage per bot retaliatory shot (Cmd67 damageCode=1, value=10). */
 const BOT_RETALIATION_DAMAGE = 10;
+
+// KP8 full-forward produces sVar2 ≈ 20 in the client's throttle accumulator.
+// Using 20 as the scale means sVar2=20 → maxSpeedMag (run speed), rather than
+// the upstream assumption of 45 which capped movement at walk speed.
+const THROTTLE_RUN_SCALE = 20;
 
 // ── ComStar messaging ─────────────────────────────────────────────────────────
 
@@ -323,8 +330,9 @@ export function sendCombatBootstrapSequence(
   const extraCritCount  = mechEntry?.extraCritCount ?? 0;
   const critBytes       = Math.max(0, extraCritCount + 21);
 
-  // Store per-mech speedMag cap so Cmd8/9 handlers can apply it.
-  session.combatMaxSpeedMag = mechEntry?.maxSpeedMag ?? 0;
+  // Store per-mech speedMag caps so Cmd8/9 handlers can apply them.
+  session.combatMaxSpeedMag  = mechEntry?.maxSpeedMag  ?? 0;
+  session.combatWalkSpeedMag = mechEntry?.walkSpeedMag ?? 0;
   session.botHealth    = BOT_INITIAL_HEALTH;
   session.playerHealth = BOT_INITIAL_HEALTH; // simplified IS counter (stops Cmd67 when ≤ 0)
 
@@ -750,30 +758,55 @@ export function handleCombatMovementFrame(
     session.combatY          = frame.yRaw - COORD_BIAS;
     session.combatHeadingRaw = frame.headingRaw;
     const throttle = session.combatThrottle ?? 0;
-    const legVel = session.combatLegVel ?? 0;
-    const speedMag = session.combatSpeedMag ?? 0;
-    connLog.debug(
-      '[world/combat] cmd8 coasting: x=%d y=%d heading=%d throttle=%d legVel=%d speedMag=%d',
-      session.combatX, session.combatY, frame.headingRaw, throttle, legVel, speedMag,
-    );
+    const legVel   = session.combatLegVel   ?? 0;
+    let speedMag   = session.combatSpeedMag ?? 0;
 
-    send(
-      session.socket,
-      buildCmd65PositionSyncPacket(
-        {
-          slot:     0,
-          x:        session.combatX,
-          y:        session.combatY,
-          z:        0,
-          facing:   (frame.headingRaw - MOTION_NEUTRAL) * MOTION_DIV,
-          throttle,
-          legVel,
-          speedMag,
-        },
-        nextSeq(session),
-      ),
-      capture,
-      'CMD65_MOVEMENT',
+    // Ghidra: DAT_004f1f7c=0 → is_moving=false → client sends Cmd8 forever.
+    // When the mech is moving (clientSpeed!=0), echo Cmd65 with a non-zero
+    // throttle to set DAT_004f1f7c != 0 → is_moving=true → next frame is Cmd9.
+    const clientSpeed = frame.rotationRaw - MOTION_NEUTRAL;
+    if (clientSpeed !== 0) {
+      const maxSpeedMag   = session.combatMaxSpeedMag ?? 0;
+      const dir           = Math.sign(clientSpeed);
+      const boostThrottle = dir * MOTION_DIV;   // minimal non-zero value in correct direction
+      const boostSpeedMag = dir * maxSpeedMag;  // drive to run speed immediately
+      session.combatThrottle = boostThrottle;
+      session.combatLegVel   = 0;
+      session.combatSpeedMag = boostSpeedMag;
+      connLog.debug(
+        '[world/combat] cmd8 coasting: x=%d y=%d heading=%d clientSpeed=%d → boosting Cmd65 throttle=%d speedMag=%d',
+        session.combatX, session.combatY, frame.headingRaw, clientSpeed, boostThrottle, boostSpeedMag,
+      );
+      send(
+        session.socket,
+        buildCmd65PositionSyncPacket(
+          {
+            slot:     0,
+            x:        session.combatX,
+            y:        session.combatY,
+            z:        0,
+            facing:   (frame.headingRaw - MOTION_NEUTRAL) * MOTION_DIV,
+            throttle: boostThrottle,
+            legVel:   0,
+            speedMag: boostSpeedMag,
+          },
+          nextSeq(session),
+        ),
+        capture,
+        'CMD65_MOVEMENT',
+      );
+      return;
+    }
+
+    // clientSpeed === 0 → mech has stopped; suppress Cmd65 echo to avoid
+    // resetting the movement accumulator while stationary.
+    if (speedMag !== 0) {
+      session.combatSpeedMag = 0;
+      speedMag = 0;
+    }
+    connLog.debug(
+      '[world/combat] cmd8 coasting: x=%d y=%d heading=%d clientSpeed=0 suppressing echo (stopped)',
+      session.combatX, session.combatY, frame.headingRaw,
     );
     return;
   }
@@ -785,22 +818,36 @@ export function handleCombatMovementFrame(
     session.combatY          = frame.yRaw - COORD_BIAS;
     session.combatHeadingRaw = frame.headingRaw;
 
-    const maxSpeedMag = session.combatMaxSpeedMag ?? 0;
-    const throttlePct = frame.throttleRaw - MOTION_NEUTRAL; // negative = forward
-    const signedSpeedMag = maxSpeedMag > 0
-      ? Math.round(-throttlePct * maxSpeedMag / 45)
+    const maxSpeedMag    = session.combatMaxSpeedMag ?? 0;
+    const throttlePct    = frame.throttleRaw - MOTION_NEUTRAL; // negative = forward
+    const legVelPct      = frame.legVelRaw   - MOTION_NEUTRAL;
+    const previousSpeedMag = session.combatSpeedMag ?? 0;
+
+    // Scale sVar2 (max=20 from KP8) directly to maxSpeedMag so full-throttle
+    // input produces run speed rather than stopping at walk speed.
+    const nextSpeedMag = maxSpeedMag > 0
+      ? Math.max(-maxSpeedMag, Math.min(maxSpeedMag, Math.round(-throttlePct * maxSpeedMag / THROTTLE_RUN_SCALE)))
       : 0;
+
+    // Only latch new speed when the throttle or leg velocity is active; idle
+    // Cmd9 samples (legVelPct==0 and clientSpeed==0) preserve the last speed.
+    const clientSpeed  = frame.rotationRaw - MOTION_NEUTRAL;
+    const shouldLatch  = !(legVelPct === 0 && clientSpeed === 0);
+    const signedSpeedMag = shouldLatch ? nextSpeedMag : previousSpeedMag;
+
     const throttle = (frame.throttleRaw - MOTION_NEUTRAL) * MOTION_DIV;
-    const legVel = (frame.legVelRaw - MOTION_NEUTRAL) * MOTION_DIV;
+    const legVel   = (frame.legVelRaw   - MOTION_NEUTRAL) * MOTION_DIV;
     session.combatThrottle = throttle;
-    session.combatLegVel = legVel;
+    session.combatLegVel   = legVel;
     session.combatSpeedMag = signedSpeedMag;
 
     connLog.debug(
-      '[world/combat] cmd9 moving: throttlePct=%d throttle=%d legVel=%d maxSpeedMag=%d signedSpeedMag=%d',
-      throttlePct, throttle, legVel, maxSpeedMag, signedSpeedMag,
+      '[world/combat] cmd9 moving: throttlePct=%d legVelPct=%d clientSpeed=%d throttle=%d legVel=%d maxSpeedMag=%d nextSpeedMag=%d latchedSpeedMag=%d',
+      throttlePct, legVelPct, clientSpeed, throttle, legVel, maxSpeedMag, nextSpeedMag, signedSpeedMag,
     );
 
+    // Echo only the speed target; negate throttle so the sign convention
+    // (FUN_0042c830 negation of DAT_004f1f7c) keeps the client in Cmd9 mode.
     send(
       session.socket,
       buildCmd65PositionSyncPacket(
@@ -810,7 +857,7 @@ export function handleCombatMovementFrame(
           y:        session.combatY,
           z:        0,
           facing:   (frame.headingRaw - MOTION_NEUTRAL) * MOTION_DIV,
-          throttle,
+          throttle: -throttle,
           legVel,
           speedMag: signedSpeedMag,
         },
@@ -909,6 +956,10 @@ export function handleCombatActionFrame(
     connLog.warn('[world/combat] cmd-12 action parse failed (len=%d)', payload.length);
     return;
   }
+  // Ghidra confirmed: action 0x34 (THROTTLE_UP) calls FUN_004229a0 locally
+  // but does NOT call Combat_SendCmd12Action_v123 — so these packets never
+  // arrive from the client.  Speed is driven entirely by the Cmd9
+  // throttleRaw → THROTTLE_RUN_SCALE path; no server response is needed here.
   connLog.debug('[world/combat] cmd-12 combat action=%d — no response', action.action);
 }
 
@@ -940,17 +991,19 @@ export function handleMechPickerCmd7(
       sendMechClassPicker(session, connLog, capture);
       return true;
     }
-    const seenChassis = new Set<string>();
-    const chassisList: string[] = [];
-    for (const mech of WORLD_MECHS) {
-      const chassis = getMechChassis(mech.typeString);
-      if (!seenChassis.has(chassis)) {
-        seenChassis.add(chassis);
-        chassisList.push(chassis);
-      }
+    const classIndex  = session.mechPickerClass ?? 0;
+    const page        = session.mechPickerChassisPage ?? 0;
+    const chassisList = getMechChassisListForClass(classIndex);
+    const start       = page * MECH_CHASSIS_PAGE_SIZE;
+    const visible     = chassisList.slice(start, start + MECH_CHASSIS_PAGE_SIZE);
+    const hasMore     = start + MECH_CHASSIS_PAGE_SIZE < chassisList.length;
+
+    // "More…" row is always the last entry when hasMore is true.
+    if (hasMore && selection === visible.length + 1) {
+      sendMechChassisPicker(session, classIndex, connLog, capture, page + 1);
+      return true;
     }
-    chassisList.sort((a, b) => a.localeCompare(b));
-    const chassis = chassisList[selection - 1];
+    const chassis = visible[selection - 1];
     if (!chassis) {
       sendMechClassPicker(session, connLog, capture);
       return true;
@@ -961,7 +1014,7 @@ export function handleMechPickerCmd7(
 
   if (step === 'variant' && listId === MECH_CLASS_LIST_ID) {
     if (selection === 0) {
-      sendMechChassisPicker(session, session.mechPickerClass ?? 0, connLog, capture);
+      sendMechChassisPicker(session, session.mechPickerClass ?? 0, connLog, capture, session.mechPickerChassisPage ?? 0);
       return true;
     }
     const chassis = session.mechPickerChassis ?? '';
@@ -978,11 +1031,12 @@ export function handleMechPickerCmd7(
       return true;
     }
 
-    session.selectedMechSlot  = chosen.slot;
-    session.selectedMechId    = chosen.id;
-    session.mechPickerStep    = undefined;
-    session.mechPickerClass   = undefined;
-    session.mechPickerChassis = undefined;
+    session.selectedMechSlot       = chosen.slot;
+    session.selectedMechId         = chosen.id;
+    session.mechPickerStep         = undefined;
+    session.mechPickerClass        = undefined;
+    session.mechPickerChassis      = undefined;
+    session.mechPickerChassisPage  = undefined;
 
     connLog.info('[world] mech selected: callsign="%s" slot=%d id=%d typeString=%s',
       getDisplayName(session), chosen.slot, chosen.id, chosen.typeString);

--- a/src/world/world-scene.ts
+++ b/src/world/world-scene.ts
@@ -22,7 +22,6 @@ import { buildMenuDialogPacket, buildMechListPacket } from '../protocol/game.js'
 import { PlayerRegistry, ClientSession } from '../state/players.js';
 import { Logger }         from '../util/logger.js';
 import { CaptureLogger }  from '../util/capture.js';
-import { MECH_STATS }     from '../data/mech-stats.js';
 
 import {
   worldCaptures,
@@ -39,10 +38,12 @@ import {
   getSolarisRoomIcon,
   WORLD_MECHS,
   getMechChassis,
+  getMechChassisListForClass,
   CLASS_LABELS,
   CLASS_KEYS,
   MECH_CLASS_LIST_ID,
   MECH_CHASSIS_LIST_ID,
+  MECH_CHASSIS_PAGE_SIZE,
   mechKph,
 } from './world-data.js';
 
@@ -431,7 +432,10 @@ export function sendMechClassPicker(
   connLog: Logger,
   capture: CaptureLogger,
 ): void {
-  session.mechPickerStep = 'class';
+  session.mechPickerStep        = 'class';
+  session.mechPickerClass       = undefined;
+  session.mechPickerChassis     = undefined;
+  session.mechPickerChassisPage = undefined;
   const entries = CLASS_LABELS.map((label, slot) => ({
     id:         0,
     mechType:   0,
@@ -439,6 +443,7 @@ export function sendMechClassPicker(
     typeString: '',
     variant:    '',
     name:       label,
+    walkSpeedMag: 0,
     maxSpeedMag: 0,
     extraCritCount: 0,
     tonnage:    0,
@@ -453,43 +458,54 @@ export function sendMechClassPicker(
   send(session.socket, buildCmd5CursorNormalPacket(nextSeq(session)), capture, 'CMD5_NORMAL');
 }
 
-/** Step 2 — send the chassis picker for the chosen weight class. */
+/** Step 2 — send the chassis picker for the chosen weight class (with pagination). */
 export function sendMechChassisPicker(
   session: ClientSession,
   classIndex: number,
   connLog: Logger,
   capture: CaptureLogger,
+  page = 0,
 ): void {
-  session.mechPickerStep   = 'chassis';
-  session.mechPickerClass  = classIndex;
+  session.mechPickerStep        = 'chassis';
+  session.mechPickerClass       = classIndex;
+  session.mechPickerChassisPage = page;
 
-  const classKey = CLASS_KEYS[classIndex] as string | undefined;
-  const seenChassis = new Set<string>();
-  const rawEntries: Array<{ chassis: string }> = [];
-  for (const mech of WORLD_MECHS) {
-    const stat = MECH_STATS.get(mech.typeString);
-    if (classKey && stat && !stat.disabled && stat.weightClass.toUpperCase() !== classKey) continue;
-    const chassis = getMechChassis(mech.typeString);
-    if (!seenChassis.has(chassis)) {
-      seenChassis.add(chassis);
-      rawEntries.push({ chassis });
-    }
-  }
-  rawEntries.sort((a, b) => a.chassis.localeCompare(b.chassis));
+  const classKey    = CLASS_KEYS[classIndex] as string | undefined;
+  const chassisList = getMechChassisListForClass(classIndex);
+  const start       = page * MECH_CHASSIS_PAGE_SIZE;
+  const visible     = chassisList.slice(start, start + MECH_CHASSIS_PAGE_SIZE);
+  const hasMore     = start + MECH_CHASSIS_PAGE_SIZE < chassisList.length;
 
-  const entries = rawEntries.map(({ chassis }, slot) => ({
+  const entries = visible.map((chassis, slot) => ({
     id:         0,
     mechType:   0,
     slot,
     typeString: '',
     variant:    '',
     name:       chassis,
+    walkSpeedMag: 0,
     maxSpeedMag: 0,
     extraCritCount: 0,
     tonnage:    0,
   }));
 
-  connLog.info('[world] sending mech chassis picker: class=%s entries=%d', classKey ?? classIndex, entries.length);
+  if (hasMore) {
+    entries.push({
+      id:         0,
+      mechType:   0,
+      slot:       visible.length,
+      typeString: '',
+      variant:    '',
+      name:       'More...',
+      walkSpeedMag: 0,
+      maxSpeedMag: 0,
+      extraCritCount: 0,
+      tonnage:    0,
+    });
+  }
+
+  connLog.info('[world] sending mech chassis picker: class=%s page=%d entries=%d total=%d',
+    classKey ?? classIndex, page, entries.length, chassisList.length);
   send(
     session.socket,
     buildMechListPacket(entries, MECH_CHASSIS_LIST_ID, '', nextSeq(session)),
@@ -515,8 +531,9 @@ export function sendMechVariantPicker(
     mechType:   mech.mechType,
     slot:       mech.slot,
     typeString: mech.typeString,
-    variant:    `${mechKph(mech.maxSpeedMag)} kph`,
+    variant:    `${mechKph(mech.walkSpeedMag)}/${mechKph(mech.maxSpeedMag)} kph`,
     name:       mech.typeString,
+    walkSpeedMag: mech.walkSpeedMag,
     maxSpeedMag: mech.maxSpeedMag,
     extraCritCount: mech.extraCritCount,
     tonnage:    mech.tonnage,


### PR DESCRIPTION
## Summary

Three related M6 enhancements developed through live RE and in-client testing:

1. **Walk/run speed split** — correct the per-mech speed formula from the wrong \mec_speed × 450\ to the client-verified \walkSpeedMag = mec_speed × 300\ / \maxSpeedMag = round(mec_speed × 1.5) × 300\.  The old formula coincidentally gave the right answer for even \mec_speed\ values (ANH-1A) but was off for odd values (Atlas AS7-D: 1350 → 1500).

2. **Throttle scaling fix (THROTTLE_RUN_SCALE = 20)** — KP8 full-forward produces a \sVar2\ accumulator peak of ≈ 20 in the client.  Dividing by 20 maps full-throttle to \maxSpeedMag\ (run speed).  The prior divisor of 45 capped forward movement at walk speed: \20 × maxSpeedMag / 45 ≈ walkSpeedMag\.

3. **Mech picker chassis pagination** — Cmd26 comfortably fits 20 rows; heavier weight classes (Assault has 30+ chassis) now page in groups of 19 with a 'More...' entry.  The variant picker label is updated to show both speeds (e.g. \22/32 kph\).

## Related Issue

Closes #82

## Type of Change

- [x] Bug fix
- [x] Feature / enhancement
- [x] Research finding / protocol update
- [x] Documentation update

## Implementation Notes

**Walk/run speed split** — \mec_speed\ at .MEC offset 0x16 feeds two registers in \Combat_InitActorRuntimeFromMec_v123\ (0x00433910).  The walk register is \mec_speed × 300\; the run register uses the standard BattleTech formula \ound(mec_speed × 1.5) × 300\ (multiplied movement points × 300 unit scale).  See RESEARCH.md §24.1.

**THROTTLE_RUN_SCALE** — confirmed by live capture: KP8 held to full produces Cmd9 frames with \	hrottleRaw - MOTION_NEUTRAL ≈ -20\ at peak.  RESEARCH.md §24.2.

**Cmd8 trap fix** — Ghidra RE showed that \DAT_004f1f7c = 0\ (is_moving = false) causes the client to keep sending Cmd8 frames rather than switching to Cmd9.  When a Cmd8 frame carries a non-zero \clientSpeed\, the server echoes a Cmd65 with a minimal non-zero throttle in the correct direction, which sets \DAT_004f1f7c ≠ 0\ and breaks the trap.  When \clientSpeed = 0\ the echo is suppressed entirely to avoid resetting the accumulator while the mech is stopped.

**Cmd9 echo throttle negation** — the client's velocity integrator negates \DAT_004f1f7c\ internally, so the server must echo \-throttle\ (not \+throttle\) to maintain the correct accumulator sign and keep the client in Cmd9 mode.

**Cmd12 comment** — Ghidra confirmed that KP8/KP2 call \FUN_004229a0\ (throttle target update) locally and do *not* call \Combat_SendCmd12Action_v123\, so Cmd12 packets for throttle actions are never sent to the server.  The handler correctly takes no action; the comment now documents this finding.

**Physics equilibrium (globalA = 2800)** — already shipped in #84; §24.3 adds the derivation proof and confirmation table for the record.

## Testing

- Live MPBT v1.23 client connected; ANH-1A selected.
- Full forward throttle (KP8 held): HUD speed gauge reached **32 kph** ✓ (was capped at 21 kph before THROTTLE_RUN_SCALE fix)
- Reverse (KP2 held): gauge reached **−21 kph** ✓ (was capped at −14 kph)
- Mech picker: Assault class displayed first 19 chassis with 'More...' row; clicking 'More...' showed next page ✓
- Variant picker: ANH-1A entry shows **22/32 kph** ✓

## Checklist

- [x] Branch is based on \master\
- [x] Commit messages follow \	ype: description\ convention
- [x] TypeScript builds cleanly (\
pm run build\)
- [x] No debug \console.log\ left in production code paths
- [x] \RESEARCH.md\ updated (§24 added: walk/run speed, throttle scale, physics equilibrium proof)
- [ ] \symbols.json\ updated if new canonical names were introduced
- [x] This PR is ready for review (not a draft)