### PR TITLE
fix: route incoming ComStar prompts

### DIFF
--- a/src/server-world.ts
+++ b/src/server-world.ts
@@ -641,9 +641,6 @@ function handleWorldGameData(
       const requestedSlot = Number.isFinite(slotPlusOne) ? slotPlusOne - 1 : 0;
       selection = Math.max(0, requestedSlot);
     }
-    if (handleComstarIncomingPromptCmd20(session, selection, connLog, capture)) {
-      return;
-    }
     if (handleMechPickerCmd20(session, selection, connLog, capture)) {
       return;
     }
@@ -699,6 +696,10 @@ function handleWorldGameData(
     connLog.info('[world] cmd-7 menu reply: listId=%d selection=%d', parsed.listId, parsed.selection);
 
     if (handleMechPickerCmd7(players, session, parsed.listId, parsed.selection, connLog, capture)) {
+      return;
+    }
+
+    if (parsed.listId === 7 && handleComstarIncomingPromptCmd20(session, parsed.selection, connLog, capture)) {
       return;
     }
 

--- a/src/server-world.ts
+++ b/src/server-world.ts
@@ -116,7 +116,8 @@ import {
 import {
   handleComstarTextReply,
   handleComstarAccessSelection,
-  handleComstarIncomingPromptCmd20,
+  COMSTAR_INCOMING_DIALOG_ID,
+  handleComstarIncomingPromptCmd7,
   handleComstarSendTargetSelection,
   handleMatchResultsSelection,
   handleNewsCategorySelection,
@@ -699,7 +700,10 @@ function handleWorldGameData(
       return;
     }
 
-    if (parsed.listId === 7 && handleComstarIncomingPromptCmd20(session, parsed.selection, connLog, capture)) {
+    if (
+      parsed.listId === COMSTAR_INCOMING_DIALOG_ID
+      && handleComstarIncomingPromptCmd7(session, parsed.selection, connLog, capture)
+    ) {
       return;
     }
 

--- a/src/world/world-handlers.ts
+++ b/src/world/world-handlers.ts
@@ -4174,7 +4174,7 @@ export function handleComstarIncomingPromptCmd20(
 
   clearPendingIncomingComstarPrompt(session);
 
-  if (selection === 0) {
+  if (selection === 1) {
     connLog.info('[world] live ComStar prompt accepted: msgId=%d sender=%d', messageId, senderId);
     send(
       session.socket,

--- a/src/world/world-handlers.ts
+++ b/src/world/world-handlers.ts
@@ -286,7 +286,7 @@ const BOT_RESULT_DELAY_MS = 1500;
 const COMBAT_DROP_DELAY_MS = 4000;
 const RESULT_WORLD_RESTORE_DELAY_MS = 10_500;
 const COMSTAR_DIALOG_ID = 6;
-const COMSTAR_INCOMING_DIALOG_ID = 7;
+export const COMSTAR_INCOMING_DIALOG_ID = 7;
 const HEAD_RETALIATION_SECTION: CombatAttachmentHitSection = {
   armorIndex: NO_ARMOR_INDEX,
   internalIndex: 7,
@@ -4159,7 +4159,7 @@ export function handleComstarSendTargetSelection(
   connLog.warn('[world] ComStar send-target: unsupported selection=%d', selection);
 }
 
-export function handleComstarIncomingPromptCmd20(
+export function handleComstarIncomingPromptCmd7(
   session: ClientSession,
   selection: number,
   connLog: Logger,
@@ -4174,6 +4174,8 @@ export function handleComstarIncomingPromptCmd20(
 
   clearPendingIncomingComstarPrompt(session);
 
+  // Cmd7 prompt replies are 1-based; for this incoming ComStar prompt,
+  // selection 1 is the retail client's "Read now" choice.
   if (selection === 1) {
     connLog.info('[world] live ComStar prompt accepted: msgId=%d sender=%d', messageId, senderId);
     send(


### PR DESCRIPTION
## Summary

Fixes the live incoming ComStar prompt so the retail client can open the message body instead of having the `Read now` reply ignored.

## Related Issue

Closes #129

## Type of Change

- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Research finding / protocol update
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Chore (dependencies, CI, config)

## Implementation Notes

- route the incoming ComStar `Read now?` prompt through the generic `cmd-7` menu reply dispatcher in `server-world.ts`
- remove the misplaced inbound-`cmd20` hook for this prompt path
- treat `selection === 1` as `Read now` in `handleComstarIncomingPromptCmd20(...)` to match the live client reply
- keep the existing `Cmd36` message-view response and read/save persistence flow unchanged

## Testing

- `npm run build`
- live MPBT client retest against the restarted server
- confirmed the incoming ComStar prompt now opens successfully without disconnecting

## Checklist

- [x] Branch is based on `master`
- [x] Commit messages follow `type: description` convention (e.g. `fix: correct CRC seed`)
- [x] TypeScript builds cleanly (`npm run build`)
- [x] No debug `console.log` left in production code paths
- [x] `RESEARCH.md` updated if this reflects a new RE finding (not applicable for this packet-routing fix)
- [x] `symbols.json` updated if new canonical names were introduced (not applicable)
- [x] This PR is ready for review (not a draft)