### PR TITLE
fix: align combat ammo with retail client

### DIFF
--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -4787,6 +4787,19 @@ actorDisplayName = Frame_ReadString();   // max 31 bytes
 
 The static initializer `Combat_InitDamageStateFromMec_v123` copies the `.MEC` maxima into the actor state before those server-supplied bytes arrive: 11 values from `.MEC` offsets `0x1a..0x2e`, one zeroed weapon damage state per weapon, critical-slot defaults from the `.MEC` table at `0xde`, ammo-bin caps from `.MEC` ammo types, and 8 internal-structure maxima from `Combat_GetInternalStructureForSection_v123`. This means a minimal `Cmd72` builder should not omit the variable-length local damage block; it seeds the same state that later `Cmd66`/`Cmd67` mutate.
 
+2026-04-22 ammo-state correction:
+
+- `Combat_InitDamageStateFromMec_v123` does **not** seed runtime ammo state from the raw `.MEC` `ammo_bin_qty[]` values at `0x1ee`.
+- Instead, it looks up each bin's `ammo_bin_type[]` entry at `.MEC + 0x202`, indexes the retail weapon-family table at `DAT_0047b278 + weaponType * 0x5c`, and copies that table's first dword into the runtime ammo-state slot.
+- Recovered retail starting ammo-per-bin values are:
+  - flamer / energy families: `0`
+  - Machine Gun: `200`
+  - AC/2 / AC/5 / AC/10 / AC/20: `45 / 20 / 10 / 5`
+  - SRM-2 / SRM-4 / SRM-6: `50 / 25 / 15`
+  - LRM-5 / LRM-10 / LRM-15 / LRM-20: `24 / 12 / 8 / 6`
+- `FUN_0042c200` decrements the selected ammo-state bin by `1` per accepted shot.
+- `FUN_0042c110` scans for another non-empty bin with the same weapon type and repoints matching weapon slots when the current bin empties.
+
 `FUN_0040d830` field transforms:
 
 ```c

--- a/src/data/mechs.ts
+++ b/src/data/mechs.ts
@@ -117,6 +117,10 @@ function readMecFields(
   armorLikeMaxValues: number[];
   weaponMountInternalIndices: number[];
   weaponTypeIds: number[];
+  /**
+   * Raw ammo-bin quantities from the mech's decrypted .MEC file.
+   * Retail combat does not seed live ammo directly from these values.
+   */
   ammoBinCapacities: number[];
   ammoBinTypeIds: number[];
 } {

--- a/src/data/weapons.ts
+++ b/src/data/weapons.ts
@@ -13,6 +13,7 @@ export interface WeaponSpec {
   damage?: number;
   heat?: number;
   cooldownMs?: number;
+  ammoPerBin?: number;
   shortRangeMeters?: number;
   mediumRangeMeters?: number;
   longRangeMeters?: number;
@@ -34,23 +35,23 @@ const WEAPON_SPECS: readonly WeaponSpec[] = [
   // missile rows track average cluster damage. That lifts flamer to direct
   // damage=3 without forcing a broader missile damage reinterpretation here.
   // Flamers share the same S/M/L band caps as Machine Guns in retail play.
-  { typeId: 0, name: 'Flamer', damage: 3, heat: 3, cooldownMs: 3_000, shortRangeMeters: 30, mediumRangeMeters: 60, longRangeMeters: 90, maxRangeMeters: 90 },
-  { typeId: 1, name: 'Machine Gun', damage: 2, heat: 0, cooldownMs: 0, shortRangeMeters: 30, mediumRangeMeters: 60, longRangeMeters: 90, maxRangeMeters: 90 },
-  { typeId: 2, name: 'Small Laser', damage: 3, heat: 1, cooldownMs: 1_000, shortRangeMeters: 30, mediumRangeMeters: 60, longRangeMeters: 90, maxRangeMeters: 90 },
-  { typeId: 3, name: 'Medium Laser', damage: 5, heat: 3, cooldownMs: 3_000, shortRangeMeters: 90, mediumRangeMeters: 180, longRangeMeters: 270, maxRangeMeters: 270 },
-  { typeId: 4, name: 'Large Laser', damage: 8, heat: 8, cooldownMs: 8_000, shortRangeMeters: 150, mediumRangeMeters: 300, longRangeMeters: 450, maxRangeMeters: 450 },
-  { typeId: 5, name: 'Particle Projector Cannon', damage: 10, heat: 10, cooldownMs: 10_000, shortRangeMeters: 180, mediumRangeMeters: 360, longRangeMeters: 540, maxRangeMeters: 540 },
-  { typeId: 6, name: 'Autocannon/2', damage: 2, heat: 1, cooldownMs: 1_000, shortRangeMeters: 240, mediumRangeMeters: 480, longRangeMeters: 720, maxRangeMeters: 720 },
-  { typeId: 7, name: 'Autocannon/5', damage: 5, heat: 1, cooldownMs: 1_000, shortRangeMeters: 180, mediumRangeMeters: 360, longRangeMeters: 540, maxRangeMeters: 540 },
-  { typeId: 8, name: 'Autocannon/10', damage: 10, heat: 3, cooldownMs: 3_000, shortRangeMeters: 120, mediumRangeMeters: 240, longRangeMeters: 360, maxRangeMeters: 360 },
-  { typeId: 9, name: 'Autocannon/20', damage: 20, heat: 7, cooldownMs: 7_000, shortRangeMeters: 90, mediumRangeMeters: 180, longRangeMeters: 270, maxRangeMeters: 270 },
-  { typeId: 10, name: 'SRM-2', damage: 4, heat: 2, cooldownMs: 2_000, shortRangeMeters: 90, mediumRangeMeters: 180, longRangeMeters: 270, maxRangeMeters: 270 },
-  { typeId: 11, name: 'SRM-4', damage: 8, heat: 3, cooldownMs: 3_000, shortRangeMeters: 90, mediumRangeMeters: 180, longRangeMeters: 270, maxRangeMeters: 270 },
-  { typeId: 12, name: 'SRM-6', damage: 12, heat: 4, cooldownMs: 4_000, shortRangeMeters: 90, mediumRangeMeters: 180, longRangeMeters: 270, maxRangeMeters: 270 },
-  { typeId: 13, name: 'LRM-5', damage: 5, heat: 2, cooldownMs: 2_000, shortRangeMeters: 210, mediumRangeMeters: 420, longRangeMeters: 630, maxRangeMeters: 630 },
-  { typeId: 14, name: 'LRM-10', damage: 10, heat: 4, cooldownMs: 4_000, shortRangeMeters: 210, mediumRangeMeters: 420, longRangeMeters: 630, maxRangeMeters: 630 },
-  { typeId: 15, name: 'LRM-15', damage: 15, heat: 5, cooldownMs: 5_000, shortRangeMeters: 210, mediumRangeMeters: 420, longRangeMeters: 630, maxRangeMeters: 630 },
-  { typeId: 16, name: 'LRM-20', damage: 20, heat: 6, cooldownMs: 6_000, shortRangeMeters: 210, mediumRangeMeters: 420, longRangeMeters: 630, maxRangeMeters: 630 },
+  { typeId: 0, name: 'Flamer', damage: 3, heat: 3, cooldownMs: 3_000, ammoPerBin: 0, shortRangeMeters: 30, mediumRangeMeters: 60, longRangeMeters: 90, maxRangeMeters: 90 },
+  { typeId: 1, name: 'Machine Gun', damage: 2, heat: 0, cooldownMs: 0, ammoPerBin: 200, shortRangeMeters: 30, mediumRangeMeters: 60, longRangeMeters: 90, maxRangeMeters: 90 },
+  { typeId: 2, name: 'Small Laser', damage: 3, heat: 1, cooldownMs: 1_000, ammoPerBin: 0, shortRangeMeters: 30, mediumRangeMeters: 60, longRangeMeters: 90, maxRangeMeters: 90 },
+  { typeId: 3, name: 'Medium Laser', damage: 5, heat: 3, cooldownMs: 3_000, ammoPerBin: 0, shortRangeMeters: 90, mediumRangeMeters: 180, longRangeMeters: 270, maxRangeMeters: 270 },
+  { typeId: 4, name: 'Large Laser', damage: 8, heat: 8, cooldownMs: 8_000, ammoPerBin: 0, shortRangeMeters: 150, mediumRangeMeters: 300, longRangeMeters: 450, maxRangeMeters: 450 },
+  { typeId: 5, name: 'Particle Projector Cannon', damage: 10, heat: 10, cooldownMs: 10_000, ammoPerBin: 0, shortRangeMeters: 180, mediumRangeMeters: 360, longRangeMeters: 540, maxRangeMeters: 540 },
+  { typeId: 6, name: 'Autocannon/2', damage: 2, heat: 1, cooldownMs: 1_000, ammoPerBin: 45, shortRangeMeters: 240, mediumRangeMeters: 480, longRangeMeters: 720, maxRangeMeters: 720 },
+  { typeId: 7, name: 'Autocannon/5', damage: 5, heat: 1, cooldownMs: 1_000, ammoPerBin: 20, shortRangeMeters: 180, mediumRangeMeters: 360, longRangeMeters: 540, maxRangeMeters: 540 },
+  { typeId: 8, name: 'Autocannon/10', damage: 10, heat: 3, cooldownMs: 3_000, ammoPerBin: 10, shortRangeMeters: 120, mediumRangeMeters: 240, longRangeMeters: 360, maxRangeMeters: 360 },
+  { typeId: 9, name: 'Autocannon/20', damage: 20, heat: 7, cooldownMs: 7_000, ammoPerBin: 5, shortRangeMeters: 90, mediumRangeMeters: 180, longRangeMeters: 270, maxRangeMeters: 270 },
+  { typeId: 10, name: 'SRM-2', damage: 4, heat: 2, cooldownMs: 2_000, ammoPerBin: 50, shortRangeMeters: 90, mediumRangeMeters: 180, longRangeMeters: 270, maxRangeMeters: 270 },
+  { typeId: 11, name: 'SRM-4', damage: 8, heat: 3, cooldownMs: 3_000, ammoPerBin: 25, shortRangeMeters: 90, mediumRangeMeters: 180, longRangeMeters: 270, maxRangeMeters: 270 },
+  { typeId: 12, name: 'SRM-6', damage: 12, heat: 4, cooldownMs: 4_000, ammoPerBin: 15, shortRangeMeters: 90, mediumRangeMeters: 180, longRangeMeters: 270, maxRangeMeters: 270 },
+  { typeId: 13, name: 'LRM-5', damage: 5, heat: 2, cooldownMs: 2_000, ammoPerBin: 24, shortRangeMeters: 210, mediumRangeMeters: 420, longRangeMeters: 630, maxRangeMeters: 630 },
+  { typeId: 14, name: 'LRM-10', damage: 10, heat: 4, cooldownMs: 4_000, ammoPerBin: 12, shortRangeMeters: 210, mediumRangeMeters: 420, longRangeMeters: 630, maxRangeMeters: 630 },
+  { typeId: 15, name: 'LRM-15', damage: 15, heat: 5, cooldownMs: 5_000, ammoPerBin: 8, shortRangeMeters: 210, mediumRangeMeters: 420, longRangeMeters: 630, maxRangeMeters: 630 },
+  { typeId: 16, name: 'LRM-20', damage: 20, heat: 6, cooldownMs: 6_000, ammoPerBin: 6, shortRangeMeters: 210, mediumRangeMeters: 420, longRangeMeters: 630, maxRangeMeters: 630 },
 ] as const;
 
 const WEAPON_SPEC_BY_TYPE_ID = new Map<number, WeaponSpec>(
@@ -71,6 +72,10 @@ export function getWeaponSpecByName(name: string | undefined): WeaponSpec | unde
 
 export function getWeaponNameByTypeId(typeId: number | undefined): string | undefined {
   return getWeaponSpecByTypeId(typeId)?.name;
+}
+
+export function getWeaponAmmoPerBinByTypeId(typeId: number | undefined): number | undefined {
+  return getWeaponSpecByTypeId(typeId)?.ammoPerBin;
 }
 
 export function getWeaponLongRangeMeters(spec: WeaponSpec | undefined): number | undefined {

--- a/src/world/world-handlers.ts
+++ b/src/world/world-handlers.ts
@@ -83,6 +83,7 @@ import { CaptureLogger } from '../util/capture.js';
 import { buildMechExamineText, MECH_STATS } from '../data/mech-stats.js';
 import { mechInternalStateBytes } from '../data/mechs.js';
 import {
+  getWeaponAmmoPerBinByTypeId,
   getWeaponNameByTypeId,
   getWeaponLongRangeMeters,
   getWeaponRangeBandForDistance,
@@ -2521,11 +2522,23 @@ function getAmmoDamageCodeBase(extraCritCount: number | undefined, weaponCount: 
   return 0x28 + weaponCount + normalizeExtraCritCount(extraCritCount);
 }
 
+function weaponTypeUsesAmmo(weaponTypeId: number | undefined): boolean {
+  return (getWeaponAmmoPerBinByTypeId(weaponTypeId) ?? 0) > 0;
+}
+
+function getInitialCombatAmmoStateValues(ammoBinTypeIds: readonly number[] | undefined): number[] {
+  if (!ammoBinTypeIds || ammoBinTypeIds.length === 0) {
+    return [];
+  }
+
+  return ammoBinTypeIds.map(typeId => getWeaponAmmoPerBinByTypeId(typeId) ?? 0);
+}
+
 function getOrCreateAmmoStateValues(
   currentValues: number[] | undefined,
-  ammoBinCapacities: readonly number[],
+  ammoBinTypeIds: readonly number[] | undefined,
 ): number[] {
-  return currentValues ? [...currentValues] : [...ammoBinCapacities];
+  return currentValues ? [...currentValues] : getInitialCombatAmmoStateValues(ammoBinTypeIds);
 }
 
 const INTERNAL_SECTION_LABELS = [
@@ -3334,6 +3347,9 @@ function consumeWeaponAmmo(
   if (!mechEntry || weaponTypeId === undefined) {
     return { allowed: true, weaponName };
   }
+  if (!weaponTypeUsesAmmo(weaponTypeId)) {
+    return { allowed: true, weaponName };
+  }
 
   const matchingAmmoBinIndexes: number[] = [];
   for (let ammoBinIndex = 0; ammoBinIndex < mechEntry.ammoBinTypeIds.length; ammoBinIndex += 1) {
@@ -3342,10 +3358,10 @@ function consumeWeaponAmmo(
     }
   }
   if (matchingAmmoBinIndexes.length === 0) {
-    return { allowed: true, weaponName };
+    return { allowed: false, weaponName };
   }
 
-  const ammoStateValues = getOrCreateAmmoStateValues(session.combatAmmoStateValues, mechEntry.ammoBinCapacities);
+  const ammoStateValues = getOrCreateAmmoStateValues(session.combatAmmoStateValues, mechEntry.ammoBinTypeIds);
   const ammoBinIndex = matchingAmmoBinIndexes.find(index => (ammoStateValues[index] ?? 0) > 0);
   if (ammoBinIndex === undefined) {
     return { allowed: false, weaponName };
@@ -3434,6 +3450,9 @@ function getBotWeaponAmmoGate(
   if (!mechEntry || weaponTypeId === undefined) {
     return { allowed: true, weaponName };
   }
+  if (!weaponTypeUsesAmmo(weaponTypeId)) {
+    return { allowed: true, weaponName };
+  }
 
   const matchingAmmoBinIndexes: number[] = [];
   for (let ammoBinIndex = 0; ammoBinIndex < mechEntry.ammoBinTypeIds.length; ammoBinIndex += 1) {
@@ -3442,12 +3461,12 @@ function getBotWeaponAmmoGate(
     }
   }
   if (matchingAmmoBinIndexes.length === 0) {
-    return { allowed: true, weaponName };
+    return { allowed: false, weaponName };
   }
 
   const ammoStateValues = consume
-    ? getOrCreateAmmoStateValues(session.combatBotAmmoStateValues, mechEntry.ammoBinCapacities)
-    : (session.combatBotAmmoStateValues ?? mechEntry.ammoBinCapacities);
+    ? getOrCreateAmmoStateValues(session.combatBotAmmoStateValues, mechEntry.ammoBinTypeIds)
+    : (session.combatBotAmmoStateValues ?? getInitialCombatAmmoStateValues(mechEntry.ammoBinTypeIds));
   const ammoBinIndex = matchingAmmoBinIndexes.find(index => (ammoStateValues[index] ?? 0) > 0);
   if (ammoBinIndex === undefined) {
     return { allowed: false, weaponName };
@@ -6349,7 +6368,7 @@ function startArenaCombatSession(
       const localExtraCritCount = localMechEntry?.extraCritCount ?? 0;
       const localCritBytes = Math.max(0, localExtraCritCount + 21);
       const localCriticalStateBytes = createCriticalStateBytes(localExtraCritCount);
-      const localAmmoStateValues = [...(localMechEntry?.ammoBinCapacities ?? [])];
+      const localAmmoStateValues = getInitialCombatAmmoStateValues(localMechEntry?.ammoBinTypeIds);
       const localCallsign = getDisplayName(participant);
       participant.combatAmmoStateValues = [...localAmmoStateValues];
 
@@ -6642,7 +6661,7 @@ export function tryStartStagedDuelCombat(
       const localExtraCritCount = localMechEntry?.extraCritCount ?? 0;
       const localCritBytes = Math.max(0, localExtraCritCount + 21);
       const localCriticalStateBytes = createCriticalStateBytes(localExtraCritCount);
-      const localAmmoStateValues = [...(localMechEntry?.ammoBinCapacities ?? [])];
+      const localAmmoStateValues = getInitialCombatAmmoStateValues(localMechEntry?.ammoBinTypeIds);
       const peerMechId = participant.peer.selectedMechId ?? FALLBACK_MECH_ID;
       const peerMechEntry = WORLD_MECH_BY_ID.get(peerMechId);
       const localCallsign = getDisplayName(participant.local);
@@ -7757,7 +7776,8 @@ export function sendCombatBootstrapSequence(
   // Store per-mech speedMag caps so Cmd8/9 handlers can apply them.
   session.combatMaxSpeedMag  = mechEntry?.maxSpeedMag  ?? 0;
   session.combatWalkSpeedMag = mechEntry?.walkSpeedMag ?? 0;
-  session.combatAmmoStateValues = [...(mechEntry?.ammoBinCapacities ?? [])];
+  const localAmmoStateValues = getInitialCombatAmmoStateValues(mechEntry?.ammoBinTypeIds);
+  session.combatAmmoStateValues = [...localAmmoStateValues];
   if (session.combatResultTimer !== undefined) {
     clearTimeout(session.combatResultTimer);
     session.combatResultTimer = undefined;
@@ -7843,7 +7863,7 @@ export function sendCombatBootstrapSequence(
           // Indices 4 and 7 are also required non-zero by the IS gate (FUN_0042bb00).
           // Order: [arm, arm, side, side, CT, leg, leg, head] (§23.8, IS lookup RE).
           internalStateBytes:   mechInternalStateBytes(mechEntry?.tonnage ?? 0),
-          ammoStateValues:      [...(mechEntry?.ammoBinCapacities ?? [])],
+          ammoStateValues:      localAmmoStateValues,
           actorDisplayName:     callsign.substring(0, 31),
         },
       },
@@ -7881,7 +7901,7 @@ export function sendCombatBootstrapSequence(
     session.combatBotMoveVectorX = 0;
     session.combatBotMoveVectorY = 0;
     session.combatBotWeaponReadyAtBySlot = [];
-    session.combatBotAmmoStateValues = [...(botMechEntry?.ammoBinCapacities ?? [])];
+    session.combatBotAmmoStateValues = getInitialCombatAmmoStateValues(botMechEntry?.ammoBinTypeIds);
     session.combatBotHeat = 0;
     session.combatBotJumpActive = false;
     session.combatBotJumpFuel = JUMP_JET_FUEL_MAX;


### PR DESCRIPTION
## Summary

Align combat ammo state with the retail client by seeding ammo bins from the recovered weapon-family ammo table instead of raw `.MEC` ammo quantities. This keeps ballistic and missile weapons from depleting far too early, preserves proper same-type bin rollover, and leaves energy weapons ammo-free under the same retail `usesAmmo` rule the client uses.

## Related Issue

Closes #142

## Type of Change

- [x] Bug fix
- [ ] Feature / enhancement
- [x] Research finding / protocol update
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Chore (dependencies, CI, config)

## Implementation Notes

- add recovered retail ammo-per-bin values to shared weapon metadata and expose a helper for combat-state seeding
- seed all combat ammo bootstrap paths (single-player, duel, arena, and bot) from ammo-bin weapon types instead of raw `.MEC` `ammo_bin_qty[]` values
- match the retail `usesAmmo` predicate so flamer / laser / PPC families stay ammo-free while ammo-using weapons without matching bins are rejected instead of firing infinitely
- document the recovered retail ammo-state initialization and depletion path in `RESEARCH.md`

## Testing

- `npm run build`

## Checklist

- [x] Branch is based on `master`
- [x] Commit messages follow `type: description` convention (e.g. `fix: correct CRC seed`)
- [x] TypeScript builds cleanly (`npm run build`)
- [x] No debug `console.log` left in production code paths
- [x] `RESEARCH.md` updated if this reflects a new RE finding
- [x] `symbols.json` updated if new canonical names were introduced
- [x] This PR is ready for review (not a draft)