### PR TITLE
feat(M6): scripted damage sweep verification modes

### DIFF
--- a/src/server-world.ts
+++ b/src/server-world.ts
@@ -293,11 +293,21 @@ function handleWorldGameData(
     }
     const textCmd = parsed.text.trim().toLowerCase();
     // "/fight" family: trigger combat bootstrap if not already in combat.
-    if (textCmd === '/fight' || textCmd === '/fightwin' || textCmd === '/fightlose') {
+    if (
+      textCmd === '/fight' ||
+      textCmd === '/fightwin' ||
+      textCmd === '/fightlose' ||
+      textCmd === '/fightdmglocal' ||
+      textCmd === '/fightdmgbot'
+    ) {
       if (textCmd === '/fightwin') {
         session.combatVerificationMode = 'autowin';
       } else if (textCmd === '/fightlose') {
         session.combatVerificationMode = 'autolose';
+      } else if (textCmd === '/fightdmglocal') {
+        session.combatVerificationMode = 'dmglocal';
+      } else if (textCmd === '/fightdmgbot') {
+        session.combatVerificationMode = 'dmgbot';
       } else {
         session.combatVerificationMode = undefined;
       }

--- a/src/state/players.ts
+++ b/src/state/players.ts
@@ -125,7 +125,7 @@ export interface ClientSession {
   selectedMechSlot?: number;
 
   /** Optional scripted combat verification mode consumed on the next /fight bootstrap. */
-  combatVerificationMode?: 'autowin' | 'autolose';
+  combatVerificationMode?: 'autowin' | 'autolose' | 'dmglocal' | 'dmgbot';
 
   /**
    * Pending mech slot chosen in the mech-select dialog, held until the

--- a/src/world/world-handlers.ts
+++ b/src/world/world-handlers.ts
@@ -103,6 +103,12 @@ const FIRE_ACTION_WINDOW_MS = 1_000;
 const BOT_FIRE_INTERVAL_MS = 3_000;
 /** Prototype damage per bot retaliatory shot (Cmd67 damageCode=1, value=10). */
 const BOT_RETALIATION_DAMAGE = 10;
+/** Delay before scripted verification actions run after bootstrap. */
+const VERIFY_DELAY_MS = 1200;
+/** Delay between scripted damage sweep packets (ms). */
+const VERIFY_SWEEP_STEP_MS = 700;
+/** Damage codes used for quick client-side classifier probing. */
+const VERIFY_DAMAGE_CODES = [1, 2, 8, 16, 32, 64] as const;
 
 // KP8 full-forward produces sVar2 ≈ 20 in the client's throttle accumulator.
 // Using 20 as the scale means sVar2=20 → maxSpeedMag (run speed), rather than
@@ -548,7 +554,7 @@ export function sendCombatBootstrapSequence(
         clearInterval(session.botFireTimer);
         session.botFireTimer = undefined;
       }
-    }, 1200).unref();
+    }, VERIFY_DELAY_MS).unref();
   } else if (verificationMode === 'autolose') {
     setTimeout(() => {
       if (session.socket.destroyed || !session.socket.writable) return;
@@ -564,7 +570,35 @@ export function sendCombatBootstrapSequence(
         clearInterval(session.botFireTimer);
         session.botFireTimer = undefined;
       }
-    }, 1200).unref();
+    }, VERIFY_DELAY_MS).unref();
+  } else if (verificationMode === 'dmglocal' || verificationMode === 'dmgbot') {
+    const sendSweep = (): void => {
+      if (session.socket.destroyed || !session.socket.writable) return;
+      connLog.info('[world/combat] scripted verification: %s sweep', verificationMode);
+
+      VERIFY_DAMAGE_CODES.forEach((code, idx) => {
+        setTimeout(() => {
+          if (session.socket.destroyed || !session.socket.writable) return;
+          if (verificationMode === 'dmglocal') {
+            send(
+              session.socket,
+              buildCmd67LocalDamagePacket(code, 5, nextSeq(session)),
+              capture,
+              `CMD67_VERIFY_SWEEP_${code}`,
+            );
+          } else {
+            send(
+              session.socket,
+              buildCmd66ActorDamagePacket(1, code, 5, nextSeq(session)),
+              capture,
+              `CMD66_VERIFY_SWEEP_${code}`,
+            );
+          }
+        }, idx * VERIFY_SWEEP_STEP_MS).unref();
+      });
+    };
+
+    setTimeout(sendSweep, VERIFY_DELAY_MS).unref();
   }
 
   session.combatInitialized = true;


### PR DESCRIPTION
## Summary
Adds deterministic combat damage sweep tools to accelerate M6 damage-model and classifier verification.

## Changes
- Extend combatVerificationMode with dmglocal and dmgbot
- Add world text commands:
  - /fightdmglocal -> enter combat and run local damage-code sweep via Cmd67
  - /fightdmgbot -> enter combat and run bot damage-code sweep via Cmd66
- Add reusable verification timing constants for delayed bootstrap-driven test flows
- Keep existing /fight, /fightwin, /fightlose behavior unchanged

## Validation
- npx tsc --noEmit passes