### PR TITLE
feat(M5): display SOLARIS.MAP room descriptions in Cmd4 scene panel via 0x5C line-break

### DIFF
--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -1428,7 +1428,10 @@ are silently discarded if `g_chatReady == 0`.
 [byte × 4: opp_type + 1]       0x21 = "no opponent" for all 4 slots
 [B85_1 × 4: opp_mech_id + 1]  0x2121 = "no opponent" for all 4
 [string: callsign]             player display name
-[string: scene_name]           "Solaris Arena"
+[string: scene_name]           "Solaris Arena" — may embed `\x5C` (0x5C) as a hard
+                               line-break; `FUN_00431320` and `FUN_00416710` both
+                               treat 0x5C as an explicit newline, allowing multi-line
+                               text (e.g. room description) below the scene title.
 [byte: arena_option_count]     0 → 2D world mode, no arena buttons
 ```
 
@@ -1531,7 +1534,7 @@ Confirmed correct order for entering the 2D game world with no arena slots:
 
 ```
 Server → Client: Cmd6  CursorBusy      (hourglass)
-Server → Client: Cmd4  SceneInit       (world frame; arena_count=0 → 2D mode)
+Server → Client: Cmd4  SceneInit       (world frame; sceneName = title + \x5C + room desc)
 Server → Client: Cmd9  RoomRoster      (count=0; sets ready flag)
 Server → Client: Cmd10 RoomPresence    (self slot + sentinel; empty room)
 Server → Client: Cmd3  TextBroadcast   (room description / welcome message)

--- a/src/data/maps.ts
+++ b/src/data/maps.ts
@@ -180,6 +180,8 @@ export interface WorldRoom {
   centreY: number;
   /** 0-based position in the SOLARIS.MAP room list (used as scene-slot index). */
   sceneIndex: number;
+  /** Flavor text from SOLARIS.MAP; empty string when no description is available. */
+  description: string;
 }
 
 function projectRoot(): string {
@@ -228,6 +230,7 @@ export function loadSolarisRooms(filePath?: string): WorldRoom[] | null {
     centreX:    (room.bounds.x1 + room.bounds.x2) / 2,
     centreY:    (room.bounds.y1 + room.bounds.y2) / 2,
     sceneIndex: index,
+    description: room.description,
   }));
 }
 

--- a/src/server-world.ts
+++ b/src/server-world.ts
@@ -69,7 +69,6 @@ import {
   PERSONNEL_MORE_ID,
   SOLARIS_TRAVEL_CONTEXT_ID,
   getSolarisRoomName,
-  getSolarisRoomDescription,
   setSessionRoomPosition,
   worldMapByRoomId,
 } from './world/world-data.js';
