### PR TITLE
fix: migrate server behavior for v1.29 client

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,12 @@ npm start --prefix mpbt-server
 start "" "C:\MPBT\MPBTWIN.EXE" "C:\MPBT\play.pcgi"
 ```
 
-Packet captures are written to `mpbt-server/captures/` and logs to `mpbt-server/logs/` for each session.
+Logs are written to `mpbt-server/logs/` for each session.
+
+Per-session packet captures are now opt-in so normal playtesting does not pay the
+hex-dump disk-I/O cost on every packet. Set `MPBT_CAPTURE=1` when you want fresh
+wire captures in `mpbt-server/captures/`, and set `MPBT_LOG_LEVEL=debug` when you
+also want the verbose per-packet debug trace back in `logs/server.log`.
 
 ## Reverse Engineering Notes
 

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -1182,9 +1182,8 @@ Combat-only entries (cmd 62–79, only non-null in combat table):
 > client. The later `v1.29` client now targeted by `mpbt-server` diverges
 > materially in world slots `39`, `44`, `46`, and `57`, and also preserves a
 > Solaris mech-management family at `Cmd30` / `Cmd31` that is not reflected in
-> the older display-family summary below. See §19.4 and
-> `docs/v1.23-to-1.29-migration.md` before reusing these mappings for `v1.29`
-> server work.
+> the older display-family summary below. See §19.4 before reusing these
+> mappings for `v1.29` server work.
 
 Not every RPS/world dispatch address is a real function start. Several entries
 (`17`, `21`–`24`, `44`, `46`–`47`, `50`–`51`, `61`) jump into interior labels of
@@ -5782,20 +5781,36 @@ equilibrium depends on the `globalA/globalB` pair rather than `globalA` alone.
 
 ### §19.4 — v1.29 client migration deltas (2026-04-23)
 
-Primary reference: `docs/v1.23-to-1.29-migration.md`.
-
 This is the part of the migration story that currently matters most for
 `mpbt-server`: **the transport/launcher side is largely unchanged, while the
 world/Solaris UI routing is not.**
 
 #### High-confidence baseline
 
+- Baseline binaries compared:
+  - `v1.23`: `C:\MPBT\Mpbtwin.exe` (`FileVersion 1.23`, `621,568` bytes)
+  - `v1.29`: `C:\MPBT-v1.29\mpbtwin.exe` (`FileVersion 1.29`, `629,248` bytes)
+  - `v1.23` `mpbtwin.exe` SHA-256: `DDB766C5F5092EF814ABC5E2D5331E86E3076832CF67A45881CD04A30F15FC5A`
+  - `v1.29` `mpbtwin.exe` SHA-256: `F9ACDA6290F820D0BD632E791CAB1CB8324A7D4145FA8E163BAEC0BC30196D68`
 - `COMMEG32.DLL` is byte-identical between the local retail `v1.23` install and
   `C:\MPBT-v1.29`.
+  - SHA-256: `683A2424B5C57BF6B07E7429087797FA2EEFD3EB408A064C03CEB34B25AAE82A`
 - `INITAR.DLL` is also byte-identical between those installs.
+  - SHA-256: `7BD4C51D4C45091A62B8493EB02B05EB45D8B7D68CE5EB946EEC08E718345640`
 - Practical implication: moving `mpbt-server` to a `v1.29` client does **not**
   require a new ARIES transport interpretation or a new launcher/`play.pcgi`
   contract just because of the version bump.
+
+#### Release-history clues from `v1.29` client text
+
+- `v1.29` notes (24 Jun 1999): fixed bugs introduced by `1.28` anti-hacking code,
+  fixed target-info HUD color, restored missile-impact sounds on the player's
+  mech, restored fall-impact sound.
+- `v1.28` notes (27 May 1999): added client hacking-prevention code.
+- `v1.27` notes (16 Oct 1998): jump-jet fix for mechs with fewer than 4 jets
+  and Team Sanctioned Battles support.
+- Practical implication: migration risk is concentrated in anti-tamper checks,
+  world/Solaris UI flow, low-jet jump behavior, and combat event hooks.
 
 #### Combat-side migration read
 
@@ -5869,8 +5884,8 @@ The highest-risk `v1.23` carry-forward mistakes are now known:
 
 - When `mpbt-server` is paired with the `v1.29` client, **do not assume the old
   `v1.23` world-slot meanings for `Cmd39`, `Cmd44`, or `Cmd46`**.
-- Solaris/world work should treat `docs/v1.23-to-1.29-migration.md` as the
-  current compatibility note for the repurposed world slots.
+- Solaris/world work should treat this section as the current compatibility note
+  for repurposed `v1.29` world slots.
 - The most important `v1.29` world-side surfaces to align in code are now:
   - chooser/menu flows that likely need `Cmd57` rather than old `Cmd44`
   - Solaris mech-management flows built around `Cmd26` / `Cmd30` / `Cmd31` /

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -26,7 +26,7 @@ contributors who want to extend or audit the server emulator.
 16. [Open Questions](#16-open-questions)
 17. [COMMEG32.DLL — Secondary Connection Protocol (M2 RE)](#17-commeg32dll--secondary-connection-protocol-m2-re)
 18. [Game World Protocol — MPBTWIN.EXE RE](#18-game-world-protocol--mpbtwinexe-re)
-19. [Client v1.23 Migration Notes](#19-client-v123-migration-notes)
+19. [Client Migration Notes](#19-client-migration-notes)
 20. [MEC File Binary Format](#20-mec-file-binary-format)
 21. [MAP File Leading Room Table](#21-map-file-leading-room-table)
 22. [Windowed Mode — DirectDraw Rendering Architecture](#22-windowed-mode--directdraw-rendering-architecture)
@@ -1178,6 +1178,14 @@ Combat-only entries (cmd 62–79, only non-null in combat table):
 
 ### 12.1 World UI / display-family map (2026-04-14)
 
+> **Version scope warning:** §12.1–§12.2 describe the **v1.23** world/RPS
+> client. The later `v1.29` client now targeted by `mpbt-server` diverges
+> materially in world slots `39`, `44`, `46`, and `57`, and also preserves a
+> Solaris mech-management family at `Cmd30` / `Cmd31` that is not reflected in
+> the older display-family summary below. See §19.4 and
+> `docs/v1.23-to-1.29-migration.md` before reusing these mappings for `v1.29`
+> server work.
+
 Not every RPS/world dispatch address is a real function start. Several entries
 (`17`, `21`–`24`, `44`, `46`–`47`, `50`–`51`, `61`) jump into interior labels of
 larger handlers. Even with that limitation, the inbound world-command table now
@@ -1191,6 +1199,19 @@ clusters into a few concrete UI families:
 | Scroll-list shell | `45`, `58` plus row-feed helpers | scrollable list with optional `Space` / `ESC` footer controls | Backed by `DAT_004e2620`. `Cmd58` latches the list id; `Cmd45` opens the shell; Enter on a populated row emits `Cmd7(listId, item_id + 1)`. |
 | Solaris map / scene overlays | `40`, `43`, `49`, `56`, `60`, `61` | map / overlay family | `Cmd40` / `Cmd43` open the Inner Sphere / Solaris maps; `Cmd49`, `Cmd56`, and `Cmd60` draw connectors/markers; `Cmd61` refreshes scene location icons after map/scene state changes. |
 | Scene status text | `39` | inline world status text | Updates the status/toast text region in the current world scene. |
+
+Important `v1.29` override for `mpbt-server` work: the later client **does not**
+keep the same meaning for every world slot above. Current migration RE now shows:
+
+- `Cmd39` is no longer the inline scene-status slot; in `v1.29` it is the
+  selectable **Buy Extra Ammo** list under Solaris mech management.
+- `Cmd44` is no longer the keyed single-string chooser; in `v1.29` it is a
+  location-distance-scale setter for the Solaris browser family.
+- `Cmd46` is no longer the richer ranking/personnel info-panel candidate; in
+  `v1.29` it is an explicit world-UI clear / browser-child teardown packet.
+- `Cmd57` is the strongest live `v1.29` chooser-family replacement, and
+  `Cmd30` / `Cmd31` survive as the preserved per-mech **Mech Status** /
+  component-maintenance pages above the repurposed `Cmd39`.
 
 ### 12.2 Sanctioned-duel ranking and results display-family inference
 
@@ -2454,10 +2475,12 @@ Offset  Ptr (LE32)   Resolved
 
 ---
 
-## 19. Client v1.23 Migration Notes
+## 19. Client Migration Notes
 
 > **Branch:** `feat/client-1.23` — all RE below is being re-verified against the 1.23 Ghidra project.
 > All function addresses throughout §1–§18 are from the **v1.06** binaries unless explicitly noted here.
+> The earlier material in this section is `v1.23`-centric; the `v1.29` deltas
+> that now matter for `mpbt-server` are summarized in §19.4.
 
 ### Binary metadata
 
@@ -2856,8 +2879,9 @@ Confirmed call sites:
     - `F12` pressed during the active collapse-animation window is expected to be ignored even if `Cmd70/8` already set the down latch
     - but this gate is **not** a long-lived timer and does **not** look like a one-frame blip either: once the callback fires, the bit should clear and stay clear while the actor remains parked on the collapse end pose
     - the double-`Cmd70/8` pattern in the live `legseq` probe can only restart that short animation-gate once; it does not explain the full multi-second absence of `cmd12/action0` by itself
-    - practical next probe: begin with a sustained `F12` hold shortly after the **last** observed `Cmd70/8` and continue for several seconds, then also test a rapid repeated-press burst in the same post-collapse window; that matches the recovered gate logic and the broader remembered retail interaction better than a single brief tap
-    - if that still yields no `cmd12/action0`, collapse-animation timing is effectively ruled out as the primary blocker, and the next best RE target is why state `8` never seems to leave the client in a truly recoverable local posture
+  - practical next probe: begin with a sustained `F12` hold shortly after the **last** observed `Cmd70/8` and continue for several seconds, then also test a rapid repeated-press burst in the same post-collapse window; that matches the recovered gate logic and the broader remembered retail interaction better than a single brief tap
+  - if that still yields no `cmd12/action0`, collapse-animation timing is effectively ruled out as the primary blocker, and the next best RE target is why state `8` never seems to leave the client in a truly recoverable local posture
+
 - Fresh 2026-04-19 collapse-trigger follow-up:
   - `FUN_0043b4a0` is now clearly the **state-8 collapse installer**, not the upstream cause:
     - it clears two posture/fall bits in the actor flag field
@@ -4894,6 +4918,26 @@ The exact labels for the early code ranges still need correlation against `.MEC`
 - Retail visible fall/recovery state still sits on the separate `Cmd70` sequence: `4` airborne, `8` immediate/deferred collapse, `6` landing resolution.
 - Server implication: `mpbt-server` now mirrors the minimum retail-fall experiment by sending class-2 internal updates, head criticals, conservative leg-actuator critical updates on first leg destruction, and a non-death `Cmd70/8` collapse transition. It still does **not** emit `Cmd73` rate-field packets or handle stand-up / `cmd12 action 0x15`, so recovery fidelity remains the next open slice.
 
+2026-04-22 death / destruction-tail follow-up on `Cmd70` and result handoff:
+
+- `Combat_Cmd70_ActorAnimState_v123` (`0x0040e700`) is the live combat animation/status driver for stand / fall / jump / collapse / destruction-style transitions.
+- `Cmd70` subcommand `8` is the confirmed **collapse start** path:
+  - it sets the collapse/deferred-collapse state,
+  - uses `Combat_StartFallDownAnim_SetRecoveryBlock_v123` (`0x0043b4a0`) for the immediate fall path,
+  - and reaches the nearby sound/effect helper chain that includes `FUN_00419100`.
+- `Cmd70` subcommand `0` is **not** just a neutral stand/reset command. When the actor is already in late collapse/death states, it advances into the destruction tail:
+  - current state `7` -> `FUN_0043b4e0` -> state `0xb`
+  - current state `8` -> `FUN_0043b500` -> state `0xc`
+  - current state `9` -> `FUN_0043b540` -> state `0xd` (with callback back toward the `0xb` path)
+  - current state `10` -> `FUN_0043b520` -> state `0xe` (also callback-linked toward `0xb`)
+- `Cmd70` subcommand `4` is **not** the post-death "wreck/explosion" transition. In the v1.23 client it is the airborne/jump helper, so using `8 -> 4` for destruction is the wrong shape.
+- Practical server implication: retail-shaped death animation should use **`Cmd70 8 -> 0`**, not `8 -> 4`.
+- Result-scene handoff is a separate packet-driven step:
+  - `Cmd75` (`FUN_00445820`) stores the match result selector (`0 = VICT`, `1 = LOST`) and enters the pending result path.
+  - `Cmd63` (`FUN_00445870`) then initializes the arena/result scene.
+  - Therefore `Cmd75/Cmd63` are **not** the live explosion/death animation; they are the later result-scene transition.
+- Heuristic asset cross-check (`MPBTWIN.EXE.c`) also shows distinct loaded audio resources for both explosion and ejection (`SOUND_EXPLD1..4_PCM`, `SOUND_EJECT_PCM`), but the exact live-binary eject animation path is still less certain than the kill/death path above.
+
 ---
 
 ### §19.7 — v1.23 IS.MAP / SOLARIS.MAP Binary Format (CONFIRMED)
@@ -5495,7 +5539,7 @@ rendering investigation and should be considered canonical names:
 
 ### §23.1 — Finding: No Server-to-Client "Match-End" Packet
 
-**The match-end transition is entirely client-driven.** There is no dedicated server→client combat command that signals "match over, show results screen." The client determines match outcome using its local combat simulation.
+**The client determines combat death locally, but the full post-match handoff is not entirely client-driven.** There is no single server→client "you died, explode now" packet; live death presentation is driven by local combat state plus `Cmd70` animation/status transitions. However, the later result-scene handoff is packet-assisted through `Cmd75` (result selector) followed by `Cmd63` (arena/result scene init).
 
 ---
 
@@ -5585,9 +5629,11 @@ Live packet capture is needed to confirm the exact IS component threshold and de
 
 ### §23.7 — Server Implementation Implications
 
-- **No match-end packet to send.** The server does not need to signal match-end.
+- **No single death packet to send.** The server does not need a dedicated "explode now / match over" packet beyond the normal damage and `Cmd70` transition path.
 - **WIN** is triggered automatically by client local simulation when the bot (seeded via `Cmd64`) dies from player weapon fire. The server should only ensure the bot has correct IS/HP seeded (see Issue #80).
 - **LOSS** is triggered when enough `Cmd67` damage drains an IS component on actor 0 to zero. Server should stop sending `Cmd67` once it estimates player HP is depleted.
+- **Live death presentation** should use the retail-shaped `Cmd70` destruction sequence (`8 -> 0`), not the older `8 -> 4` guess.
+- **Result scene** is a separate server-assisted step: send `Cmd75` to choose `VICT` / `LOST`, then `Cmd63` to enter the corresponding result scene.
 - **Cleanup**: The client closes the TCP connection itself (via `FUN_0040b3d0`) after the results screen. Server handles cleanup in the TCP-close handler.
 
 ---
@@ -5603,6 +5649,9 @@ Live packet capture is needed to confirm the exact IS component threshold and de
 | `Combat_ProjectileLoop` | `0x004409f0` | Iterates active projectiles; calls `FUN_00441130` on expiry |
 | `Combat_InputFlagSet` | `0x0040b4a0` | Generic bit-setter for `g_inputFlags` |
 | `Combat_KeyTranslator` | `0x0043d500` | Translates raw key scancode → flag index → `FUN_0040b4a0` |
+| `Combat_Cmd75_ResultSelector` | `0x00445820` | Stores `VICT` / `LOST` and enters pending result path |
+| `Combat_Cmd63_ResultSceneInit` | `0x00445870` | Initializes the arena/result scene after the selector |
+| `Combat_Cmd70_ActorAnimState` | `0x0040e700` | Live actor animation/status transition handler; collapse and destruction tail |
 | `Combat_TimerSet` | `0x004461c0` | Sets `g_disconnectTimer = now + N` (only if `g_exitState == 4`) |
 | `Combat_Disconnect` | `FUN_0040b3d0` | Closes TCP connection (called when timer fires) |
 | `Combat_ResultsPanel` | `0x00438170` | Renders the post-match results screen panel |
@@ -5730,5 +5779,113 @@ equilibrium depends on the `globalA/globalB` pair rather than `globalA` alone.
 | `FUN_0042c830` | `0x0042c830` | Velocity integrator; uses `DAT_004f56b4` (globalA) |
 | `FUN_0042cd20` | `0x0042cd20` | Ground drag; uses `DAT_004f56b4` (globalA) |
 | `FUN_004229a0` | `0x004229a0` | Client-local throttle target update (KP8/KP2 path) |
+
+### §19.4 — v1.29 client migration deltas (2026-04-23)
+
+Primary reference: `docs/v1.23-to-1.29-migration.md`.
+
+This is the part of the migration story that currently matters most for
+`mpbt-server`: **the transport/launcher side is largely unchanged, while the
+world/Solaris UI routing is not.**
+
+#### High-confidence baseline
+
+- `COMMEG32.DLL` is byte-identical between the local retail `v1.23` install and
+  `C:\MPBT-v1.29`.
+- `INITAR.DLL` is also byte-identical between those installs.
+- Practical implication: moving `mpbt-server` to a `v1.29` client does **not**
+  require a new ARIES transport interpretation or a new launcher/`play.pcgi`
+  contract just because of the version bump.
+
+#### Combat-side migration read
+
+- The later `v1.29` combat decoded-packet table at `DAT_0047EA38` is now
+  recovered across the full `Cmd59`-`Cmd74` window.
+- `Combat_Cmd65_UpdateActorPosition_v123` survives semantically in `v1.29` at
+  `0x0042A050`; the earlier mismatch was caused by a missing function boundary,
+  not a wire-level redesign.
+- The recovered `v1.29` `Cmd65` body still reads the same
+  `3 / 3 / 2 / 1 / 1 / 1 / 1` type pattern and still uses the same motion /
+  heading constants seen in `v1.23`.
+- Practical implication: existing `mpbt-server` combat packet work should be
+  treated as **largely portable** to `v1.29`, with follow-up attention aimed
+  more at feature deltas (anti-hacking, Team Sanctioned Battles, low-jet jump,
+  sound/event fixes) than at a wholesale combat-protocol rewrite.
+
+#### World/Solaris-side migration read
+
+The highest-risk `v1.23` carry-forward mistakes are now known:
+
+- `Cmd39` is **not** the old scene-status text slot in `v1.29`.
+  - It is now `World_Cmd39_BuyExtraAmmoList_v129`.
+  - It reads repeated `string + type2 + type2` rows and builds a true chooser.
+  - Confirm/cancel path uses outbound `cmd22(selectionIndex + 1)` / `cmd22(0)`.
+  - Its visible strings are anchored by the real `v1.29` `MPBT.MSG`:
+    - `0x4f` = `Ammo Type       Amount  Cost`
+    - `0x50` = `Buy`
+    - nearby `0xd0` = `Buy Extra Ammo`
+
+- `Cmd30` and `Cmd31` survive as a preserved Solaris mech-management family in
+  `v1.29`:
+  - `Cmd30 -> World_Cmd30_MechStatusOptionPage_v129`
+    - per-mech **Mech Status** option hub
+    - numbered server-provided option rows
+    - row picks submit through `World_SendMenuSelection_v129(listId, selection)`
+  - `Cmd31 -> World_Cmd31_MechComponentActionPage_v129`
+    - deeper component/location maintenance/detail page
+    - action form uses `Repair / Examine / Replace / Store / Done`
+    - `mode == 2` is read-only / Done-only; other modes are actionable
+
+- `Cmd26` / `Cmd27` also survive as the mech chooser family above that branch.
+  - Strong current route:
+    - `Cmd26 Choose a mech`
+    - `Cmd30 Mech Status option page`
+    - one server-provided row
+    - `Cmd39 Buy Extra Ammo list` or `Cmd31` deeper maintenance/details
+  - Main remaining uncertainty is only the exact `Cmd30` row order for:
+    - `Repair All`
+    - `Reload`
+    - `Buy Extra Ammo`
+    - `Name Mech`
+
+- `Cmd41` no longer reads best as a plain standings list in `v1.29`.
+  - Current live name/classification is `World_Cmd41_NameMechScoreMatrix_v129`.
+  - Best current read is a round-robin / match-results matrix surface with
+    `NAME / MECH / SCORE` columns plus per-opponent score cells and row totals.
+
+- `Cmd44` and `Cmd46` are genuine repurposings in `v1.29`, not simple moved
+  equivalents of the older world UI:
+  - `Cmd44 -> World_Cmd44_SetLocationDistanceScale_v129`
+  - `Cmd46 -> World_Cmd46_ClearWorldUiChildren_v129`
+
+- `Cmd57` is now the strongest live chooser-family replacement in the `v1.29`
+  world UI.
+  - `World_Cmd57_HotkeySelectionMenu_v129` builds a keyed menu from a title plus
+    repeated `(hotkey,row-text)` style entries.
+  - Its input callback sends `World_SendMenuSelection_v129(menu_id,
+    selection_index)` on Enter or hotkey match.
+
+#### Practical server implications
+
+- When `mpbt-server` is paired with the `v1.29` client, **do not assume the old
+  `v1.23` world-slot meanings for `Cmd39`, `Cmd44`, or `Cmd46`**.
+- Solaris/world work should treat `docs/v1.23-to-1.29-migration.md` as the
+  current compatibility note for the repurposed world slots.
+- The most important `v1.29` world-side surfaces to align in code are now:
+  - chooser/menu flows that likely need `Cmd57` rather than old `Cmd44`
+  - Solaris mech-management flows built around `Cmd26` / `Cmd30` / `Cmd31` /
+    repurposed `Cmd39`
+  - any location-browser/map work that depends on the now-recovered
+    `Cmd40` / `Cmd43` / `Cmd44` / `Cmd46` / `Cmd47` / `Cmd49` / `Cmd54` /
+    `Cmd55` / `Cmd56` / `Cmd57` / `Cmd60` / `Cmd61` family
+
+#### Current migration summary for implementation planning
+
+- **Good news:** auth/login transport, launcher behavior, and the core combat
+  packet families are much closer to `v1.23` than the raw version jump suggests.
+- **Main risk:** the Solaris/world UI layer in `v1.29` contains several real
+  slot repurposings and preserved late-game mech-management pages that can make
+  a `v1.23`-shaped server look superficially alive while still driving the wrong
+  screens.
 
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+import type { LogLevel } from './util/logger.js';
+
 function readNonNegativeIntEnv(name: string, defaultValue: number): number {
   const raw = process.env[name];
   if (raw === undefined || raw.trim() === '') {
@@ -11,6 +13,47 @@ function readNonNegativeIntEnv(name: string, defaultValue: number): number {
   return value;
 }
 
+function readBooleanEnv(name: string, defaultValue: boolean): boolean {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === '') {
+    return defaultValue;
+  }
+
+  switch (raw.trim().toLowerCase()) {
+    case '1':
+    case 'true':
+    case 'yes':
+    case 'on':
+      return true;
+    case '0':
+    case 'false':
+    case 'no':
+    case 'off':
+      return false;
+    default:
+      throw new Error(`${name} must be a boolean (1/0, true/false, yes/no, on/off), got "${raw}"`);
+  }
+}
+
+function readLogLevelEnv(name: string, defaultValue: LogLevel): LogLevel {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === '') {
+    return defaultValue;
+  }
+
+  const normalized = raw.trim().toLowerCase();
+  if (
+    normalized === 'debug' ||
+    normalized === 'info' ||
+    normalized === 'warn' ||
+    normalized === 'error'
+  ) {
+    return normalized;
+  }
+
+  throw new Error(`${name} must be one of debug/info/warn/error, got "${raw}"`);
+}
+
 // ARIES type-0x05 keepalive interval. 0 disables server-initiated keepalives.
 export const ARIES_KEEPALIVE_INTERVAL_MS = readNonNegativeIntEnv(
   'ARIES_KEEPALIVE_INTERVAL_MS',
@@ -22,3 +65,11 @@ export const SOCKET_IDLE_TIMEOUT_MS = readNonNegativeIntEnv(
   'SOCKET_IDLE_TIMEOUT_MS',
   120_000,
 );
+
+// Default to info-level logs during normal play. Protocol reverse-engineering can
+// opt back into per-packet debug logging with MPBT_LOG_LEVEL=debug.
+export const MPBT_LOG_LEVEL = readLogLevelEnv('MPBT_LOG_LEVEL', 'info');
+
+// Packet hex captures are useful during protocol work, but they add sustained disk
+// I/O on every send/receive. Keep them opt-in for regular local playtesting.
+export const MPBT_CAPTURE_ENABLED = readBooleanEnv('MPBT_CAPTURE', false);

--- a/src/data/weapons.ts
+++ b/src/data/weapons.ts
@@ -14,6 +14,8 @@ export interface WeaponSpec {
   heat?: number;
   cooldownMs?: number;
   ammoPerBin?: number;
+  missileCount?: number;
+  damagePerMissile?: number;
   shortRangeMeters?: number;
   mediumRangeMeters?: number;
   longRangeMeters?: number;
@@ -45,13 +47,13 @@ const WEAPON_SPECS: readonly WeaponSpec[] = [
   { typeId: 7, name: 'Autocannon/5', damage: 5, heat: 1, cooldownMs: 1_000, ammoPerBin: 20, shortRangeMeters: 180, mediumRangeMeters: 360, longRangeMeters: 540, maxRangeMeters: 540 },
   { typeId: 8, name: 'Autocannon/10', damage: 10, heat: 3, cooldownMs: 3_000, ammoPerBin: 10, shortRangeMeters: 120, mediumRangeMeters: 240, longRangeMeters: 360, maxRangeMeters: 360 },
   { typeId: 9, name: 'Autocannon/20', damage: 20, heat: 7, cooldownMs: 7_000, ammoPerBin: 5, shortRangeMeters: 90, mediumRangeMeters: 180, longRangeMeters: 270, maxRangeMeters: 270 },
-  { typeId: 10, name: 'SRM-2', damage: 4, heat: 2, cooldownMs: 2_000, ammoPerBin: 50, shortRangeMeters: 90, mediumRangeMeters: 180, longRangeMeters: 270, maxRangeMeters: 270 },
-  { typeId: 11, name: 'SRM-4', damage: 8, heat: 3, cooldownMs: 3_000, ammoPerBin: 25, shortRangeMeters: 90, mediumRangeMeters: 180, longRangeMeters: 270, maxRangeMeters: 270 },
-  { typeId: 12, name: 'SRM-6', damage: 12, heat: 4, cooldownMs: 4_000, ammoPerBin: 15, shortRangeMeters: 90, mediumRangeMeters: 180, longRangeMeters: 270, maxRangeMeters: 270 },
-  { typeId: 13, name: 'LRM-5', damage: 5, heat: 2, cooldownMs: 2_000, ammoPerBin: 24, shortRangeMeters: 210, mediumRangeMeters: 420, longRangeMeters: 630, maxRangeMeters: 630 },
-  { typeId: 14, name: 'LRM-10', damage: 10, heat: 4, cooldownMs: 4_000, ammoPerBin: 12, shortRangeMeters: 210, mediumRangeMeters: 420, longRangeMeters: 630, maxRangeMeters: 630 },
-  { typeId: 15, name: 'LRM-15', damage: 15, heat: 5, cooldownMs: 5_000, ammoPerBin: 8, shortRangeMeters: 210, mediumRangeMeters: 420, longRangeMeters: 630, maxRangeMeters: 630 },
-  { typeId: 16, name: 'LRM-20', damage: 20, heat: 6, cooldownMs: 6_000, ammoPerBin: 6, shortRangeMeters: 210, mediumRangeMeters: 420, longRangeMeters: 630, maxRangeMeters: 630 },
+  { typeId: 10, name: 'SRM-2', damage: 4, heat: 2, cooldownMs: 2_000, ammoPerBin: 50, missileCount: 2, damagePerMissile: 2, shortRangeMeters: 90, mediumRangeMeters: 180, longRangeMeters: 270, maxRangeMeters: 270 },
+  { typeId: 11, name: 'SRM-4', damage: 8, heat: 3, cooldownMs: 3_000, ammoPerBin: 25, missileCount: 4, damagePerMissile: 2, shortRangeMeters: 90, mediumRangeMeters: 180, longRangeMeters: 270, maxRangeMeters: 270 },
+  { typeId: 12, name: 'SRM-6', damage: 12, heat: 4, cooldownMs: 4_000, ammoPerBin: 15, missileCount: 6, damagePerMissile: 2, shortRangeMeters: 90, mediumRangeMeters: 180, longRangeMeters: 270, maxRangeMeters: 270 },
+  { typeId: 13, name: 'LRM-5', damage: 5, heat: 2, cooldownMs: 2_000, ammoPerBin: 24, missileCount: 5, damagePerMissile: 1, shortRangeMeters: 210, mediumRangeMeters: 420, longRangeMeters: 630, maxRangeMeters: 630 },
+  { typeId: 14, name: 'LRM-10', damage: 10, heat: 4, cooldownMs: 4_000, ammoPerBin: 12, missileCount: 10, damagePerMissile: 1, shortRangeMeters: 210, mediumRangeMeters: 420, longRangeMeters: 630, maxRangeMeters: 630 },
+  { typeId: 15, name: 'LRM-15', damage: 15, heat: 5, cooldownMs: 5_000, ammoPerBin: 8, missileCount: 15, damagePerMissile: 1, shortRangeMeters: 210, mediumRangeMeters: 420, longRangeMeters: 630, maxRangeMeters: 630 },
+  { typeId: 16, name: 'LRM-20', damage: 20, heat: 6, cooldownMs: 6_000, ammoPerBin: 6, missileCount: 20, damagePerMissile: 1, shortRangeMeters: 210, mediumRangeMeters: 420, longRangeMeters: 630, maxRangeMeters: 630 },
 ] as const;
 
 const WEAPON_SPEC_BY_TYPE_ID = new Map<number, WeaponSpec>(

--- a/src/protocol/game.ts
+++ b/src/protocol/game.ts
@@ -937,54 +937,10 @@ export function buildMenuDialogPacket(
   return buildGamePacket(7, buildMenuDialogArgs(listId, title, items), false, seq);
 }
 
-// ── Command 44 — keyed single-string list (server→client) ─────────────────────
-// CONFIRMED from FUN_0040fe80 / Cmd44_KeyedSingleStringList.
-//
-// Wire layout (args after seq+cmd bytes):
-//   [type1 2B: list_id]
-//   [string:   title]              — short arg-string via FUN_00401c80/FUN_0043d9b0
-//   [byte:     count]
-//   [repeat count times:
-//     [type4 5B: item_id]
-//     [string:   item text]
-//   ]
-//
-// Selecting a row later sends client cmd-7 with:
-//   [type1 list_id] [type4 item_id + 1]
-//
-// Special note: list_id 0x22 triggers a client-local synthetic "Exit to online service"
-// row (item_id=100) and keeps the dialog open after ordinary picks.
-
-export interface Cmd44KeyedStringItem {
-  itemId: number;
-  text: string;
-}
-
-export function buildCmd44KeyedSingleStringListArgs(
-  listId: number,
-  title: string,
-  items: Cmd44KeyedStringItem[],
-): Buffer {
-  const parts: Buffer[] = [
-    encodeB85_1(listId),
-    encodeString(title),
-    encodeAsByte(items.length),
-  ];
-  for (const item of items) {
-    parts.push(encodeB85_4(item.itemId));
-    parts.push(encodeString(item.text));
-  }
-  return Buffer.concat(parts);
-}
-
-export function buildCmd44KeyedSingleStringListPacket(
-  listId: number,
-  title: string,
-  items: Cmd44KeyedStringItem[],
-  seq = 0,
-): Buffer {
-  return buildGamePacket(44, buildCmd44KeyedSingleStringListArgs(listId, title, items), false, seq);
-}
+// v1.29 migration warning:
+//   v1.23's Cmd44_KeyedSingleStringList was repurposed to
+//   World_Cmd44_SetLocationDistanceScale_v129. This server targets v1.29 and
+//   intentionally does not expose the old Cmd44 list builder.
 
 // ── Command 36 — Read / Reply message view (server→client) ──────────────────
 // CONFIRMED from MPBTWIN.EXE FUN_004161a0:

--- a/src/protocol/world.ts
+++ b/src/protocol/world.ts
@@ -478,28 +478,10 @@ export function buildCmd58SetScrollListIdPacket(listId: number, seq = 0): Buffer
   return buildGamePacket(58, encodeB85_1(listId), false, seq);
 }
 
-// ── Cmd 46 — Rich Info Panel ──────────────────────────────────────────────────
-// Strong current RE fit for richer Solaris ranking/personnel detail.
-//
-// Wire args:
-//   [type4: id]
-//   [type3: battles to date]
-//   [type4: legacy/unused]
-//   [type4: legacy/unused]
-//   [Frame_ReadArg × 6: detail lines]
-//
-// Current best-fit assumption: same payload layout as Cmd14, but routed to the
-// richer info-panel handler family (`World_HandleInfoPanelPacket_v123`).
-
-export interface Cmd46InfoPanelOptions extends Cmd14PersonnelRecordOptions {}
-
-/** Build a Cmd46 rich info-panel packet. */
-export function buildCmd46InfoPanelPacket(
-  opts: Cmd46InfoPanelOptions,
-  seq = 0,
-): Buffer {
-  return buildGamePacket(46, buildCmd14Args(opts), false, seq);
-}
+// v1.29 migration warning:
+//   v1.23's Cmd46 rich info-panel was repurposed to
+//   World_Cmd46_ClearWorldUiChildren_v129. This server targets v1.29 and
+//   intentionally does not expose the old Cmd46 detail builder.
 
 // ── Cmd 17 — Scene-Action Response Family / Duel Terms ──────────────────────
 // CONFIRMED subtype 3 handler: World_HandleCmd5SceneActionSubtype3_v123 @ 0x0041e5b0.

--- a/src/server-world.ts
+++ b/src/server-world.ts
@@ -54,6 +54,7 @@ import {
 } from './protocol/world.js';
 import { PlayerRegistry, ClientSession } from './state/players.js';
 import { launchRegistry } from './state/launch.js';
+import { replaceSessionForReconnect } from './state/session-replacement.js';
 import { worldResumeRegistry } from './state/world-resume.js';
 import {
   countSavedUnreadMessages,
@@ -200,23 +201,23 @@ async function handleWorldLogin(
   }
 
   if (launch.accountId !== undefined) {
+    session.accountId = launch.accountId;
     const existingSession = players.findActiveSessionByAccountId(launch.accountId, session.id);
     if (existingSession) {
-      connLog.warn(
-        '[world-login] rejected duplicate session for accountId=%d (existingSession=%s phase=%s)',
+      connLog.info(
+        '[world-login] replacing existing session for accountId=%d (existingSession=%s phase=%s -> replacement=%s)',
         launch.accountId,
         existingSession.id.slice(0, 8),
         existingSession.phase,
+        session.id.slice(0, 8),
       );
-      session.socket.destroy();
-      return;
+      replaceSessionForReconnect(existingSession, session.id);
     }
   }
 
-  const accountResume = worldResumeRegistry.consume(launch.accountId, session.username);
+  const accountResume = worldResumeRegistry.consume(session.accountId, session.username);
   const restoredRoomId = accountResume?.worldMapRoomId ?? DEFAULT_MAP_ROOM_ID;
 
-  session.accountId       = launch.accountId;
   session.displayName     = accountResume?.displayName ?? launch.displayName;
   session.allegiance      = accountResume?.allegiance ?? launch.allegiance;
   session.cbills          = accountResume?.cbills ?? launch.cbills;
@@ -1098,14 +1099,25 @@ function handleWorldConnection(socket: net.Socket, players: PlayerRegistry, log:
   });
 
   socket.on('close', () => {
-    connLog.info(
-      '[world] client disconnected (phase=%s, bytes=%d)',
-      session.phase, session.bytesReceived,
-    );
+    if (session.replacedBySessionId) {
+      connLog.info(
+        '[world] client disconnected (phase=%s, bytes=%d, replacedBy=%s)',
+        session.phase,
+        session.bytesReceived,
+        session.replacedBySessionId.slice(0, 8),
+      );
+    } else {
+      connLog.info(
+        '[world] client disconnected (phase=%s, bytes=%d)',
+        session.phase, session.bytesReceived,
+      );
+    }
     savePendingIncomingComstarPrompt(session, connLog, 'disconnect');
     handleArenaCombatDisconnect(players, session, connLog);
     clearSessionDuelState(players, session, connLog, 'player disconnected');
-    worldResumeRegistry.save(session);
+    if (!session.skipWorldResumeSave) {
+      worldResumeRegistry.save(session);
+    }
     if (session.worldInitialized) {
       notifyRoomDeparture(players, session, connLog);
     }

--- a/src/server-world.ts
+++ b/src/server-world.ts
@@ -325,7 +325,7 @@ function handleWorldGameData(
   }
 
   const cmdIdx = payload[2] - 0x21;
-  connLog.info('[world] client seq=%d cmd=%d', seq, cmdIdx);
+  connLog.debug('[world] client seq=%d cmd=%d', seq, cmdIdx);
 
   if (cmdIdx === 3) {
     if (session.worldInitialized) {
@@ -1172,6 +1172,7 @@ function handleWorldConnection(socket: net.Socket, players: PlayerRegistry, log:
     capture.close();
   });
 
+  socket.setNoDelay(true);
   socket.setKeepAlive(true, 15_000);
   if (SOCKET_IDLE_TIMEOUT_MS > 0) {
     socket.setTimeout(SOCKET_IDLE_TIMEOUT_MS);

--- a/src/server.ts
+++ b/src/server.ts
@@ -40,6 +40,7 @@ import { loadMechs } from './data/mechs.js';
 import { buildMechExamineText } from './data/mech-stats.js';
 import { PlayerRegistry, ClientSession } from './state/players.js';
 import { launchRegistry } from './state/launch.js';
+import { replaceSessionForReconnect } from './state/session-replacement.js';
 import { startWorldServer } from './server-world.js';
 import { Logger } from './util/logger.js';
 import { CaptureLogger } from './util/capture.js';
@@ -194,7 +195,16 @@ function handleConnection(socket: net.Socket): void {
   });
 
   socket.on('close', () => {
-    connLog.info('Client disconnected (phase=%s, bytes=%d)', session.phase, session.bytesReceived);
+    if (session.replacedBySessionId) {
+      connLog.info(
+        'Client disconnected (phase=%s, bytes=%d, replacedBy=%s)',
+        session.phase,
+        session.bytesReceived,
+        session.replacedBySessionId.slice(0, 8),
+      );
+    } else {
+      connLog.info('Client disconnected (phase=%s, bytes=%d)', session.phase, session.bytesReceived);
+    }
     players.remove(session.id);
     if (keepaliveTimer !== undefined) {
       clearInterval(keepaliveTimer);
@@ -279,19 +289,19 @@ function handleLogin(
     }
 
     const accountId = authResult.account.id;
+    session.accountId = accountId;
     const existingSession = players.findActiveSessionByAccountId(accountId, session.id);
     if (existingSession) {
-      connLog.warn(
-        '[login] rejected duplicate session for accountId=%d (existingSession=%s phase=%s)',
+      connLog.info(
+        '[login] replacing existing session for accountId=%d (existingSession=%s phase=%s -> replacement=%s)',
         accountId,
         existingSession.id.slice(0, 8),
         existingSession.phase,
+        session.id.slice(0, 8),
       );
-      session.socket.destroy();
-      return;
+      replaceSessionForReconnect(existingSession, session.id);
     }
 
-    session.accountId = accountId;
     session.phase = 'lobby';
 
     if (authResult.created) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -46,11 +46,16 @@ import { Logger } from './util/logger.js';
 import { CaptureLogger } from './util/capture.js';
 import { verifyOrRegister } from './db/accounts.js';
 import { findCharacter, createCharacter, ALLEGIANCES } from './db/characters.js';
-import { ARIES_KEEPALIVE_INTERVAL_MS, SOCKET_IDLE_TIMEOUT_MS } from './config.js';
+import {
+  ARIES_KEEPALIVE_INTERVAL_MS,
+  SOCKET_IDLE_TIMEOUT_MS,
+  MPBT_LOG_LEVEL,
+  MPBT_CAPTURE_ENABLED,
+} from './config.js';
 
 // ── Global state ──────────────────────────────────────────────────────────────
 
-const log = new Logger('server', 'debug', path.join('logs', 'server.log'));
+const log = new Logger('server', MPBT_LOG_LEVEL, path.join('logs', 'server.log'));
 const players = new PlayerRegistry();
 
 // Advertised host sent in REDIRECT packets.
@@ -213,6 +218,7 @@ function handleConnection(socket: net.Socket): void {
   });
 
   // ── TCP keep-alive ──────────────────────────────────────────────────────────
+  socket.setNoDelay(true);
   socket.setKeepAlive(true, 15_000);
   if (SOCKET_IDLE_TIMEOUT_MS > 0) {
     socket.setTimeout(SOCKET_IDLE_TIMEOUT_MS);
@@ -420,7 +426,7 @@ function handleGameData(
   }
 
   const cmdIdx = payload[2] - 0x21;
-  connLog.info('[game] client seq=%d cmd=%d phase=%s', seq, cmdIdx, session.phase);
+  connLog.debug('[game] client seq=%d cmd=%d phase=%s', seq, cmdIdx, session.phase);
 
   if (cmdIdx === 3 && session.phase === 'lobby') {
     // cmd 3 = client-ready signal.
@@ -717,7 +723,11 @@ server.listen(ARIES_PORT, '0.0.0.0', () => {
   log.info('  Hostname: %s', os.hostname());
   log.info('  Protocol: ARIES binary (12-byte header, confirmed by RE)');
   log.info('    play.pcgi server=127.0.0.1:%d', addr.port);
-  log.info('  Captures → captures/    Logs → logs/server.log');
+  log.info('  Log level: %s → logs/server.log', MPBT_LOG_LEVEL.toUpperCase());
+  log.info(
+    '  Packet captures: %s',
+    MPBT_CAPTURE_ENABLED ? 'enabled → captures/' : 'disabled (set MPBT_CAPTURE=1 to enable)',
+  );
   log.info('═══════════════════════════════════════════════════════');
 });
 

--- a/src/state/players.ts
+++ b/src/state/players.ts
@@ -92,6 +92,10 @@ export interface ClientSession {
   id: string;
   /** Authenticated username (empty until auth completes). */
   username: string;
+  /** Session ID of a newer connection that is replacing this one, if any. */
+  replacedBySessionId?: string;
+  /** True when reconnect handoff already persisted the old world snapshot. */
+  skipWorldResumeSave?: boolean;
   /** Current lifecycle phase. */
   phase: SessionPhase;
   /** Current room ID in the world. */
@@ -551,6 +555,7 @@ export class PlayerRegistry {
       session.id !== excludeId &&
       session.accountId === accountId &&
       session.phase !== 'closing' &&
+      session.replacedBySessionId === undefined &&
       !session.socket.destroyed,
     );
   }

--- a/src/state/session-replacement.ts
+++ b/src/state/session-replacement.ts
@@ -1,0 +1,28 @@
+import type { ClientSession } from './players.js';
+import { worldResumeRegistry } from './world-resume.js';
+
+function shouldPreserveWorldResume(session: ClientSession): boolean {
+  return (
+    session.worldMapRoomId !== undefined
+    || session.pendingDuelSettlementNotice !== undefined
+    || session.phase === 'world'
+    || session.phase === 'combat'
+  );
+}
+
+export function replaceSessionForReconnect(
+  existingSession: ClientSession,
+  replacementSessionId: string,
+): void {
+  if (existingSession.socket.destroyed || existingSession.replacedBySessionId !== undefined) {
+    return;
+  }
+
+  if (shouldPreserveWorldResume(existingSession)) {
+    worldResumeRegistry.save(existingSession);
+    existingSession.skipWorldResumeSave = true;
+  }
+
+  existingSession.replacedBySessionId = replacementSessionId;
+  existingSession.socket.destroy();
+}

--- a/src/util/capture.ts
+++ b/src/util/capture.ts
@@ -17,14 +17,19 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { hexDump } from '../protocol/aries.js';
+import { MPBT_CAPTURE_ENABLED } from '../config.js';
 
 const CAPTURE_DIR = path.join(process.cwd(), 'captures');
 
 export class CaptureLogger {
-  private stream: fs.WriteStream;
+  private stream: fs.WriteStream | null = null;
   private packetIndex = 0;
 
   constructor(sessionId: string) {
+    if (!MPBT_CAPTURE_ENABLED) {
+      return;
+    }
+
     fs.mkdirSync(CAPTURE_DIR, { recursive: true });
     const filename = `${Date.now()}_${sessionId}.txt`;
     this.stream = fs.createWriteStream(path.join(CAPTURE_DIR, filename), {
@@ -39,6 +44,7 @@ export class CaptureLogger {
   }
 
   logRecv(payload: Buffer, streamOffset: number): void {
+    if (!this.stream) return;
     const header =
       `=== RECV #${this.packetIndex++} offset=${streamOffset} len=${payload.length} ` +
       `time=${new Date().toISOString()} ===\n`;
