### PR TITLE
feat(M6): scripted /fightwin and /fightlose verification modes

### DIFF
--- a/src/server-world.ts
+++ b/src/server-world.ts
@@ -291,8 +291,16 @@ function handleWorldGameData(
       connLog.warn('[world] cmd-4 parse failed');
       return;
     }
-    // "/fight" command: trigger combat bootstrap if not already in combat.
-    if (parsed.text.trim().toLowerCase() === '/fight') {
+    const textCmd = parsed.text.trim().toLowerCase();
+    // "/fight" family: trigger combat bootstrap if not already in combat.
+    if (textCmd === '/fight' || textCmd === '/fightwin' || textCmd === '/fightlose') {
+      if (textCmd === '/fightwin') {
+        session.combatVerificationMode = 'autowin';
+      } else if (textCmd === '/fightlose') {
+        session.combatVerificationMode = 'autolose';
+      } else {
+        session.combatVerificationMode = undefined;
+      }
       if (!session.combatInitialized && session.phase === 'world') {
         sendCombatBootstrapSequence(session, connLog, capture);
       } else {
@@ -652,6 +660,7 @@ function handleWorldConnection(socket: net.Socket, players: PlayerRegistry, log:
     // Reset combat per-session counters so a reconnect starts fresh.
     session.botHealth            = undefined;
     session.playerHealth         = undefined;
+    session.combatVerificationMode = undefined;
     session.combatJumpFuel       = undefined;
     session.lastCombatFireActionAt = undefined;
     capture.close();

--- a/src/state/players.ts
+++ b/src/state/players.ts
@@ -124,6 +124,9 @@ export interface ClientSession {
    */
   selectedMechSlot?: number;
 
+  /** Optional scripted combat verification mode consumed on the next /fight bootstrap. */
+  combatVerificationMode?: 'autowin' | 'autolose';
+
   /**
    * Pending mech slot chosen in the mech-select dialog, held until the
    * player confirms their selection (cmd-7 confirm reply).

--- a/src/world/world-handlers.ts
+++ b/src/world/world-handlers.ts
@@ -521,6 +521,52 @@ export function sendCombatBootstrapSequence(
   }, BOT_FIRE_INTERVAL_MS);
   session.botFireTimer.unref();
 
+  const verificationMode = session.combatVerificationMode;
+  session.combatVerificationMode = undefined;
+  if (verificationMode === 'autowin') {
+    setTimeout(() => {
+      if (session.socket.destroyed || !session.socket.writable) return;
+      connLog.info('[world/combat] scripted verification: autowin');
+      session.botHealth = 0;
+      send(
+        session.socket,
+        buildCmd66ActorDamagePacket(1, 1, 999, nextSeq(session)),
+        capture,
+        'CMD66_VERIFY_AUTOWIN',
+      );
+      send(
+        session.socket,
+        buildCmd70ActorTransitionPacket(1, 4, nextSeq(session)),
+        capture,
+        'CMD70_VERIFY_AUTOWIN',
+      );
+      if (session.botPositionTimer !== undefined) {
+        clearInterval(session.botPositionTimer);
+        session.botPositionTimer = undefined;
+      }
+      if (session.botFireTimer !== undefined) {
+        clearInterval(session.botFireTimer);
+        session.botFireTimer = undefined;
+      }
+    }, 1200).unref();
+  } else if (verificationMode === 'autolose') {
+    setTimeout(() => {
+      if (session.socket.destroyed || !session.socket.writable) return;
+      connLog.info('[world/combat] scripted verification: autolose');
+      session.playerHealth = 0;
+      send(
+        session.socket,
+        buildCmd67LocalDamagePacket(1, 999, nextSeq(session)),
+        capture,
+        'CMD67_VERIFY_AUTOLOSE',
+      );
+      if (session.botFireTimer !== undefined) {
+        clearInterval(session.botFireTimer);
+        session.botFireTimer = undefined;
+      }
+    }, 1200).unref();
+  }
+
   session.combatInitialized = true;
   connLog.info('[world] combat entry complete for "%s"', callsign);
 }


### PR DESCRIPTION
## Summary
Adds deterministic M6 verification helpers to quickly exercise win/loss combat paths.

## Changes
- Add combatVerificationMode on ClientSession
- Extend cmd-4 text command handling:
  - /fight = normal behavior
  - /fightwin = scripted auto-win path after bootstrap
  - /fightlose = scripted auto-lose path after bootstrap
- Scripted modes send combat packets shortly after bootstrap to drive outcome:
  - autowin: Cmd66 damage + Cmd70 death for bot slot
  - autolose: Cmd67 local damage spike
- Clear verification mode on disconnect

## Validation
- npx tsc --noEmit passes