@@ -593,12 +592,6 @@ function sendWorldInitSequence(
   // Cmd3 — TextBroadcast: welcome message. g_chatReady is set to 1 by Cmd4, so
   // this is the earliest point at which Cmd3 will be displayed by the client.
   send(socket, buildCmd3BroadcastPacket(WELCOME_TEXT, nextSeq(session)), capture, 'CMD3_WELCOME');
-
-  // Cmd3 — TextBroadcast: starting room description (Solaris Starport).
-  const startDesc = getSolarisRoomDescription(session.worldMapRoomId ?? DEFAULT_MAP_ROOM_ID);
-  if (startDesc) {
-    send(socket, buildCmd3BroadcastPacket(startDesc, nextSeq(session)), capture, 'CMD3_ROOM_DESCRIPTION');
-  }
 
   // Cmd5 — CursorNormal: restore the arrow cursor.
   send(socket, buildCmd5CursorNormalPacket(nextSeq(session)), capture, 'CMD5_NORMAL');

--- a/src/server-world.ts
+++ b/src/server-world.ts
@@ -69,6 +69,7 @@ import {
   PERSONNEL_MORE_ID,
   SOLARIS_TRAVEL_CONTEXT_ID,
   getSolarisRoomName,
+  getSolarisRoomDescription,
   setSessionRoomPosition,
   worldMapByRoomId,
 } from './world/world-data.js';
@@ -592,6 +593,12 @@ function sendWorldInitSequence(
   // Cmd3 — TextBroadcast: welcome message. g_chatReady is set to 1 by Cmd4, so
   // this is the earliest point at which Cmd3 will be displayed by the client.
   send(socket, buildCmd3BroadcastPacket(WELCOME_TEXT, nextSeq(session)), capture, 'CMD3_WELCOME');
+
+  // Cmd3 — TextBroadcast: starting room description (Solaris Starport).
+  const startDesc = getSolarisRoomDescription(session.worldMapRoomId ?? DEFAULT_MAP_ROOM_ID);
+  if (startDesc) {
+    send(socket, buildCmd3BroadcastPacket(startDesc, nextSeq(session)), capture, 'CMD3_ROOM_DESCRIPTION');
+  }
 
   // Cmd5 — CursorNormal: restore the arrow cursor.
   send(socket, buildCmd5CursorNormalPacket(nextSeq(session)), capture, 'CMD5_NORMAL');

--- a/src/world/world-data.ts
+++ b/src/world/world-data.ts
@@ -67,38 +67,38 @@ export const worldCaptures = new Map<string, CaptureLogger>();
 
 /** Hardcoded fallback used when SOLARIS.MAP is not present. */
 export const SOLARIS_FALLBACK_ROOMS: WorldRoom[] = [
-  { roomId: 146, name: 'Solaris Starport',       flags: 0, centreX: 0, centreY: 0, sceneIndex: 0 },
-  { roomId: 147, name: 'Ishiyama Arena',          flags: 0, centreX: 0, centreY: 0, sceneIndex: 1 },
-  { roomId: 148, name: 'Government House',        flags: 0, centreX: 0, centreY: 0, sceneIndex: 2 },
-  { roomId: 149, name: 'White Lotus',             flags: 0, centreX: 0, centreY: 0, sceneIndex: 3 },
-  { roomId: 150, name: 'Waterfront',              flags: 0, centreX: 0, centreY: 0, sceneIndex: 4 },
-  { roomId: 151, name: 'Kobe Slums',              flags: 0, centreX: 0, centreY: 0, sceneIndex: 5 },
-  { roomId: 152, name: 'Steiner Stadium',         flags: 0, centreX: 0, centreY: 0, sceneIndex: 6 },
-  { roomId: 153, name: 'Lyran Building',          flags: 0, centreX: 0, centreY: 0, sceneIndex: 7 },
-  { roomId: 154, name: 'Chahar Park',             flags: 0, centreX: 0, centreY: 0, sceneIndex: 8 },
-  { roomId: 155, name: 'Riverside',               flags: 0, centreX: 0, centreY: 0, sceneIndex: 9 },
-  { roomId: 156, name: 'Black Throne',            flags: 0, centreX: 0, centreY: 0, sceneIndex: 10 },
-  { roomId: 157, name: 'Factory',                 flags: 0, centreX: 0, centreY: 0, sceneIndex: 11 },
-  { roomId: 158, name: 'Marik Tower',             flags: 0, centreX: 0, centreY: 0, sceneIndex: 12 },
-  { roomId: 159, name: 'Allman',                  flags: 0, centreX: 0, centreY: 0, sceneIndex: 13 },
-  { roomId: 160, name: 'Riverfront',              flags: 0, centreX: 0, centreY: 0, sceneIndex: 14 },
-  { roomId: 161, name: 'Wasteland',               flags: 0, centreX: 0, centreY: 0, sceneIndex: 15 },
-  { roomId: 162, name: 'Jungle',                  flags: 0, centreX: 0, centreY: 0, sceneIndex: 16 },
-  { roomId: 163, name: "Chancellor's Quarters",   flags: 0, centreX: 0, centreY: 0, sceneIndex: 17 },
-  { roomId: 164, name: 'Middletown',              flags: 0, centreX: 0, centreY: 0, sceneIndex: 18 },
-  { roomId: 165, name: 'Rivertown',               flags: 0, centreX: 0, centreY: 0, sceneIndex: 19 },
-  { roomId: 166, name: 'Maze',                    flags: 0, centreX: 0, centreY: 0, sceneIndex: 20 },
-  { roomId: 167, name: 'Davion Arena',            flags: 0, centreX: 0, centreY: 0, sceneIndex: 21 },
-  { roomId: 168, name: 'Sortek Building',         flags: 0, centreX: 0, centreY: 0, sceneIndex: 22 },
-  { roomId: 169, name: 'Guzman Park',             flags: 0, centreX: 0, centreY: 0, sceneIndex: 23 },
-  { roomId: 170, name: 'Marina',                  flags: 0, centreX: 0, centreY: 0, sceneIndex: 24 },
-  { roomId: 171, name: 'Viewpoint',               flags: 0, centreX: 0, centreY: 0, sceneIndex: 25 },
-  { roomId: 1,   name: 'International Sector',    flags: 0, centreX: 0, centreY: 0, sceneIndex: 26 },
-  { roomId: 2,   name: 'Kobe Sector',             flags: 0, centreX: 0, centreY: 0, sceneIndex: 27 },
-  { roomId: 3,   name: 'Silesia Sector',          flags: 0, centreX: 0, centreY: 0, sceneIndex: 28 },
-  { roomId: 4,   name: 'Montenegro Sector',       flags: 0, centreX: 0, centreY: 0, sceneIndex: 29 },
-  { roomId: 5,   name: 'Cathay Sector',           flags: 0, centreX: 0, centreY: 0, sceneIndex: 30 },
-  { roomId: 6,   name: 'Black Hills Sector',      flags: 0, centreX: 0, centreY: 0, sceneIndex: 31 },
+  { roomId: 146, name: 'Solaris Starport',       flags: 0, centreX: 0, centreY: 0, sceneIndex: 0,  description: '' },
+  { roomId: 147, name: 'Ishiyama Arena',          flags: 0, centreX: 0, centreY: 0, sceneIndex: 1,  description: '' },
+  { roomId: 148, name: 'Government House',        flags: 0, centreX: 0, centreY: 0, sceneIndex: 2,  description: '' },
+  { roomId: 149, name: 'White Lotus',             flags: 0, centreX: 0, centreY: 0, sceneIndex: 3,  description: '' },
+  { roomId: 150, name: 'Waterfront',              flags: 0, centreX: 0, centreY: 0, sceneIndex: 4,  description: '' },
+  { roomId: 151, name: 'Kobe Slums',              flags: 0, centreX: 0, centreY: 0, sceneIndex: 5,  description: '' },
+  { roomId: 152, name: 'Steiner Stadium',         flags: 0, centreX: 0, centreY: 0, sceneIndex: 6,  description: '' },
+  { roomId: 153, name: 'Lyran Building',          flags: 0, centreX: 0, centreY: 0, sceneIndex: 7,  description: '' },
+  { roomId: 154, name: 'Chahar Park',             flags: 0, centreX: 0, centreY: 0, sceneIndex: 8,  description: '' },
+  { roomId: 155, name: 'Riverside',               flags: 0, centreX: 0, centreY: 0, sceneIndex: 9,  description: '' },
+  { roomId: 156, name: 'Black Throne',            flags: 0, centreX: 0, centreY: 0, sceneIndex: 10, description: '' },
+  { roomId: 157, name: 'Factory',                 flags: 0, centreX: 0, centreY: 0, sceneIndex: 11, description: '' },
+  { roomId: 158, name: 'Marik Tower',             flags: 0, centreX: 0, centreY: 0, sceneIndex: 12, description: '' },
+  { roomId: 159, name: 'Allman',                  flags: 0, centreX: 0, centreY: 0, sceneIndex: 13, description: '' },
+  { roomId: 160, name: 'Riverfront',              flags: 0, centreX: 0, centreY: 0, sceneIndex: 14, description: '' },
+  { roomId: 161, name: 'Wasteland',               flags: 0, centreX: 0, centreY: 0, sceneIndex: 15, description: '' },
+  { roomId: 162, name: 'Jungle',                  flags: 0, centreX: 0, centreY: 0, sceneIndex: 16, description: '' },
+  { roomId: 163, name: "Chancellor's Quarters",   flags: 0, centreX: 0, centreY: 0, sceneIndex: 17, description: '' },
+  { roomId: 164, name: 'Middletown',              flags: 0, centreX: 0, centreY: 0, sceneIndex: 18, description: '' },
+  { roomId: 165, name: 'Rivertown',               flags: 0, centreX: 0, centreY: 0, sceneIndex: 19, description: '' },
+  { roomId: 166, name: 'Maze',                    flags: 0, centreX: 0, centreY: 0, sceneIndex: 20, description: '' },
+  { roomId: 167, name: 'Davion Arena',            flags: 0, centreX: 0, centreY: 0, sceneIndex: 21, description: '' },
+  { roomId: 168, name: 'Sortek Building',         flags: 0, centreX: 0, centreY: 0, sceneIndex: 22, description: '' },
+  { roomId: 169, name: 'Guzman Park',             flags: 0, centreX: 0, centreY: 0, sceneIndex: 23, description: '' },
+  { roomId: 170, name: 'Marina',                  flags: 0, centreX: 0, centreY: 0, sceneIndex: 24, description: '' },
+  { roomId: 171, name: 'Viewpoint',               flags: 0, centreX: 0, centreY: 0, sceneIndex: 25, description: '' },
+  { roomId: 1,   name: 'International Sector',    flags: 0, centreX: 0, centreY: 0, sceneIndex: 26, description: '' },
+  { roomId: 2,   name: 'Kobe Sector',             flags: 0, centreX: 0, centreY: 0, sceneIndex: 27, description: '' },
+  { roomId: 3,   name: 'Silesia Sector',          flags: 0, centreX: 0, centreY: 0, sceneIndex: 28, description: '' },
+  { roomId: 4,   name: 'Montenegro Sector',       flags: 0, centreX: 0, centreY: 0, sceneIndex: 29, description: '' },
+  { roomId: 5,   name: 'Cathay Sector',           flags: 0, centreX: 0, centreY: 0, sceneIndex: 30, description: '' },
+  { roomId: 6,   name: 'Black Hills Sector',      flags: 0, centreX: 0, centreY: 0, sceneIndex: 31, description: '' },
 ];
 
 let solarisRooms: WorldRoom[];
@@ -145,12 +145,13 @@ let _nextSynthSceneIndex = SOLARIS_ROOM_BY_ID.size;
 for (const [id, mapRoom] of worldMapByRoomId) {
   if (!SOLARIS_ROOM_BY_ID.has(id)) {
     SOLARIS_ROOM_BY_ID.set(id, {
-      roomId:     id,
-      name:       mapRoom.name ?? `Room ${id}`,
-      flags:      0,
-      centreX:    0,
-      centreY:    0,
-      sceneIndex: _nextSynthSceneIndex++,
+      roomId:      id,
+      name:        mapRoom.name ?? `Room ${id}`,
+      flags:       0,
+      centreX:     0,
+      centreY:     0,
+      sceneIndex:  _nextSynthSceneIndex++,
+      description: '',
     });
   }
 }
@@ -167,6 +168,10 @@ export function getSolarisSceneIndex(roomId: number): number {
 
 export function getSolarisRoomName(roomId: number): string {
   return getSolarisRoomInfo(roomId).name;
+}
+
+export function getSolarisRoomDescription(roomId: number): string {
+  return SOLARIS_ROOM_BY_ID.get(roomId)?.description ?? '';
 }
 
 export function uniqueRoomIds(roomIds: number[]): number[] {

--- a/src/world/world-scene.ts
+++ b/src/world/world-scene.ts
@@ -285,7 +285,12 @@ export function buildSceneInitForSession(session: ClientSession) {
         return arr;
       })(),
       callsign:         getDisplayName(session),
-      sceneName:        getSolarisRoomName(roomId),
+      sceneName:        (() => {
+        const name = getSolarisRoomName(roomId);
+        const desc = getSolarisRoomDescription(roomId);
+        // 0x5C (\) is a hard line-break in both FUN_00416710 and FUN_00431320
+        return desc ? `${name}\x5c${desc}` : name;
+      })(),
       arenaOptions,
     },
     nextSeq(session),
@@ -316,16 +321,6 @@ export function sendSceneRefresh(
     capture,
     'CMD3_TRAVEL_COMPLETE',
   );
-
-  const desc = getSolarisRoomDescription(session.worldMapRoomId ?? 0);
-  if (desc) {
-    send(
-      session.socket,
-      buildCmd3BroadcastPacket(desc, nextSeq(session)),
-      capture,
-      'CMD3_ROOM_DESCRIPTION',
-    );
-  }
 
   send(session.socket, buildCmd5CursorNormalPacket(nextSeq(session)), capture, 'CMD5_NORMAL');
 }

--- a/src/world/world-scene.ts
+++ b/src/world/world-scene.ts
@@ -35,6 +35,7 @@ import {
   getSolarisRoomExits,
   getSolarisSceneIndex,
   getSolarisRoomName,
+  getSolarisRoomDescription,
   getSolarisRoomIcon,
   WORLD_MECHS,
   getMechChassis,
@@ -315,6 +316,17 @@ export function sendSceneRefresh(
     capture,
     'CMD3_TRAVEL_COMPLETE',
   );
+
+  const desc = getSolarisRoomDescription(session.worldMapRoomId ?? 0);
+  if (desc) {
+    send(
+      session.socket,
+      buildCmd3BroadcastPacket(desc, nextSeq(session)),
+      capture,
+      'CMD3_ROOM_DESCRIPTION',
+    );
+  }
+
   send(session.socket, buildCmd5CursorNormalPacket(nextSeq(session)), capture, 'CMD5_NORMAL');
 }
 


### PR DESCRIPTION
## Summary

Route SOLARIS.MAP room descriptions to the bottom-right scene panel (below the room title). Confirmed via Ghidra RE that both Cmd4 scene-name renderers treat `0x5C` as a hard line-break, so appending the description to `sceneName` with a backslash separator is sufficient — no extra protocol commands needed.

## Related Issue

Closes #99

## Type of Change

- [x] Feature / enhancement
- [x] Research finding / protocol update

## Implementation Notes

**RE finding — `0x5C` is a hard line-break in both Cmd4 scene-name renderers:**

`FUN_00414ec0` gates which renderer is used: returns 1 only if `sceneName` contains `[pXXXXXX]` or `[rXXXXXX]` image-ref tokens; plain ASCII room names always return 0.

- **`FUN_00431320`** (word-wrap renderer — used for all plain-text scene names): explicit `if (bVar10 == 0x5C) goto LAB_0043164a` triggers the line-break handler without rewinding to the previous word boundary.
- **`FUN_00416710`** (inline renderer — used when image-refs are present): identical `goto LAB_00416891` on `0x5C`, same no-rewind semantics.

See RESEARCH.md §18c "Cmd4 — SceneInit" for the full wire-format table.

**Code changes:**

| File | Change |
|------|--------|
| `src/data/maps.ts` | Add `description: string` to `WorldRoom`; populate from `room.description` in `loadSolarisRooms()` |
| `src/world/world-data.ts` | Add `description: ''` to `SOLARIS_FALLBACK_ROOMS` entries; export `getSolarisRoomDescription(roomId)` helper |
| `src/world/world-scene.ts` | `buildSceneInitForSession`: `sceneName = name + '\x5c' + desc` (only when desc is non-empty); remove Cmd3 description send from `sendSceneRefresh` |
| `src/server-world.ts` | Remove Cmd3 description send from `sendWorldInitSequence`; remove unused import |
| `RESEARCH.md` | Document `0x5C` line-break in Cmd4 wire-format table; update world-init sequence diagram |

## Testing

Tested with a live `MPBTWIN.EXE` client (Kesmai CommEngine 3.29 / v1.23):

- Connected, authenticated, entered world → Cmd4 SceneInit logged with `sceneName = "Solaris Starport\<desc>"`
- Room description appears in the bottom-right scene panel, word-wrapped correctly below the room title.
- Top chat scroll window contains only the travel arrival message — no duplicate description line.
- Traveling to a new room via Cmd43 → Cmd4 refresh renders the destination room's description in the panel.
- `npm run build` passes cleanly (zero TypeScript errors).

## Checklist

- [x] Branch is based on `master`
- [x] Commit messages follow `type: description` convention (e.g. `fix: correct CRC seed`)
- [x] TypeScript builds cleanly (`npm run build`)
- [x] No debug `console.log` left in production code paths
- [x] `RESEARCH.md` updated if this reflects a new RE finding
- [ ] `symbols.json` updated if new canonical names were introduced — no new canonical symbols added
- [x] This PR is ready for review (not a draft)
