### PR TITLE
fix: align combat distance with client radar

### DIFF
--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -5120,6 +5120,10 @@ Step 6: Cmd65 timer (every 1000 ms) — keep bot position fresh
 - `COORD_BIAS = 0x18e4258` is added to all type3 world coordinates in Cmd65/Cmd72 payloads
 - Earlier `z=300000` bot-spawn notes in this section are stale. The later confirmed bot-spawn path uses `y=BOT_SPAWN_DISTANCE`, while the `Cmd65` handler work still points to the **third** coordinate field as airborne altitude.
 - Treat `x/y` as the arena ground plane and `z` as the current best-confirmed altitude field for `Cmd65`.
+- Fresh 2026-04-22 radar-calibration pass:
+  - `Combat_ActiveRound` (`FUN_004466c0`) projects actor radar deltas as `dx100 = trunc((actorX - localX) / 100)` and `dy100 = trunc((actorY - localY) / 100)`, then compares `FUN_0041ef20(dx100*dx100 + dy100*dy100)` against the selected radar-range value in `DAT_004ee948`
+  - `FUN_00425480` cycles `DAT_004ee948` through `50 / 100 / 300 / 800 / 2500`
+  - practical server implication: if `mpbt-server` wants its range math and spawn stand-off to match the client radar / range text, combat `x/y` should be calibrated as **100 world units per displayed meter**, not `1000`
 
 ---
 

--- a/src/data/mech-attachments.ts
+++ b/src/data/mech-attachments.ts
@@ -399,6 +399,22 @@ function rotateLocalPointToWorld(
   ];
 }
 
+export function projectCombatImpactToTargetLocalSpace(
+  context: CombatAttachmentImpactContext,
+): { forward: number; lateral: number; vertical: number } {
+  const angleRaw = (context.facingAccumulator + ROOT_FACING_OFFSET) & 0xffff;
+  const radians = angleRaw * (Math.PI * 2 / ANGLE_UNITS_PER_TURN);
+  const cos = Math.cos(radians);
+  const sin = Math.sin(radians);
+  const dx = context.impactX - context.targetX;
+  const dy = context.impactY - context.targetY;
+  return {
+    forward: (dx * cos) + (dy * sin),
+    lateral: (-dx * sin) + (dy * cos),
+    vertical: context.impactZ - context.targetZ,
+  };
+}
+
 function squaredDistance3(a: Vec3, b: Vec3): number {
   const dx = a[0] - b[0];
   const dy = a[1] - b[1];

--- a/src/world/combat-config.ts
+++ b/src/world/combat-config.ts
@@ -11,8 +11,16 @@
 /** Baseline server-side durability counter used for simple bot/player estimates. */
 export const BOT_INITIAL_HEALTH = 100;
 
+/**
+ * Combat-world coordinate scale: the client radar/render path truncates each x/y
+ * delta by 100, then runs integer sqrt(dx^2 + dy^2) against the selected
+ * 50/100/300/800/2500 radar-range setting. That makes 100 combat world units
+ * correspond to 1 displayed meter.
+ */
+export const COMBAT_WORLD_UNITS_PER_METER = 100;
+
 /** Initial shared remote-actor stand-off distance in combat world units (1000m north). */
-export const BOT_SPAWN_DISTANCE = 1_000_000;
+export const BOT_SPAWN_DISTANCE = 1_000 * COMBAT_WORLD_UNITS_PER_METER;
 
 /** Initial single-player AI-bot stand-off distance in combat world units (1000m north). */
 export const BOT_AI_SPAWN_DISTANCE = BOT_SPAWN_DISTANCE;
@@ -24,9 +32,6 @@ export const BOT_AI_SPAWN_DISTANCE = BOT_SPAWN_DISTANCE;
 export const BOT_FALLBACK_WEAPON_DAMAGE = 5;
 
 // ── Jump jets ──────────────────────────────────────────────────────────────────
-
-/** Combat-world coordinate scale: 1000 units = 1 meter. */
-export const COMBAT_WORLD_UNITS_PER_METER = 1_000;
 
 /**
  * Fallback visible jump apex (meters) when a chassis has jump jets but no
@@ -64,10 +69,10 @@ export const JUMP_JET_FUEL_REGEN_PER_TICK = 10;
 // ── Collision-damage research probes ───────────────────────────────────────────
 
 /** Horizontal distance (combat world units) considered "close contact" for probe logging. */
-export const COLLISION_PROBE_HORIZONTAL_DISTANCE = 18_000;
+export const COLLISION_PROBE_HORIZONTAL_DISTANCE = 18 * COMBAT_WORLD_UNITS_PER_METER;
 
 /** Vertical tolerance for grounded overlap probes when neither actor is airborne. */
-export const COLLISION_PROBE_VERTICAL_TOLERANCE = 2_500;
+export const COLLISION_PROBE_VERTICAL_TOLERANCE = Math.round(2.5 * COMBAT_WORLD_UNITS_PER_METER);
 
 /** Cooldown between repeated collision-candidate probe logs for the same duel pair. */
 export const COLLISION_PROBE_LOG_COOLDOWN_MS = 1_500;

--- a/src/world/world-handlers.ts
+++ b/src/world/world-handlers.ts
@@ -95,6 +95,7 @@ import {
   type CombatAttachmentHitSection,
   findRepresentativeCombatAttachmentIdForSection,
   getCombatModelIdForMechId,
+  projectCombatImpactToTargetLocalSpace,
   resolveCombatAttachmentHitSection,
 } from '../data/mech-attachments.js';
 
@@ -2433,6 +2434,22 @@ function buildTargetImpactContext(
   };
 }
 