@@ -46,6 +52,7 @@ export class CaptureLogger {
   }
 
   logSend(payload: Buffer, label?: string): void {
+    if (!this.stream) return;
     const labelSuffix = label ? ` label=${label}` : '';
     const header =
       `=== SEND #${this.packetIndex++}${labelSuffix} len=${payload.length} ` +
@@ -54,6 +61,7 @@ export class CaptureLogger {
   }
 
   close(): void {
+    if (!this.stream) return;
     this.stream.write(`# Session ended: ${new Date().toISOString()}\n`);
     this.stream.end();
   }

--- a/src/world/combat-config.ts
+++ b/src/world/combat-config.ts
@@ -19,10 +19,10 @@ export const BOT_INITIAL_HEALTH = 100;
  */
 export const COMBAT_WORLD_UNITS_PER_METER = 100;
 
-/** Initial shared remote-actor stand-off distance in combat world units (1000m north). */
-export const BOT_SPAWN_DISTANCE = 1_000 * COMBAT_WORLD_UNITS_PER_METER;
+/** Initial shared remote-actor stand-off distance in combat world units (3000m north). */
+export const BOT_SPAWN_DISTANCE = 3_000 * COMBAT_WORLD_UNITS_PER_METER;
 
-/** Initial single-player AI-bot stand-off distance in combat world units (1000m north). */
+/** Initial single-player AI-bot stand-off distance in combat world units (3000m north). */
 export const BOT_AI_SPAWN_DISTANCE = BOT_SPAWN_DISTANCE;
 
 /**

--- a/src/world/world-handlers.ts
+++ b/src/world/world-handlers.ts
@@ -7,8 +7,8 @@
  */
 
 import {
+  buildCmd14PersonnelRecordPacket,
   buildCmd3BroadcastPacket,
-  buildCmd46InfoPanelPacket,
   buildCmd17DuelTermsPacket,
   buildCmd4SceneInitPacket,
   buildCmd5CursorNormalPacket,
@@ -374,7 +374,6 @@ const LEG_SECTION_LABEL_BY_INTERNAL_INDEX: Readonly<Record<number, string>> = {
   5: 'left-leg',
   6: 'right-leg',
 };
-const WEAPON_STATE_READY = 0;
 const WEAPON_STATE_UNAVAILABLE = 1;
 const PLAYER_RESULT_DELAY_MS = 750;
 const BOT_RESULT_DELAY_MS = 1500;
@@ -403,15 +402,30 @@ const LEFT_TORSO_FRONT_RETALIATION_SECTION: CombatAttachmentHitSection = {
   internalIndex: 2,
   label: 'left-torso-front',
 };
+const LEFT_TORSO_REAR_RETALIATION_SECTION: CombatAttachmentHitSection = {
+  armorIndex: 8,
+  internalIndex: 2,
+  label: 'left-torso-rear',
+};
 const CENTER_TORSO_FRONT_RETALIATION_SECTION: CombatAttachmentHitSection = {
   armorIndex: 4,
   internalIndex: 4,
   label: 'center-torso-front',
 };
+const CENTER_TORSO_REAR_RETALIATION_SECTION: CombatAttachmentHitSection = {
+  armorIndex: 7,
+  internalIndex: 4,
+  label: 'center-torso-rear',
+};
 const RIGHT_TORSO_FRONT_RETALIATION_SECTION: CombatAttachmentHitSection = {
   armorIndex: 6,
   internalIndex: 3,
   label: 'right-torso-front',
+};
+const RIGHT_TORSO_REAR_RETALIATION_SECTION: CombatAttachmentHitSection = {
+  armorIndex: 9,
+  internalIndex: 3,
+  label: 'right-torso-rear',
 };
 const LEFT_LEG_RETALIATION_SECTION: CombatAttachmentHitSection = {
   armorIndex: 2,
@@ -1662,16 +1676,20 @@ function sendRankingInfoPanel(
     classKey?: SolarisClassKey;
   },
 ): void {
+  const packetOptions = {
+    comstarId: standing.comstarId,
+    battlesToDate: standing.matches,
+    lines: buildRankingInfoPanelLines(standing, latestResult, context),
+  };
+
+  // v1.29 repurposes world Cmd46 as an explicit UI-clear/browser-child teardown
+  // packet. Cmd14 keeps the same detail payload shape and is the v1.29-safe
+  // ranking-detail surface.
+  const packet = buildCmd14PersonnelRecordPacket(packetOptions, nextSeq(session));
+
   send(
     session.socket,
-    buildCmd46InfoPanelPacket(
-      {
-        comstarId: standing.comstarId,
-        battlesToDate: standing.matches,
-        lines: buildRankingInfoPanelLines(standing, latestResult, context),
-      },
-      nextSeq(session),
-    ),
+    packet,
     capture,
     label,
   );
@@ -2058,6 +2076,12 @@ const LOCAL_RETALIATION_SECTIONS: readonly CombatAttachmentHitSection[] = [
 type DamageCodeUpdate = { damageCode: number; damageValue: number };
 type DestroyedLegSection = { internalIndex: number; label: string };
 type PostDamageStateUpdates = { updates: DamageCodeUpdate[]; newlyDestroyedLegs: DestroyedLegSection[] };
+type AppliedWeaponDamageResult = {
+  updates: DamageCodeUpdate[];
+  headArmor: number;
+  hitSections: CombatAttachmentHitSection[];
+  headInternalDamaged: boolean;
+};
 
 function sumValues(values: readonly number[]): number {
   return values.reduce((sum, value) => sum + value, 0);
@@ -2628,16 +2652,19 @@ function getWeaponSectionLossUpdates(
 function getShotDamageForMechSlot(
   mechId: number | undefined,
   weaponSlot: number,
-): { damage: number; weaponName?: string } {
+): { damage: number; weaponName?: string; weaponSpec?: WeaponDataSpec; weaponTypeId?: number } {
   const weaponName = getWeaponNameForMechSlot(mechId, weaponSlot);
+  const weaponTypeId = getWeaponTypeIdForMechSlot(mechId, weaponSlot);
   const weaponSpec = getWeaponSpecForMechSlot(mechId, weaponSlot);
   return {
     damage: weaponSpec?.damage ?? BOT_FALLBACK_WEAPON_DAMAGE,
     weaponName,
+    weaponSpec,
+    weaponTypeId,
   };
 }
 
-function getShotDamage(session: ClientSession, weaponSlot: number): { damage: number; weaponName?: string } {
+function getShotDamage(session: ClientSession, weaponSlot: number): { damage: number; weaponName?: string; weaponSpec?: WeaponDataSpec; weaponTypeId?: number } {
   return getShotDamageForMechSlot(session.selectedMechId ?? FALLBACK_MECH_ID, weaponSlot);
 }
 
@@ -3312,31 +3339,6 @@ function getWeaponCooldownGate(
   );
 }
 
-function sendLocalWeaponStateUpdate(
-  session: ClientSession,
-  weaponSlot: number,
-  weaponState: number,
-  label: string,
-): void {
-  sendToWorldSession(
-    session,
-    buildCmd67LocalDamagePacket(0x28 + weaponSlot, weaponState, nextSeq(session)),
-    label,
-  );
-}
-
-function sendLocalAmmoStateUpdate(
-  session: ClientSession,
-  damageCode: number,
-  ammoValue: number,
-): void {
-  sendToWorldSession(
-    session,
-    buildCmd67LocalDamagePacket(damageCode, ammoValue, nextSeq(session)),
-    'CMD67_LOCAL_AMMO_UPDATE',
-  );
-}
-
 function consumeWeaponAmmo(
   session: ClientSession,
   weaponSlot: number,
@@ -3404,8 +3406,8 @@ function markWeaponSlotFired(
     clearTimeout(existingTimer);
   }
 
-  sendLocalWeaponStateUpdate(session, weaponSlot, WEAPON_STATE_UNAVAILABLE, 'CMD67_LOCAL_WEAPON_COOLDOWN');
-
+  // Retail updates the local actor's weapon/ammo HUD state inside the client's
+  // own fire gate. We keep the timer only for server-side rejection logic.
   const readyTimer = setTimeout(() => {
     if (session.combatWeaponReadyTimerBySlot) {
       session.combatWeaponReadyTimerBySlot[weaponSlot] = undefined;
@@ -3432,7 +3434,6 @@ function markWeaponSlotFired(
     if (!mountGate.allowed) {
       return;
     }
-    sendLocalWeaponStateUpdate(session, weaponSlot, WEAPON_STATE_READY, 'CMD67_LOCAL_WEAPON_READY');
   }, cooldownMs);
   readyTimer.unref();
   session.combatWeaponReadyTimerBySlot[weaponSlot] = readyTimer;
@@ -3677,6 +3678,280 @@ function resolveEffectiveHitSection(
     hitSection = { armorIndex: 4, internalIndex: 4, label: 'ct-front-spill' };
   }
   return hitSection;
+}
+
+function sectionsMatch(
+  a: CombatAttachmentHitSection,
+  b: CombatAttachmentHitSection,
+): boolean {
+  return a.armorIndex === b.armorIndex && a.internalIndex === b.internalIndex;
+}
+
+function getMissileSpreadFallbackSection(primaryHitSection: CombatAttachmentHitSection): CombatAttachmentHitSection {
+  if (
+    sectionsMatch(primaryHitSection, LEFT_TORSO_REAR_RETALIATION_SECTION)
+    || sectionsMatch(primaryHitSection, CENTER_TORSO_REAR_RETALIATION_SECTION)
+    || sectionsMatch(primaryHitSection, RIGHT_TORSO_REAR_RETALIATION_SECTION)
+  ) {
+    return CENTER_TORSO_REAR_RETALIATION_SECTION;
+  }
+  if (shouldSpillUpperBodyHitToCenter(primaryHitSection)) {
+    return CENTER_TORSO_FRONT_RETALIATION_SECTION;
+  }
+  return primaryHitSection;
+}
+
+function getMissileSpreadCandidates(
+  primaryHitSection: CombatAttachmentHitSection,
+  spreadSeed: number,
+): readonly CombatAttachmentHitSection[] {
+  const preferRight = (spreadSeed & 1) !== 0;
+  const frontTorsoA = preferRight ? RIGHT_TORSO_FRONT_RETALIATION_SECTION : LEFT_TORSO_FRONT_RETALIATION_SECTION;
+  const frontTorsoB = preferRight ? LEFT_TORSO_FRONT_RETALIATION_SECTION : RIGHT_TORSO_FRONT_RETALIATION_SECTION;
+  const rearTorsoA = preferRight ? RIGHT_TORSO_REAR_RETALIATION_SECTION : LEFT_TORSO_REAR_RETALIATION_SECTION;
+  const rearTorsoB = preferRight ? LEFT_TORSO_REAR_RETALIATION_SECTION : RIGHT_TORSO_REAR_RETALIATION_SECTION;
+  const frontArmA = preferRight ? RIGHT_ARM_RETALIATION_SECTION : LEFT_ARM_RETALIATION_SECTION;
+  const frontArmB = preferRight ? LEFT_ARM_RETALIATION_SECTION : RIGHT_ARM_RETALIATION_SECTION;
+  const frontLegA = preferRight ? RIGHT_LEG_RETALIATION_SECTION : LEFT_LEG_RETALIATION_SECTION;
+  const frontLegB = preferRight ? LEFT_LEG_RETALIATION_SECTION : RIGHT_LEG_RETALIATION_SECTION;
+
+  if (sectionsMatch(primaryHitSection, HEAD_RETALIATION_SECTION)) {
+    return [
+      HEAD_RETALIATION_SECTION,
+      HEAD_RETALIATION_SECTION,
+      CENTER_TORSO_FRONT_RETALIATION_SECTION,
+      frontTorsoA,
+      frontTorsoB,
+    ];
+  }
+  if (sectionsMatch(primaryHitSection, LEFT_ARM_RETALIATION_SECTION)) {
+    return [
+      LEFT_ARM_RETALIATION_SECTION,
+      LEFT_ARM_RETALIATION_SECTION,
+      LEFT_TORSO_FRONT_RETALIATION_SECTION,
+      LEFT_TORSO_FRONT_RETALIATION_SECTION,
+      CENTER_TORSO_FRONT_RETALIATION_SECTION,
+    ];
+  }
+  if (sectionsMatch(primaryHitSection, RIGHT_ARM_RETALIATION_SECTION)) {
+    return [
+      RIGHT_ARM_RETALIATION_SECTION,
+      RIGHT_ARM_RETALIATION_SECTION,
+      RIGHT_TORSO_FRONT_RETALIATION_SECTION,
+      RIGHT_TORSO_FRONT_RETALIATION_SECTION,
+      CENTER_TORSO_FRONT_RETALIATION_SECTION,
+    ];
+  }
+  if (sectionsMatch(primaryHitSection, LEFT_TORSO_FRONT_RETALIATION_SECTION)) {
+    return [
+      LEFT_TORSO_FRONT_RETALIATION_SECTION,
+      LEFT_TORSO_FRONT_RETALIATION_SECTION,
+      LEFT_ARM_RETALIATION_SECTION,
+      CENTER_TORSO_FRONT_RETALIATION_SECTION,
+      LEFT_LEG_RETALIATION_SECTION,
+      HEAD_RETALIATION_SECTION,
+    ];
+  }
+  if (sectionsMatch(primaryHitSection, CENTER_TORSO_FRONT_RETALIATION_SECTION)) {
+    return [
+      CENTER_TORSO_FRONT_RETALIATION_SECTION,
+      CENTER_TORSO_FRONT_RETALIATION_SECTION,
+      frontTorsoA,
+      frontTorsoB,
+      HEAD_RETALIATION_SECTION,
+      frontArmA,
+      frontArmB,
+      frontLegA,
+      frontLegB,
+    ];
+  }
+  if (sectionsMatch(primaryHitSection, RIGHT_TORSO_FRONT_RETALIATION_SECTION)) {
+    return [
+      RIGHT_TORSO_FRONT_RETALIATION_SECTION,
+      RIGHT_TORSO_FRONT_RETALIATION_SECTION,
+      RIGHT_ARM_RETALIATION_SECTION,
+      CENTER_TORSO_FRONT_RETALIATION_SECTION,
+      RIGHT_LEG_RETALIATION_SECTION,
+      HEAD_RETALIATION_SECTION,
+    ];
+  }
+  if (sectionsMatch(primaryHitSection, LEFT_LEG_RETALIATION_SECTION)) {
+    return [
+      LEFT_LEG_RETALIATION_SECTION,
+      LEFT_LEG_RETALIATION_SECTION,
+      LEFT_TORSO_FRONT_RETALIATION_SECTION,
+      CENTER_TORSO_FRONT_RETALIATION_SECTION,
+    ];
+  }
+  if (sectionsMatch(primaryHitSection, RIGHT_LEG_RETALIATION_SECTION)) {
+    return [
+      RIGHT_LEG_RETALIATION_SECTION,
+      RIGHT_LEG_RETALIATION_SECTION,
+      RIGHT_TORSO_FRONT_RETALIATION_SECTION,
+      CENTER_TORSO_FRONT_RETALIATION_SECTION,
+    ];
+  }
+  if (sectionsMatch(primaryHitSection, LEFT_TORSO_REAR_RETALIATION_SECTION)) {
+    return [
+      LEFT_TORSO_REAR_RETALIATION_SECTION,
+      LEFT_TORSO_REAR_RETALIATION_SECTION,
+      CENTER_TORSO_REAR_RETALIATION_SECTION,
+      LEFT_TORSO_FRONT_RETALIATION_SECTION,
+      LEFT_ARM_RETALIATION_SECTION,
+      LEFT_LEG_RETALIATION_SECTION,
+    ];
+  }
+  if (sectionsMatch(primaryHitSection, CENTER_TORSO_REAR_RETALIATION_SECTION)) {
+    return [
+      CENTER_TORSO_REAR_RETALIATION_SECTION,
+      CENTER_TORSO_REAR_RETALIATION_SECTION,
+      rearTorsoA,
+      rearTorsoB,
+      HEAD_RETALIATION_SECTION,
+      frontTorsoA,
+      frontTorsoB,
+    ];
+  }
+  if (sectionsMatch(primaryHitSection, RIGHT_TORSO_REAR_RETALIATION_SECTION)) {
+    return [
+      RIGHT_TORSO_REAR_RETALIATION_SECTION,
+      RIGHT_TORSO_REAR_RETALIATION_SECTION,
+      CENTER_TORSO_REAR_RETALIATION_SECTION,
+      RIGHT_TORSO_FRONT_RETALIATION_SECTION,
+      RIGHT_ARM_RETALIATION_SECTION,
+      RIGHT_LEG_RETALIATION_SECTION,
+    ];
+  }
+  return [primaryHitSection];
+}
+
+function getMissileSpreadSeed(
+  weaponSlot: number,
+  targetAttach: number,
+  angleSeedA: number,
+  angleSeedB: number,
+): number {
+  const attachSeed = Math.max(0, targetAttach);
+  return (
+    ((weaponSlot + 1) * 97)
+    ^ ((attachSeed + 1) * 193)
+    ^ ((angleSeedA + 1) * 389)
+    ^ ((angleSeedB + 1) * 769)
+  ) >>> 0;
+}
+
+function chooseMissileClusterHitSection(
+  primaryHitSection: CombatAttachmentHitSection,
+  spreadSeed: number,
+  clusterIndex: number,
+  armorValues: readonly number[],
+  internalValues: readonly number[],
+  headArmor: number,
+): CombatAttachmentHitSection {
+  if (
+    clusterIndex === 0
+    && getSectionRemainingDurability(armorValues, internalValues, headArmor, primaryHitSection) > 0
+  ) {
+    return primaryHitSection;
+  }
+
+  const candidates = getMissileSpreadCandidates(primaryHitSection, spreadSeed);
+  const startIndex = clusterIndex <= 0
+    ? 0
+    : (spreadSeed + clusterIndex - 1) % candidates.length;
+  for (let offset = 0; offset < candidates.length; offset += 1) {
+    const candidate = candidates[(startIndex + offset) % candidates.length] ?? primaryHitSection;
+    if (getSectionRemainingDurability(armorValues, internalValues, headArmor, candidate) > 0) {
+      return candidate;
+    }
+  }
+
+  return getMissileSpreadFallbackSection(primaryHitSection);
+}
+
+function summarizeHitSections(hitSections: readonly CombatAttachmentHitSection[]): string {
+  const counts = new Map<string, number>();
+  for (const section of hitSections) {
+    counts.set(section.label, (counts.get(section.label) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([label, count]) => count > 1 ? `${label}x${count}` : label)
+    .join('+');
+}
+
+function applyWeaponDamage(
+  weaponSpec: WeaponDataSpec | undefined,
+  shotDamage: number,
+  primaryHitSection: CombatAttachmentHitSection,
+  weaponSlot: number,
+  targetAttach: number,
+  angleSeedA: number,
+  angleSeedB: number,
+  armorValues: number[],
+  internalValues: number[],
+  headArmor: number,
+): AppliedWeaponDamageResult {
+  const missileCount = weaponSpec?.missileCount ?? 0;
+  const damagePerMissile = weaponSpec?.damagePerMissile ?? 0;
+  if (
+    missileCount <= 1
+    || damagePerMissile <= 0
+    || missileCount * damagePerMissile !== shotDamage
+  ) {
+    const damageResult = applyDamageToSection(
+      armorValues,
+      internalValues,
+      primaryHitSection,
+      shotDamage,
+      headArmor,
+    );
+    return {
+      updates: damageResult.updates,
+      headArmor: damageResult.headArmor,
+      hitSections: [primaryHitSection],
+      headInternalDamaged: damageResult.updates.some(update => update.damageCode === 0x27),
+    };
+  }
+
+  const spreadSeed = getMissileSpreadSeed(weaponSlot, targetAttach, angleSeedA, angleSeedB);
+  const updates: DamageCodeUpdate[] = [];
+  const hitSections: CombatAttachmentHitSection[] = [];
+  let nextHeadArmor = headArmor;
+  let headInternalDamaged = false;
+  for (let clusterIndex = 0; clusterIndex < missileCount; clusterIndex += 1) {
+    const hitSection = chooseMissileClusterHitSection(
+      primaryHitSection,
+      spreadSeed,
+      clusterIndex,
+      armorValues,
+      internalValues,
+      nextHeadArmor,
+    );
+    const damageResult = applyDamageToSection(
+      armorValues,
+      internalValues,
+      hitSection,
+      damagePerMissile,
+      nextHeadArmor,
+    );
+    nextHeadArmor = damageResult.headArmor;
+    if (damageResult.updates.length > 0 || clusterIndex === 0) {
+      hitSections.push(hitSection);
+    }
+    if (damageResult.updates.length > 0) {
+      updates.push(...damageResult.updates);
+      if (!headInternalDamaged && damageResult.updates.some(update => update.damageCode === 0x27)) {
+        headInternalDamaged = true;
+      }
+    }
+  }
+
+  return {
+    updates,
+    headArmor: nextHeadArmor,
+    hitSections: hitSections.length > 0 ? hitSections : [primaryHitSection],
+    headInternalDamaged,
+  };
 }
 
 function getBotMechId(session: ClientSession): number {
@@ -4981,9 +5256,8 @@ function sendBotDeathTransition(
     session.botDeathTimer = undefined;
   }
 
-  // Dynamic test result: subcommand 1 leaves the dead bot upright in the v1.23
-  // client, so try 8 as the pre-wreck collapse trigger before the confirmed 4
-  // wreck transition.
+  // Retail v1.23 death flow uses Cmd70 subcommand 8 to start the collapse and
+  // then subcommand 0 to advance the actor through the destruction tail.
   connLog.info('[world/combat] bot destroyed — sending collapse transition (%s)', reason);
   send(
     session.socket,
@@ -4995,12 +5269,12 @@ function sendBotDeathTransition(
   session.botDeathTimer = setTimeout(() => {
     session.botDeathTimer = undefined;
     if (session.socket.destroyed || !session.socket.writable || session.phase !== 'combat') return;
-    connLog.info('[world/combat] bot wreck transition after fall (%s)', reason);
+    connLog.info('[world/combat] bot death-tail advance after collapse (%s)', reason);
     send(
       session.socket,
-      buildCmd70ActorTransitionPacket(1, 4, nextSeq(session)),
+      buildCmd70ActorTransitionPacket(1, 0, nextSeq(session)),
       capture,
-      'CMD70_BOT_WRECK',
+      'CMD70_BOT_DEATH_ADVANCE',
     );
   }, 1200);
   session.botDeathTimer.unref();
@@ -5768,8 +6042,8 @@ function sendArenaParticipantDeathTransition(
       }
       sendToWorldSession(
         viewer,
-        buildCmd70ActorTransitionPacket(slot, 4, nextSeq(viewer)),
-        viewer.id === eliminated.id ? 'CMD70_ARENA_LOCAL_WRECK' : 'CMD70_ARENA_REMOTE_WRECK',
+        buildCmd70ActorTransitionPacket(slot, 0, nextSeq(viewer)),
+        viewer.id === eliminated.id ? 'CMD70_ARENA_LOCAL_DEATH_ADVANCE' : 'CMD70_ARENA_REMOTE_DEATH_ADVANCE',
       );
     }
     eliminated.botDeathTimer = undefined;
@@ -6048,15 +6322,15 @@ function sendDuelDeathTransition(
     if (!winner.socket.destroyed && winner.socket.writable && winner.phase === 'combat') {
       sendToWorldSession(
         winner,
-        buildCmd70ActorTransitionPacket(1, 4, nextSeq(winner)),
-        'CMD70_DUEL_REMOTE_WRECK',
+        buildCmd70ActorTransitionPacket(1, 0, nextSeq(winner)),
+        'CMD70_DUEL_REMOTE_DEATH_ADVANCE',
       );
     }
     if (!loser.socket.destroyed && loser.socket.writable && loser.phase === 'combat') {
       sendToWorldSession(
         loser,
-        buildCmd70ActorTransitionPacket(0, 4, nextSeq(loser)),
-        'CMD70_DUEL_LOCAL_WRECK',
+        buildCmd70ActorTransitionPacket(0, 0, nextSeq(loser)),
+        'CMD70_DUEL_LOCAL_DEATH_ADVANCE',
       );
     }
     winner.botDeathTimer = undefined;
@@ -9094,24 +9368,9 @@ export function handleCombatMovementFrame(
     session.combatTorsoYaw = legVel;
     session.combatSpeedMag = nextPosition.speedMag;
 
-    connLog.debug(
-      '[world/combat] cmd9 moving: altitude=%d facingRaw=%d pitchRaw=%d torsoYawRaw=%d clientSpeed=%d effectiveSpeed=%d pitch=%d torsoYaw=%d%s',
-      frame.altitudeRaw,
-      frame.facingRaw,
-      frame.upperBodyPitchRaw,
-      frame.torsoYawRaw,
-      clientSpeed,
-      nextPosition.speedMag,
-      throttle,
-      legVel,
-      nextPosition.clamped
-        ? ` reverseClamp elapsed=${nextPosition.elapsedMs ?? 0}ms submitted=${nextPosition.submittedDistanceUnits ?? 0} allowed=${nextPosition.maxDistanceUnits ?? 0}`
-        : '',
-    );
-
     if (session.combatSuppressLocalCmd65WhileDowned && session.combatLocalDowned) {
       connLog.debug('[world/combat] cmd9 moving: suppressing local Cmd65 movement echo while local downed verifier is active');
-    } else {
+    } else if (nextPosition.clamped) {
       send(
         session.socket,
         buildCmd65PositionSyncPacket(
@@ -9128,9 +9387,27 @@ export function handleCombatMovementFrame(
           nextSeq(session),
         ),
         capture,
-        'CMD65_MOVEMENT',
+        'CMD65_MOVEMENT_CORRECTION',
       );
     }
+    const localEchoDetail =
+      session.combatSuppressLocalCmd65WhileDowned && session.combatLocalDowned
+        ? ' localEcho=suppressed-while-downed'
+        : nextPosition.clamped
+          ? ` localEcho=correction elapsed=${nextPosition.elapsedMs ?? 0}ms submitted=${nextPosition.submittedDistanceUnits ?? 0} allowed=${nextPosition.maxDistanceUnits ?? 0}`
+          : ' localEcho=none';
+    connLog.debug(
+      '[world/combat] cmd9 moving: altitude=%d facingRaw=%d pitchRaw=%d torsoYawRaw=%d clientSpeed=%d effectiveSpeed=%d pitch=%d torsoYaw=%d%s',
+      frame.altitudeRaw,
+      frame.facingRaw,
+      frame.upperBodyPitchRaw,
+      frame.torsoYawRaw,
+      clientSpeed,
+      nextPosition.speedMag,
+      throttle,
+      legVel,
+      localEchoDetail,
+    );
     mirrorCombatRemotePosition(players, session, 'CMD65_COMBAT_REMOTE_MOVEMENT');
     maybeLogCollisionProbeCandidate(players, session, connLog, 'CMD9_MOVEMENT');
   }
@@ -9207,9 +9484,6 @@ export function handleCombatWeaponFireFrame(
     }
 
     fireableShots.push(shot);
-    if (ammoGate.damageCode !== undefined && ammoGate.remainingAmmo !== undefined) {
-      sendLocalAmmoStateUpdate(session, ammoGate.damageCode, ammoGate.remainingAmmo);
-    }
     markWeaponSlotFired(session, shot.weaponSlot, cooldownGate.cooldownMs, now);
   }
   const rejectedWeaponStateShots = shots.length - fireableShots.length;
@@ -9260,7 +9534,7 @@ export function handleCombatWeaponFireFrame(
     let totalDamageUpdates = 0;
 
     for (const shot of fireableShots) {
-      const { damage: shotDamage, weaponName } = getShotDamage(session, shot.weaponSlot);
+      const { damage: shotDamage, weaponName, weaponSpec } = getShotDamage(session, shot.weaponSlot);
       const rangeGate = getShotMaxRangeGate(
         session,
         shot.weaponSlot,
@@ -9328,11 +9602,16 @@ export function handleCombatWeaponFireFrame(
         impactContext,
       );
       const previousInternalValues = [...duelPeerInternalValues];
-      const damageResult = applyDamageToSection(
+      const damageResult = applyWeaponDamage(
+        weaponSpec,
+        shotDamage,
+        hitSection,
+        shot.weaponSlot,
+        shot.targetAttach,
+        shot.angleSeedA,
+        shot.angleSeedB,
         duelPeerArmorValues,
         duelPeerInternalValues,
-        hitSection,
-        shotDamage,
         duelPeerHeadArmor,
       );
       const postDamageUpdates = collectPostDamageStateUpdates(
@@ -9340,7 +9619,7 @@ export function handleCombatWeaponFireFrame(
         duelPeerCriticalStateBytes,
         previousInternalValues,
         duelPeerInternalValues,
-        hitSection.internalIndex === 7 && damageResult.updates.some(update => update.damageCode === 0x27),
+        damageResult.headInternalDamaged,
       );
       duelPeerHeadArmor = damageResult.headArmor;
       const allUpdates = [...damageResult.updates, ...postDamageUpdates.updates];
@@ -9366,7 +9645,7 @@ export function handleCombatWeaponFireFrame(
 
       totalDamageUpdates += allUpdates.length;
       shotSummaries.push(
-        `${shot.weaponSlot}:${weaponName ?? 'unknown'}:${shotDamage}:${hitSection.label}:mech=${duelPeerMechId}:model=${getCombatModelIdForMechId(duelPeerMechId) ?? 'n/a'}:attach=${shot.targetAttach}:peerHealth=${duelPeer.playerHealth ?? 'n/a'}:headArmor=${duelPeerHeadArmor}:updates=${allUpdates.map(update => `0x${update.damageCode.toString(16)}=${update.damageValue}`).join('/') || 'none'}${getModel13AttachProbeSuffix(duelPeerMechId, shot.targetAttach, impactContext)}`,
+        `${shot.weaponSlot}:${weaponName ?? 'unknown'}:${shotDamage}:${summarizeHitSections(damageResult.hitSections)}:mech=${duelPeerMechId}:model=${getCombatModelIdForMechId(duelPeerMechId) ?? 'n/a'}:attach=${shot.targetAttach}:peerHealth=${duelPeer.playerHealth ?? 'n/a'}:headArmor=${duelPeerHeadArmor}:updates=${allUpdates.map(update => `0x${update.damageCode.toString(16)}=${update.damageValue}`).join('/') || 'none'}${getModel13AttachProbeSuffix(duelPeerMechId, shot.targetAttach, impactContext)}`,
       );
     }
 
@@ -9423,7 +9702,7 @@ export function handleCombatWeaponFireFrame(
     const eliminatedParticipants = new Map<string, ClientSession>();
 
     for (const shot of fireableShots) {
-      const { damage: shotDamage, weaponName } = getShotDamage(session, shot.weaponSlot);
+      const { damage: shotDamage, weaponName, weaponSpec } = getShotDamage(session, shot.weaponSlot);
       const target = getCombatTargetParticipantForViewerSlot(players, combatSession, session, shot.targetSlot);
       const targetActive = !!target
         && !target.socket.destroyed
@@ -9507,11 +9786,16 @@ export function handleCombatWeaponFireFrame(
         impactContext,
       );
       const previousInternalValues = [...targetInternalValues];
-      const damageResult = applyDamageToSection(
+      const damageResult = applyWeaponDamage(
+        weaponSpec,
+        shotDamage,
+        hitSection,
+        shot.weaponSlot,
+        shot.targetAttach,
+        shot.angleSeedA,
+        shot.angleSeedB,
         targetArmorValues,
         targetInternalValues,
-        hitSection,
-        shotDamage,
         targetHeadArmor,
       );
       const postDamageUpdates = collectPostDamageStateUpdates(
@@ -9519,7 +9803,7 @@ export function handleCombatWeaponFireFrame(
         targetCriticalStateBytes,
         previousInternalValues,
         targetInternalValues,
-        hitSection.internalIndex === 7 && damageResult.updates.some(update => update.damageCode === 0x27),
+        damageResult.headInternalDamaged,
       );
       targetHeadArmor = damageResult.headArmor;
       const allUpdates = [...damageResult.updates, ...postDamageUpdates.updates];
@@ -9564,7 +9848,7 @@ export function handleCombatWeaponFireFrame(
         );
       }
       shotSummaries.push(
-        `${shot.weaponSlot}:${weaponName ?? 'unknown'}:${shotDamage}:${getDisplayName(target)}:${hitSection.label}:mech=${targetMechId}:model=${targetModelId ?? 'n/a'}:attach=${shot.targetAttach}:health=${target.playerHealth}:updates=${allUpdates.map(update => `0x${update.damageCode.toString(16)}=${update.damageValue}`).join('/') || 'none'}${getModel13AttachProbeSuffix(targetMechId, shot.targetAttach, impactContext)}`,
+        `${shot.weaponSlot}:${weaponName ?? 'unknown'}:${shotDamage}:${getDisplayName(target)}:${summarizeHitSections(damageResult.hitSections)}:mech=${targetMechId}:model=${targetModelId ?? 'n/a'}:attach=${shot.targetAttach}:health=${target.playerHealth}:updates=${allUpdates.map(update => `0x${update.damageCode.toString(16)}=${update.damageValue}`).join('/') || 'none'}${getModel13AttachProbeSuffix(targetMechId, shot.targetAttach, impactContext)}`,
       );
 
       if (isActorDestroyed(targetInternalValues)) {
@@ -9624,8 +9908,7 @@ export function handleCombatWeaponFireFrame(
   let totalDamageUpdates = 0;
 
   for (const shot of fireableShots) {
-    const { damage: shotDamage, weaponName } = getShotDamage(session, shot.weaponSlot);
-    const weaponSpec = getWeaponSpecForSlot(session, shot.weaponSlot);
+    const { damage: shotDamage, weaponName, weaponSpec } = getShotDamage(session, shot.weaponSlot);
     const rangeGate = getShotMaxRangeGate(session, shot.weaponSlot, botX, botY);
     send(
       session.socket,
@@ -9695,11 +9978,16 @@ export function handleCombatWeaponFireFrame(
       impactContext,
     );
     const previousInternalValues = [...botInternalValues];
-    const damageResult = applyDamageToSection(
+    const damageResult = applyWeaponDamage(
+      weaponSpec,
+      shotDamage,
+      hitSection,
+      shot.weaponSlot,
+      shot.targetAttach,
+      shot.angleSeedA,
+      shot.angleSeedB,
       botArmorValues,
       botInternalValues,
-      hitSection,
-      shotDamage,
       botHeadArmor,
     );
     const postDamageUpdates = collectPostDamageStateUpdates(
@@ -9707,7 +9995,7 @@ export function handleCombatWeaponFireFrame(
       botCriticalStateBytes,
       previousInternalValues,
       botInternalValues,
-      hitSection.internalIndex === 7 && damageResult.updates.some(update => update.damageCode === 0x27),
+      damageResult.headInternalDamaged,
     );
     botHeadArmor = damageResult.headArmor;
     const allUpdates = [...damageResult.updates, ...postDamageUpdates.updates];
@@ -9733,7 +10021,7 @@ export function handleCombatWeaponFireFrame(
 
     totalDamageUpdates += allUpdates.length;
     shotSummaries.push(
-      `${shot.weaponSlot}:${weaponName ?? 'unknown'}:${shotDamage}:${hitSection.label}:${shot.targetSlot}/${shot.targetAttach}:chance=${Math.round(hitRoll.chance * 100)}:roll=${Math.round(hitRoll.roll * 100)}:cross=${Math.round(hitRoll.crossingFactor * 100)}:bot=${botX}/${botY}:headArmor=${botHeadArmor}:updates=${allUpdates.map(update => `0x${update.damageCode.toString(16)}=${update.damageValue}`).join('/') || 'none'}${getModel13AttachProbeSuffix(botMechId, shot.targetAttach, impactContext)}`,
+      `${shot.weaponSlot}:${weaponName ?? 'unknown'}:${shotDamage}:${summarizeHitSections(damageResult.hitSections)}:${shot.targetSlot}/${shot.targetAttach}:chance=${Math.round(hitRoll.chance * 100)}:roll=${Math.round(hitRoll.roll * 100)}:cross=${Math.round(hitRoll.crossingFactor * 100)}:bot=${botX}/${botY}:headArmor=${botHeadArmor}:updates=${allUpdates.map(update => `0x${update.damageCode.toString(16)}=${update.damageValue}`).join('/') || 'none'}${getModel13AttachProbeSuffix(botMechId, shot.targetAttach, impactContext)}`,
     );
   }
 
@@ -9918,29 +10206,7 @@ export function handleCombatActionFrame(
     const legVel = session.combatTorsoYaw ?? 0;
     const speedMag = session.combatSpeedMag ?? 0;
 
-    connLog.info('[world/combat] cmd-12 jump action=6 altitude=0 (landing sync)');
-    if (session.combatSuppressLocalCmd65WhileDowned && session.combatLocalDowned) {
-      connLog.info('[world/combat] cmd-12 jump action=6 suppressing local Cmd65 landing echo while local downed verifier is active');
-    } else {
-      send(
-        session.socket,
-        buildCmd65PositionSyncPacket(
-          {
-            slot:     0,
-            x,
-            y,
-            z:        0,
-            facing:   getCombatCmd65Facing(session),
-            throttle,
-            legVel,
-            speedMag,
-          },
-          nextSeq(session),
-        ),
-        capture,
-        'CMD65_JUMP_LAND',
-      );
-    }
+    connLog.info('[world/combat] cmd-12 jump action=6 altitude=0 (client-owned local landing; remote mirror only)');
     mirrorCombatRemotePosition(players, session, 'CMD65_COMBAT_JUMP_LAND');
     maybeLogCollisionProbeCandidate(players, session, connLog, 'CMD65_JUMP_LAND');
     return;

--- a/src/world/world-handlers.ts
+++ b/src/world/world-handlers.ts
@@ -2060,16 +2060,16 @@ export function savePendingIncomingComstarPrompt(
 type CombatResultCode = 0 | 1;
 
 const LOCAL_RETALIATION_SECTIONS: readonly CombatAttachmentHitSection[] = [
-  { armorIndex: 0, internalIndex: 0, label: 'left-arm' },
-  { armorIndex: 5, internalIndex: 2, label: 'left-torso-front' },
-  { armorIndex: 8, internalIndex: 2, label: 'left-torso-rear' },
-  { armorIndex: 4, internalIndex: 4, label: 'center-torso-front' },
-  { armorIndex: 7, internalIndex: 4, label: 'center-torso-rear' },
-  { armorIndex: 6, internalIndex: 3, label: 'right-torso-front' },
-  { armorIndex: 9, internalIndex: 3, label: 'right-torso-rear' },
-  { armorIndex: 1, internalIndex: 1, label: 'right-arm' },
-  { armorIndex: 2, internalIndex: 5, label: 'left-leg' },
-  { armorIndex: 3, internalIndex: 6, label: 'right-leg' },
+  LEFT_ARM_RETALIATION_SECTION,
+  LEFT_TORSO_FRONT_RETALIATION_SECTION,
+  LEFT_TORSO_REAR_RETALIATION_SECTION,
+  CENTER_TORSO_FRONT_RETALIATION_SECTION,
+  CENTER_TORSO_REAR_RETALIATION_SECTION,
+  RIGHT_TORSO_FRONT_RETALIATION_SECTION,
+  RIGHT_TORSO_REAR_RETALIATION_SECTION,
+  RIGHT_ARM_RETALIATION_SECTION,
+  LEFT_LEG_RETALIATION_SECTION,
+  RIGHT_LEG_RETALIATION_SECTION,
   HEAD_RETALIATION_SECTION,
 ] as const;
 
@@ -2652,19 +2652,17 @@ function getWeaponSectionLossUpdates(
 function getShotDamageForMechSlot(
   mechId: number | undefined,
   weaponSlot: number,
-): { damage: number; weaponName?: string; weaponSpec?: WeaponDataSpec; weaponTypeId?: number } {
+): { damage: number; weaponName?: string; weaponSpec?: WeaponDataSpec } {
   const weaponName = getWeaponNameForMechSlot(mechId, weaponSlot);
-  const weaponTypeId = getWeaponTypeIdForMechSlot(mechId, weaponSlot);
   const weaponSpec = getWeaponSpecForMechSlot(mechId, weaponSlot);
   return {
     damage: weaponSpec?.damage ?? BOT_FALLBACK_WEAPON_DAMAGE,
     weaponName,
     weaponSpec,
-    weaponTypeId,
   };
 }
 
-function getShotDamage(session: ClientSession, weaponSlot: number): { damage: number; weaponName?: string; weaponSpec?: WeaponDataSpec; weaponTypeId?: number } {
+function getShotDamage(session: ClientSession, weaponSlot: number): { damage: number; weaponName?: string; weaponSpec?: WeaponDataSpec } {
   return getShotDamageForMechSlot(session.selectedMechId ?? FALLBACK_MECH_ID, weaponSlot);
 }
 

--- a/src/world/world-scene.ts
+++ b/src/world/world-scene.ts
@@ -886,6 +886,7 @@ export function sendPersonnelRecord(
     getDisplayName(target),
     page,
   );
+  const startedAt = Date.now();
   Promise.all([listAllDuelResults(), listCharacters()])
     .then(([results, characters]) => {
       if (session.socket.destroyed || !session.socket.writable) return;
@@ -907,6 +908,12 @@ export function sendPersonnelRecord(
         capture,
         page <= 1 ? 'CMD14_PERSONNEL_P1' : 'CMD14_PERSONNEL_P2',
       );
+      connLog.debug(
+        '[world] Cmd14 personnel record ready in %d ms (results=%d characters=%d)',
+        Date.now() - startedAt,
+        results.length,
+        characters.length,
+      );
     })
     .catch((err: unknown) => {
       const detail = err instanceof Error ? err.message : String(err);
@@ -924,6 +931,10 @@ export function sendPersonnelRecord(
         ),
         capture,
         page <= 1 ? 'CMD14_PERSONNEL_P1' : 'CMD14_PERSONNEL_P2',
+      );
+      connLog.debug(
+        '[world] Cmd14 personnel record fallback sent in %d ms',
+        Date.now() - startedAt,
       );
     });
 }


### PR DESCRIPTION
## Summary

This PR submits all local work accumulated after upstream PR #143, including the v1.29 migration updates and related combat fidelity fixes. It removes v1.23-only world packet builders that are repurposed in v1.29, routes ranking details through a v1.29-safe path, and updates combat behavior and research notes to match current reverse-engineering findings.

## Related Issue

Closes #144

## Type of Change

- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Research finding / protocol update
- [x] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Chore (dependencies, CI, config)

## Implementation Notes

- Removed v1.23-only world packet builder paths that conflict with v1.29 opcode meanings (`Cmd44`, `Cmd46`) and switched ranking detail sends to `Cmd14`.
- Updated combat handling for retail-like missile spread and local weapon-state ownership behavior.
- Added weapon spec metadata needed by the updated missile logic (`missileCount`, `damagePerMissile`).
- Updated combat spawn stand-off distance and refreshed migration/research documentation for v1.29.

## Testing

- `npm run build`

## Checklist

- [x] Branch is based on `master`
- [x] Commit messages follow `type: description` convention (e.g. `fix: correct CRC seed`)
- [x] TypeScript builds cleanly (`npm run build`)
- [x] No debug `console.log` left in production code paths
- [x] `RESEARCH.md` updated if this reflects a new RE finding
- [ ] `symbols.json` updated if new canonical names were introduced
- [x] This PR is ready for review (not a draft)