### PR TITLE
fix: harden M6 combat command handling

### DIFF
--- a/src/server-world.ts
+++ b/src/server-world.ts
@@ -95,6 +95,7 @@ import {
   handleMapTravelReply,
   handleLocationAction,
   handleWorldTextCommand,
+  handleBotMechTextCommand,
   sendCombatBootstrapSequence,
   resetCombatState,
   stopCombatTimers,
@@ -320,6 +321,17 @@ function handleWorldGameData(
       return;
     }
     if (session.phase === 'combat') {
+      if (handleBotMechTextCommand(session, parsed.text, connLog, capture)) {
+        return;
+      }
+      if (textCmd === '/fight') {
+        connLog.debug(
+          '[world] /fight ignored: combatInitialized=%s phase=%s',
+          session.combatInitialized,
+          session.phase,
+        );
+        return;
+      }
       if (textCmd.length > 0) {
         connLog.debug('[world] cmd-4 text ignored during combat: %j', parsed.text);
       } else {
@@ -359,6 +371,15 @@ function handleWorldGameData(
         session.combatVerificationMode = 'dmgbot';
       } else if (textCmd === '/fightstrictfire') {
         session.combatVerificationMode = 'strictfire';
+        send(
+          session.socket,
+          buildCmd3BroadcastPacket(
+            'Strict fire gate armed: ungated SPACEBAR fire will be rejected until recent action0.',
+            nextSeq(session),
+          ),
+          capture,
+          'CMD3_STRICTFIRE_ARMED',
+        );
       } else if (textCmd === '/fighthead') {
         session.combatVerificationMode = 'headtest';
       } else {
@@ -732,6 +753,7 @@ function handleWorldConnection(socket: net.Socket, players: PlayerRegistry, log:
     // Reset combat per-session counters so a reconnect starts fresh.
     if (
       session.combatShotsAccepted !== undefined ||
+      session.combatShotsRejected !== undefined ||
       session.combatShotsAction0Correlated !== undefined ||
       session.combatShotsDirectCmd10 !== undefined
     ) {
@@ -739,10 +761,12 @@ function handleWorldConnection(socket: net.Socket, players: PlayerRegistry, log:
         ? Date.now() - session.combatStartAt
         : undefined;
       connLog.info(
-        '[world/combat] session summary: accepted=%d action0Correlated=%d directCmd10=%d duration=%s',
+        '[world/combat] session summary: requireAction0=%s accepted=%d rejected=%d ungatedAccepted=%d action0Correlated=%d duration=%s',
+        session.combatRequireAction0 === true ? 'true' : 'false',
         session.combatShotsAccepted ?? 0,
-        session.combatShotsAction0Correlated ?? 0,
+        session.combatShotsRejected ?? 0,
         session.combatShotsDirectCmd10 ?? 0,
+        session.combatShotsAction0Correlated ?? 0,
         durationMs !== undefined ? `${(durationMs / 1000).toFixed(1)}s` : 'n/a',
       );
     }
@@ -758,7 +782,9 @@ function handleWorldConnection(socket: net.Socket, players: PlayerRegistry, log:
     session.combatVerificationMode = undefined;
     session.combatJumpFuel       = undefined;
     session.lastCombatFireActionAt = undefined;
+    session.combatRequireAction0 = undefined;
     session.combatShotsAccepted = undefined;
+    session.combatShotsRejected = undefined;
     session.combatShotsAction0Correlated = undefined;
     session.combatShotsDirectCmd10 = undefined;
     session.combatStartAt = undefined;

--- a/src/state/players.ts
+++ b/src/state/players.ts
@@ -164,8 +164,12 @@ export interface ClientSession {
   combatJumpFuel?: number;
   /** Timestamp (ms) of the last cmd12/action 0 fire trigger frame from client. */
   lastCombatFireActionAt?: number;
+  /** Whether the current combat session requires recent cmd12/action0 before cmd10 fire. */
+  combatRequireAction0?: boolean;
   /** Count of cmd10 weapon-fire frames accepted in the current combat session. */
   combatShotsAccepted?: number;
+  /** Count of cmd10 weapon-fire frames rejected by the current combat policy. */
+  combatShotsRejected?: number;
   /** Count of cmd10 shots that arrived shortly after cmd12/action0. */
   combatShotsAction0Correlated?: number;
   /** Count of direct cmd10 shots that arrived without a recent cmd12/action0. */

--- a/src/world/world-handlers.ts
+++ b/src/world/world-handlers.ts
@@ -109,12 +109,15 @@ import {
   THROTTLE_RUN_SCALE,
 } from './combat-config.js';
 
-function regenJumpFuelIfGrounded(session: ClientSession): void {
+function regenJumpFuelIfGrounded(
+  session: ClientSession,
+  amount = JUMP_JET_FUEL_REGEN_PER_FRAME,
+): void {
   if (session.combatJumpTimer !== undefined) return;
   if ((session.combatJumpAltitude ?? 0) > 0) return;
   const fuel = session.combatJumpFuel ?? JUMP_JET_FUEL_MAX;
   if (fuel >= JUMP_JET_FUEL_MAX) return;
-  session.combatJumpFuel = Math.min(JUMP_JET_FUEL_MAX, fuel + JUMP_JET_FUEL_REGEN_PER_FRAME);
+  session.combatJumpFuel = Math.min(JUMP_JET_FUEL_MAX, fuel + amount);
 }
 
 const DEFAULT_BOT_ARMOR_VALUES = Array<number>(10).fill(10);
@@ -508,7 +511,9 @@ export function resetCombatState(session: ClientSession): void {
   session.combatJumpAltitude = undefined;
   session.combatJumpFuel = undefined;
   session.lastCombatFireActionAt = undefined;
+  session.combatRequireAction0 = undefined;
   session.combatShotsAccepted = undefined;
+  session.combatShotsRejected = undefined;
   session.combatShotsAction0Correlated = undefined;
   session.combatShotsDirectCmd10 = undefined;
 }
@@ -912,7 +917,7 @@ export function sendCombatBootstrapSequence(
     session.combatJumpFuelRegenTimer = setInterval(() => {
       if (session.socket.destroyed || !session.socket.writable) return;
       const before = session.combatJumpFuel ?? JUMP_JET_FUEL_MAX;
-      regenJumpFuelIfGrounded(session);
+      regenJumpFuelIfGrounded(session, JUMP_JET_FUEL_REGEN_PER_TICK);
       const after = session.combatJumpFuel ?? before;
       if (after !== before) {
         connLog.debug('[world/combat] jump fuel regen: %d -> %d', before, after);
@@ -1013,7 +1018,9 @@ export function sendCombatBootstrapSequence(
 
     const verificationMode = session.combatVerificationMode;
     session.combatVerificationMode = undefined;
+    session.combatRequireAction0 = verificationMode === 'strictfire';
     session.combatShotsAccepted = 0;
+    session.combatShotsRejected = 0;
     session.combatShotsAction0Correlated = 0;
     session.combatShotsDirectCmd10 = 0;
     if (verificationMode === 'autowin') {
@@ -1098,7 +1105,7 @@ export function sendCombatBootstrapSequence(
     } else if (verificationMode === 'strictfire') {
       setTimeout(() => {
         if (session.socket.destroyed || !session.socket.writable) return;
-        connLog.info('[world/combat] scripted verification: strictfire observation mode (cmd12/action0 correlations logged; direct TIC cmd10 accepted)');
+        connLog.info('[world/combat] scripted verification: strictfire enforcement mode (ungated cmd10 rejected until recent cmd12/action0)');
       }, VERIFY_DELAY_MS).unref();
     } else if (verificationMode === 'headtest') {
       setTimeout(() => {
@@ -1184,37 +1191,7 @@ export function handleWorldTextCommand(
   const line = `${getDisplayName(session)}: ${clean}`;
   connLog.info('[world] cmd-4 text: %s', line);
 
-  // /botmech <id> — choose the mech ID for the scripted bot opponent.
-  // The ID is a numeric mech variant ID from the loaded mech list.  Persists
-  // across /fightrestart within the same connection.
-  const botmechMatch = clean.match(/^\/botmech\s+(\d+)$/i);
-  if (botmechMatch) {
-    const requestedId = parseInt(botmechMatch[1], 10);
-    const mechEntry   = WORLD_MECH_BY_ID.get(requestedId);
-    if (!mechEntry) {
-      connLog.warn('[world] /botmech: unknown mech_id=%d', requestedId);
-      send(
-        session.socket,
-        buildCmd3BroadcastPacket(
-          `Unknown mech_id ${requestedId}. Use /mechs to browse available mechs.`,
-          nextSeq(session),
-        ),
-        capture,
-        'CMD3_BOTMECH_UNKNOWN',
-      );
-    } else {
-      session.combatBotMechId = requestedId;
-      connLog.info('[world] /botmech: bot mech set to %s (id=%d)', mechEntry.typeString, requestedId);
-      send(
-        session.socket,
-        buildCmd3BroadcastPacket(
-          `Bot mech set to ${mechEntry.typeString} (id=${requestedId}). Use /fight or /fightrestart.`,
-          nextSeq(session),
-        ),
-        capture,
-        'CMD3_BOTMECH_ACK',
-      );
-    }
+  if (handleBotMechTextCommand(session, clean, connLog, capture)) {
     return;
   }
 
@@ -1239,6 +1216,48 @@ export function handleWorldTextCommand(
 
     sendToWorldSession(other, buildCmd3BroadcastPacket(line, nextSeq(other)), 'CMD3_CHAT_FANOUT');
   }
+}
+
+export function handleBotMechTextCommand(
+  session: ClientSession,
+  text: string,
+  connLog: Logger,
+  capture: CaptureLogger,
+): boolean {
+  const clean = text.replace(/\x1b/g, '?').trim();
+  const botmechMatch = clean.match(/^\/botmech\s+(\d+)$/i);
+  if (!botmechMatch) {
+    return false;
+  }
+
+  const requestedId = parseInt(botmechMatch[1], 10);
+  const mechEntry   = WORLD_MECH_BY_ID.get(requestedId);
+  if (!mechEntry) {
+    connLog.warn('[world] /botmech: unknown mech_id=%d', requestedId);
+    send(
+      session.socket,
+      buildCmd3BroadcastPacket(
+        `Unknown mech_id ${requestedId}. Use /mechs to browse available mechs.`,
+        nextSeq(session),
+      ),
+      capture,
+      'CMD3_BOTMECH_UNKNOWN',
+    );
+    return true;
+  }
+
+  session.combatBotMechId = requestedId;
+  connLog.info('[world] /botmech: bot mech set to %s (id=%d)', mechEntry.typeString, requestedId);
+  send(
+    session.socket,
+    buildCmd3BroadcastPacket(
+      `Bot mech set to ${mechEntry.typeString} (id=${requestedId}). Use /fight or /fightrestart.`,
+      nextSeq(session),
+    ),
+    capture,
+    'CMD3_BOTMECH_ACK',
+  );
+  return true;
 }
 
 // ── Map travel ────────────────────────────────────────────────────────────────
@@ -1524,6 +1543,16 @@ export function handleCombatWeaponFireFrame(
     : now - session.lastCombatFireActionAt;
   const hasRecentFireAction = actionAgeMs !== undefined && actionAgeMs >= 0 && actionAgeMs <= FIRE_ACTION_WINDOW_MS;
   const firePath = hasRecentFireAction ? 'selected-weapon' : 'direct-cmd10';
+  if (session.combatRequireAction0 && !hasRecentFireAction) {
+    session.combatShotsRejected = (session.combatShotsRejected ?? 0) + shots.length;
+    connLog.info(
+      '[world/combat] cmd10 shot REJECTED: strict action0 gate (no recent cmd12/action0, age=%s records=%d)',
+      actionAgeMs === undefined ? 'n/a' : `${actionAgeMs}ms`,
+      shots.length,
+    );
+    return;
+  }
+
   session.combatShotsAccepted = (session.combatShotsAccepted ?? 0) + shots.length;
   if (hasRecentFireAction) {
     session.combatShotsAction0Correlated = (session.combatShotsAction0Correlated ?? 0) + shots.length;


### PR DESCRIPTION
## Summary

Harden the remaining M6 combat verification paths so the current build matches the expectations in `docs/M6-TEST-PLAN.md`.

## Related Issue

Closes #106

## Type of Change

- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Research finding / protocol update
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Chore (dependencies, CI, config)

## Implementation Notes

- allow `/botmech` while combat is active so `/fightrestart` scenarios can swap the bot cleanly
- require a recent `cmd12/action0` before accepting strict-fire `cmd10` volleys, and track rejected shots in the session summary
- fix passive jump fuel regen to use the documented per-tick amount
- ignore combat-phase `/fight` explicitly with a targeted log line instead of falling through generic text handling
- preserve the upstream combat scene/result recovery changes by basing this branch on current `master`

## Testing

- `npm run build`
- connected a live MPBT client for GUI confirmation during M6 verification
- reran the combat smoke coverage used for `docs/M6-TEST-PLAN.md`, including combat entry, strict-fire, retaliation, damage sweeps, jump/landing/fuel regen, combat-phase `/fight` ignore, disconnect cleanup, and summary flow

## Checklist

- [x] Branch is based on `master`
- [x] Commit messages follow `type: description` convention (e.g. `fix: correct CRC seed`)
- [x] TypeScript builds cleanly (`npm run build`)
- [x] No debug `console.log` left in production code paths
- [ ] `RESEARCH.md` updated if this reflects a new RE finding
- [ ] `symbols.json` updated if new canonical names were introduced
- [x] This PR is ready for review (not a draft)
