### PR TITLE
fix: restore Solaris travel fallback

### DIFF
--- a/src/world/world-scene.ts
+++ b/src/world/world-scene.ts
@@ -61,6 +61,7 @@ import {
   COMSTAR_ACCESS_ACTION_TYPE,
   FALLBACK_MECH_ID,
   SOLARIS_TRAVEL_CONTEXT_ID,
+  SOLARIS_TRAVEL_ACTION_TYPE,
   GLOBAL_COMSTAR_MENU_ITEMS,
   worldMapByRoomId,
   WORLD_MECH_BY_ID,
@@ -461,8 +462,8 @@ export function buildSceneInitForSession(session: ClientSession) {
 
   // Room-type-aware action buttons.
   // actionType 4 is reserved for the fixed lower-left world icon path.
-  // Solaris map access now hangs off tram location icons instead of a top-row
-  // Travel button, so only keep room-local actions here.
+  // Solaris map access primarily hangs off tram location icons, but keep a
+  // top-row Travel fallback so players can recover if they get stuck.
   // actionType 5 → "Fight"  (enter combat; handled by cmd-5 dispatch in server-world.ts).
   // actionType 6 → "Mech"/"Mech Bay" (opens the 3-step mech picker).
   // The client hard-codes button 0x100 as a local-only Help slot and only
@@ -475,6 +476,7 @@ export function buildSceneInitForSession(session: ClientSession) {
   const readyRoomLabel = isArena ? getArenaReadyRoomLabelForSession(session) : undefined;
   const arenaOptions: Array<{ type: number; label: string }> = [
     { type: 0, label: 'Help' },
+    { type: SOLARIS_TRAVEL_ACTION_TYPE, label: 'Travel' },
   ];
   if (isArena) {
     arenaOptions.push({ type: 6, label: 'Mech' });

--- a/world-map.json
+++ b/world-map.json
@@ -903,7 +903,7 @@
       "icon": 1,
       "exits": {
         "north": null,
-        "south": null,
+        "south": 2141,
         "west": null,
         "east": null
       },
@@ -1341,18 +1341,18 @@
     },
     {
       "roomId": 2141,
-      "type": "street",
+      "type": "terminal",
       "sector": "blackhills",
       "exits": {
-        "north": null,
+        "north": 170,
         "south": 2142,
         "west": null,
-        "east": null
+        "east": 167
       },
       "_gridCol": 8,
       "_gridRow": 15,
-      "icon": 54,
-      "_name": "Road"
+      "icon": 17,
+      "_name": "Public Data Terminal"
     },
     {
       "roomId": 2140,
@@ -1394,8 +1394,8 @@
       "exits": {
         "north": null,
         "south": null,
-        "west": null,
-        "east": null
+        "west": 2141,
+        "east": 2138
       },
       "_gridCol": 11,
       "_gridRow": 15,
@@ -1404,12 +1404,12 @@
     {
       "roomId": 2138,
       "type": "street",
-      "sector": "silesia",
+      "sector": "blackhills",
       "exits": {
         "north": null,
         "south": null,
-        "west": null,
-        "east": 2137
+        "west": 167,
+        "east": null
       },
       "_gridCol": 12,
       "_gridRow": 15,
@@ -1423,7 +1423,7 @@
       "exits": {
         "north": 2121,
         "south": null,
-        "west": 2138,
+        "west": null,
         "east": null
       },
       "_gridCol": 13,
@@ -1809,7 +1809,7 @@
         "north": 2144,
         "south": null,
         "west": 168,
-        "east": null
+        "east": 2069
       },
       "_gridCol": 6,
       "_gridRow": 18,
@@ -1823,7 +1823,7 @@
       "exits": {
         "north": 169,
         "south": 2068,
-        "west": null,
+        "west": 2143,
         "east": null
       },
       "_gridCol": 8,


### PR DESCRIPTION
## Summary

Restores a visible Solaris `Travel` scene button as a GUI fallback after the v1.29 world-flow changes, so players can reopen the travel map if the tram/location icon path leaves them stuck. Also reconnects the affected fallback `world-map.json` routes around the Black Hills/Silesia edge and restores the public data terminal node so those exits remain usable.

## Related Issue

Closes #149

## Type of Change

- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Research finding / protocol update
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Chore (dependencies, CI, config)

## Implementation Notes

- Reuses the existing `SOLARIS_TRAVEL_ACTION_TYPE` cmd-5 dispatch path; the button opens the existing Cmd43 Solaris travel map and does not replace tram-icon travel.
- Keeps `Help` as the client-local first scene button, then exposes `Travel` before room-local actions such as Mech Bay, Terminal, Side, Status, and Fight.
- Reconnects the Black Hills/Silesia fallback route data and marks room `2141` as the public data terminal with the expected terminal icon.

## Testing

- `npm run build`
- `node -e 'const fs=require("fs"); const data=JSON.parse(fs.readFileSync("world-map.json","utf8")); const ids=new Set(data.rooms.map(r=>r.roomId)); const missing=[]; for (const r of data.rooms) for (const [dir,id] of Object.entries(r.exits||{})) if (id!=null&&!ids.has(id)) missing.push(`${r.roomId}.${dir}->${id}`); if(missing.length){console.error(missing.join("\n")); process.exit(1)} console.log(`world-map.json OK: ${data.rooms.length} rooms, all exits resolve`);'`
- Started the branch locally for live testing on ports `2000`/`2001` after linking the local proprietary game assets into the isolated worktree.

## Checklist

- [x] Branch is based on `master`
- [x] Commit messages follow `type: description` convention (e.g. `fix: correct CRC seed`)
- [x] TypeScript builds cleanly (`npm run build`)
- [x] No debug `console.log` left in production code paths
- [x] `RESEARCH.md` updated if this reflects a new RE finding
- [x] `symbols.json` updated if new canonical names were introduced
- [x] This PR is ready for review (not a draft)