+function getModel13AttachProbeSuffix(
+  mechId: number | undefined,
+  attach: number,
+  impactContext: CombatAttachmentImpactContext | undefined,
+): string {
+  if (impactContext === undefined) return '';
+  if (getCombatModelIdForMechId(mechId) !== 13) return '';
+  if (attach !== 41 && attach !== 55) return '';
+
+  const localImpact = projectCombatImpactToTargetLocalSpace(impactContext);
+  return `:m13probe=local(${Math.round(localImpact.forward)},${Math.round(localImpact.lateral)},${Math.round(localImpact.vertical)})`
+    + `:target=${impactContext.targetX}/${impactContext.targetY}/${impactContext.targetZ}`
+    + `:impact=${impactContext.impactX}/${impactContext.impactY}/${impactContext.impactZ}`
+    + `:facing=${impactContext.facingAccumulator}`;
+}
+
 function shouldSpillUpperBodyHitToCenter(hitSection: CombatAttachmentHitSection): boolean {
   return hitSection.armorIndex === 0
     || hitSection.armorIndex === 1
@@ -2635,7 +2652,7 @@ function getShotMaxRangeGateForMechSlot(
     return { allowed: true, maxRangeMeters, weaponName };
   }
 
-  const distanceMeters = Math.hypot(sourceX - targetX, sourceY - targetY) / COMBAT_WORLD_UNITS_PER_METER;
+  const distanceMeters = getCombatDisplayDistanceMeters(sourceX, sourceY, targetX, targetY);
   return {
     allowed: distanceMeters <= maxRangeMeters,
     distanceMeters,
@@ -2662,6 +2679,41 @@ function getShotMaxRangeGate(
 
 function clampNumber(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
+}
+
+function getCombatClientIntegerSqrt(value: number): number {
+  if (value < 2) {
+    return value;
+  }
+  let scaled = value;
+  let estimate = value;
+  if (value < 4) {
+    return 1;
+  }
+  while (scaled > 2) {
+    scaled = Math.trunc(scaled / 4);
+    estimate = Math.trunc(estimate / 2);
+  }
+  let delta = Math.abs(estimate - value);
+  while (delta > 1) {
+    const nextEstimate = estimate + Math.trunc((Math.trunc(value / estimate) - estimate) / 2);
+    delta = Math.abs(nextEstimate - estimate);
+    estimate = nextEstimate;
+  }
+  return estimate;
+}
+
+function getCombatDisplayDistanceMeters(
+  sourceX: number,
+  sourceY: number,
+  targetX: number,
+  targetY: number,
+): number {
+  // Match the client radar exactly: truncate each axis delta by 100 world units
+  // first, then run the client's integer sqrt helper on dx^2 + dy^2.
+  const dxMeters = Math.trunc((sourceX - targetX) / COMBAT_WORLD_UNITS_PER_METER);
+  const dyMeters = Math.trunc((sourceY - targetY) / COMBAT_WORLD_UNITS_PER_METER);
+  return getCombatClientIntegerSqrt((dxMeters * dxMeters) + (dyMeters * dyMeters));
 }
 
 function speedMagToMetersPerSecond(speedMag: number): number {
@@ -4289,7 +4341,7 @@ function stepBotMovement(
   const dx = playerX - currentBotX;
   const dy = playerY - currentBotY;
   const distanceUnits = Math.hypot(dx, dy);
-  const distanceMeters = distanceUnits / COMBAT_WORLD_UNITS_PER_METER;
+  const distanceMeters = getCombatDisplayDistanceMeters(currentBotX, currentBotY, playerX, playerY);
   const rangeProfile = getBotWeaponRangeProfile(session);
   const currentRangeFitScore = getWeaponFitScoreForMechAtDistance(
     getBotMechId(session),
@@ -4575,7 +4627,7 @@ function stepBotWeaponFire(
     maybeLogBotAimLimit(session, connLog, botX, botY, botZ, targetX, targetY, targetZ, rawYaw, rawPitch);
     return;
   }
-  const distanceMeters = Math.hypot(botX - targetX, botY - targetY) / COMBAT_WORLD_UNITS_PER_METER;
+  const distanceMeters = getCombatDisplayDistanceMeters(botX, botY, targetX, targetY);
   const now = Date.now();
   const currentHeat = session.combatBotHeat ?? 0;
   const heatSinks = Math.max(1, botMechEntry.heatSinks ?? getBotHeatSinkCount(session));
@@ -5067,6 +5119,12 @@ export function resetCombatState(session: ClientSession): void {
   session.phase = 'world';
   session.botHealth = undefined;
   session.playerHealth = undefined;
+  session.combatX = undefined;
+  session.combatY = undefined;
+  session.combatFacingRaw = undefined;
+  session.combatUpperBodyPitch = undefined;
+  session.combatTorsoYaw = undefined;
+  session.combatSpeedMag = undefined;
   session.combatBotArmorValues = undefined;
   session.combatBotInternalValues = undefined;
   session.combatBotHeadArmor = undefined;
@@ -7713,6 +7771,14 @@ export function sendCombatBootstrapSequence(
   session.combatJumpActive = false;
   session.combatJumpAltitude = 0;
   session.combatJumpFuel = JUMP_JET_FUEL_MAX;
+  session.combatX = 0;
+  session.combatY = 0;
+  session.combatAltitudeRaw = 0;
+  session.combatFacingRaw = MOTION_NEUTRAL;
+  session.combatUpperBodyPitch = 0;
+  session.combatTorsoYaw = 0;
+  session.combatSpeedMag = 0;
+  session.combatLastMoveAt = undefined;
   session.combatMoveVectorX = 0;
   session.combatMoveVectorY = 0;
   session.combatLastCollisionProbeAt = undefined;
@@ -9277,7 +9343,7 @@ export function handleCombatWeaponFireFrame(
 
       totalDamageUpdates += allUpdates.length;
       shotSummaries.push(
-        `${shot.weaponSlot}:${weaponName ?? 'unknown'}:${shotDamage}:${hitSection.label}:mech=${duelPeerMechId}:model=${getCombatModelIdForMechId(duelPeerMechId) ?? 'n/a'}:attach=${shot.targetAttach}:peerHealth=${duelPeer.playerHealth ?? 'n/a'}:headArmor=${duelPeerHeadArmor}:updates=${allUpdates.map(update => `0x${update.damageCode.toString(16)}=${update.damageValue}`).join('/') || 'none'}`,
+        `${shot.weaponSlot}:${weaponName ?? 'unknown'}:${shotDamage}:${hitSection.label}:mech=${duelPeerMechId}:model=${getCombatModelIdForMechId(duelPeerMechId) ?? 'n/a'}:attach=${shot.targetAttach}:peerHealth=${duelPeer.playerHealth ?? 'n/a'}:headArmor=${duelPeerHeadArmor}:updates=${allUpdates.map(update => `0x${update.damageCode.toString(16)}=${update.damageValue}`).join('/') || 'none'}${getModel13AttachProbeSuffix(duelPeerMechId, shot.targetAttach, impactContext)}`,
       );
     }
 
@@ -9475,7 +9541,7 @@ export function handleCombatWeaponFireFrame(
         );
       }
       shotSummaries.push(
-        `${shot.weaponSlot}:${weaponName ?? 'unknown'}:${shotDamage}:${getDisplayName(target)}:${hitSection.label}:mech=${targetMechId}:model=${targetModelId ?? 'n/a'}:attach=${shot.targetAttach}:health=${target.playerHealth}:updates=${allUpdates.map(update => `0x${update.damageCode.toString(16)}=${update.damageValue}`).join('/') || 'none'}`,
+        `${shot.weaponSlot}:${weaponName ?? 'unknown'}:${shotDamage}:${getDisplayName(target)}:${hitSection.label}:mech=${targetMechId}:model=${targetModelId ?? 'n/a'}:attach=${shot.targetAttach}:health=${target.playerHealth}:updates=${allUpdates.map(update => `0x${update.damageCode.toString(16)}=${update.damageValue}`).join('/') || 'none'}${getModel13AttachProbeSuffix(targetMechId, shot.targetAttach, impactContext)}`,
       );
 
       if (isActorDestroyed(targetInternalValues)) {
@@ -9578,7 +9644,7 @@ export function handleCombatWeaponFireFrame(
       targetAirborne: session.combatBotJumpActive === true || botZ > 0,
       targetMoveVectorX: session.combatBotMoveVectorX,
       targetMoveVectorY: session.combatBotMoveVectorY,
-      distanceMeters: rangeGate.distanceMeters ?? Math.hypot((session.combatX ?? 0) - botX, (session.combatY ?? 0) - botY) / COMBAT_WORLD_UNITS_PER_METER,
+      distanceMeters: rangeGate.distanceMeters ?? getCombatDisplayDistanceMeters(session.combatX ?? 0, session.combatY ?? 0, botX, botY),
       weaponSpec,
       maxRangeMeters: rangeGate.maxRangeMeters,
     });
@@ -9644,7 +9710,7 @@ export function handleCombatWeaponFireFrame(
 
     totalDamageUpdates += allUpdates.length;
     shotSummaries.push(
-      `${shot.weaponSlot}:${weaponName ?? 'unknown'}:${shotDamage}:${hitSection.label}:${shot.targetSlot}/${shot.targetAttach}:chance=${Math.round(hitRoll.chance * 100)}:roll=${Math.round(hitRoll.roll * 100)}:cross=${Math.round(hitRoll.crossingFactor * 100)}:bot=${botX}/${botY}:headArmor=${botHeadArmor}:updates=${allUpdates.map(update => `0x${update.damageCode.toString(16)}=${update.damageValue}`).join('/') || 'none'}`,
+      `${shot.weaponSlot}:${weaponName ?? 'unknown'}:${shotDamage}:${hitSection.label}:${shot.targetSlot}/${shot.targetAttach}:chance=${Math.round(hitRoll.chance * 100)}:roll=${Math.round(hitRoll.roll * 100)}:cross=${Math.round(hitRoll.crossingFactor * 100)}:bot=${botX}/${botY}:headArmor=${botHeadArmor}:updates=${allUpdates.map(update => `0x${update.damageCode.toString(16)}=${update.damageValue}`).join('/') || 'none'}${getModel13AttachProbeSuffix(botMechId, shot.targetAttach, impactContext)}`,
     );
   }
 


### PR DESCRIPTION
## Summary

Align combat distance handling with the retail client's radar/display math. This calibrates combat x/y to the client-visible meter scale, switches range-sensitive server paths over to the same per-axis truncation plus integer-sqrt distance rule the client uses on radar, and resets stale local combat coordinates so single-player fights do not inherit range offsets from earlier combat sessions.

## Related Issue

Closes #139

## Type of Change

- [x] Bug fix
- [ ] Feature / enhancement
- [x] Research finding / protocol update
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Chore (dependencies, CI, config)

## Implementation Notes

- change the shared combat x/y scale from `1000 units = 1 meter` to the client radar's `100 units = 1 displayed meter`
- replace smooth `Math.hypot(...)/scale` distance reads in the combat path with the client's exact `trunc(dx/100)`, `trunc(dy/100)`, integer-sqrt rule
- derive bot spawn stand-off and raw collision thresholds from that shared scale so radar presentation, range gating, and bot planning agree
- clear and reinitialize local single-player combat position/facing/speed state so stale coordinates cannot leak into the next fight
- update `RESEARCH.md` and add model-13 `41/55` local-impact probe logging for the next Jenner correlation pass

## Testing

- `npm run build`

## Checklist

- [x] Branch is based on `master`
- [x] Commit messages follow `type: description` convention (e.g. `fix: correct CRC seed`)
- [x] TypeScript builds cleanly (`npm run build`)
- [x] No debug `console.log` left in production code paths
- [x] `RESEARCH.md` updated if this reflects a new RE finding
- [x] `symbols.json` updated if new canonical names were introduced
- [x] This PR is ready for review (not a draft)