### PR TITLE
feat(M6): add /fightrestart and /botmech commands for combat re-entry and bot mech selection

### DIFF
--- a/src/server-world.ts
+++ b/src/server-world.ts
@@ -94,6 +94,7 @@ import {
   handleLocationAction,
   handleWorldTextCommand,
   sendCombatBootstrapSequence,
+  stopCombatTimers,
   notifyRoomArrival,
   notifyRoomDeparture,
   handleCombatMovementFrame,
@@ -292,6 +293,30 @@ function handleWorldGameData(
       return;
     }
     const textCmd = parsed.text.trim().toLowerCase();
+    // "/fightrestart": stop any running combat timers, reset state, and
+    // re-run the bootstrap from scratch — works even if combat was already
+    // started.  Useful for iterating test scenarios without disconnecting.
+    if (textCmd === '/fightrestart') {
+      if (session.phase !== 'world') {
+        connLog.debug('[world] /fightrestart ignored in phase=%s', session.phase);
+        return;
+      }
+      connLog.info('[world] /fightrestart: stopping timers and resetting combat state');
+      stopCombatTimers(session);
+      session.combatInitialized = false;
+      session.phase = 'world';
+      session.botHealth    = undefined;
+      session.playerHealth = undefined;
+      session.combatJumpAltitude = undefined;
+      session.combatJumpFuel = undefined;
+      session.lastCombatFireActionAt = undefined;
+      session.combatRequireAction0ForFire = undefined;
+      session.combatShotsAccepted = undefined;
+      session.combatShotsRejected = undefined;
+      session.combatShotsUngatedAccepted = undefined;
+      sendCombatBootstrapSequence(session, connLog, capture);
+      return;
+    }
     // "/fight" family: trigger combat bootstrap if not already in combat.
     if (
       textCmd === '/fight' ||
@@ -658,18 +683,7 @@ function handleWorldConnection(socket: net.Socket, players: PlayerRegistry, log:
     if (keepaliveTimer !== undefined) {
       clearInterval(keepaliveTimer);
     }
-    if (session.botPositionTimer !== undefined) {
-      clearInterval(session.botPositionTimer);
-    }
-    if (session.botFireTimer !== undefined) {
-      clearInterval(session.botFireTimer);
-    }
-    if (session.combatJumpTimer !== undefined) {
-      clearInterval(session.combatJumpTimer);
-    }
-    if (session.combatJumpFuelRegenTimer !== undefined) {
-      clearInterval(session.combatJumpFuelRegenTimer);
-    }
+    stopCombatTimers(session);
     // Reset combat per-session counters so a reconnect starts fresh.
     if (
       session.combatShotsAccepted !== undefined ||

--- a/src/state/players.ts
+++ b/src/state/players.ts
@@ -164,6 +164,11 @@ export interface ClientSession {
   combatShotsRejected?: number;
   /** Count of cmd10 shots accepted without a recent cmd12/action0 gate (relaxed mode). */
   combatShotsUngatedAccepted?: number;
+  /**
+   * Mech ID override for the scripted bot opponent.  Set via `/botmech <id>`;
+   * used instead of the player's own mech when bootstrapping combat.
+   */
+  combatBotMechId?: number;
   /** Per-mech run/max speedMag cap (round(mec_speed * 1.5) * 300), set at combat bootstrap. */
   combatMaxSpeedMag?: number;
   /** Per-mech walk speedMag (mec_speed * 300), set at combat bootstrap. */

--- a/src/world/world-handlers.ts
+++ b/src/world/world-handlers.ts
@@ -123,6 +123,32 @@ function regenJumpFuelIfGrounded(session: ClientSession): void {
   session.combatJumpFuel = Math.min(JUMP_JET_FUEL_MAX, fuel + JUMP_JET_FUEL_REGEN_PER_FRAME);
 }
 
+/**
+ * Clear all repeating combat timers on a session.
+ *
+ * Called both from the TCP 'close' handler (cleanup on disconnect) and from
+ * the `/fightrestart` handler (cleanup before re-bootstrapping in the same
+ * connection).  Idempotent — safe to call multiple times.
+ */
+export function stopCombatTimers(session: ClientSession): void {
+  if (session.botPositionTimer !== undefined) {
+    clearInterval(session.botPositionTimer);
+    session.botPositionTimer = undefined;
+  }
+  if (session.botFireTimer !== undefined) {
+    clearInterval(session.botFireTimer);
+    session.botFireTimer = undefined;
+  }
+  if (session.combatJumpTimer !== undefined) {
+    clearInterval(session.combatJumpTimer);
+    session.combatJumpTimer = undefined;
+  }
+  if (session.combatJumpFuelRegenTimer !== undefined) {
+    clearInterval(session.combatJumpFuelRegenTimer);
+    session.combatJumpFuelRegenTimer = undefined;
+  }
+}
+
 // ── ComStar messaging ─────────────────────────────────────────────────────────
 
 export function handleComstarTextReply(
@@ -435,6 +461,8 @@ export function sendCombatBootstrapSequence(
   send(socket, cmd72, capture, 'CMD72_COMBAT_BOOTSTRAP');
 
   // 3. Cmd64 — add remote bot actor at slot 1.
+  const botMechId   = session.combatBotMechId ?? mechId;
+  const botMechEntry = WORLD_MECH_BY_ID.get(botMechId);
   const cmd64 = buildCmd64RemoteActorPacket(
     {
       slot:          1,
@@ -445,11 +473,12 @@ export function sendCombatBootstrapSequence(
       identity3:     '',
       identity4:     '',
       statusByte:    0,
-      mechId:        mechId,  // same mech type as player
+      mechId:        botMechId,
     },
     nextSeq(session),
   );
   send(socket, cmd64, capture, 'CMD64_BOT_ACTOR');
+  connLog.info('[world] bot actor: mech_id=%d type=%s', botMechId, botMechEntry?.typeString ?? '?');
 
   // 4. Cmd65 — initial position for the local actor (slot 0) at the origin.
   //    Gives the client something to render immediately after bootstrap.
@@ -690,6 +719,40 @@ export function handleWorldTextCommand(
 
   const line = `${getDisplayName(session)}: ${clean}`;
   connLog.info('[world] cmd-4 text: %s', line);
+
+  // /botmech <id> — choose the mech ID for the scripted bot opponent.
+  // The ID is a numeric mech variant ID from the loaded mech list.  Persists
+  // across /fightrestart within the same connection.
+  const botmechMatch = clean.match(/^\/botmech\s+(\d+)$/i);
+  if (botmechMatch) {
+    const requestedId = parseInt(botmechMatch[1], 10);
+    const mechEntry   = WORLD_MECH_BY_ID.get(requestedId);
+    if (!mechEntry) {
+      connLog.warn('[world] /botmech: unknown mech_id=%d', requestedId);
+      send(
+        session.socket,
+        buildCmd3BroadcastPacket(
+          `Unknown mech_id ${requestedId}. Use /mechs to browse available mechs.`,
+          nextSeq(session),
+        ),
+        capture,
+        'CMD3_BOTMECH_UNKNOWN',
+      );
+    } else {
+      session.combatBotMechId = requestedId;
+      connLog.info('[world] /botmech: bot mech set to %s (id=%d)', mechEntry.typeString, requestedId);
+      send(
+        session.socket,
+        buildCmd3BroadcastPacket(
+          `Bot mech set to ${mechEntry.typeString} (id=${requestedId}). Use /fight or /fightrestart.`,
+          nextSeq(session),
+        ),
+        capture,
+        'CMD3_BOTMECH_ACK',
+      );
+    }
+    return;
+  }
 
   const senderStatus  = getPresenceStatus(session);
   const senderInBooth = senderStatus > 5;


### PR DESCRIPTION
## Summary

Adds two new debug/test commands for iterative combat testing in M6:

### `/fightrestart`
Stops all running combat timers, resets `combatInitialized` and all per-combat session fields, then immediately re-bootstraps a fresh combat session — all within the same TCP connection. Previously the only way to reset combat was to disconnect and reconnect.

### `/botmech <id>`
Sets the scripted bot opponent's mech type by numeric ID before the next `/fight` or `/fightrestart`. The ID is validated against the loaded mech table and confirmed via a Cmd3 broadcast. The override persists within the connection; clear it by omitting `/botmech` on the next session.

### Refactor: `stopCombatTimers()`
Extracts the four `clearInterval` calls (botPositionTimer, botFireTimer, combatJumpTimer, combatJumpFuelRegenTimer) into an exported `stopCombatTimers(session)` helper. Both the disconnect cleanup in `server-world.ts` and the new `/fightrestart` handler now call this single helper instead of duplicating the code.

## Files changed
- `src/state/players.ts` — add `combatBotMechId?: number` to `ClientSession`
- `src/world/world-handlers.ts` — export `stopCombatTimers()`; update Cmd64 bot mech to use `session.combatBotMechId ?? mechId`; add `/botmech` handler
- `src/server-world.ts` — import `stopCombatTimers`; add `/fightrestart` routing; consolidate disconnect timer cleanup