### PR TITLE
Add validated Solaris world map reconstruction workflow

### DIFF
--- a/src/data/maps.ts
+++ b/src/data/maps.ts
@@ -238,9 +238,21 @@ export function loadSolarisRooms(filePath?: string): WorldRoom[] | null {
 
 /**
  * Room type tags used in world-map.json.
- * bar | arena | hub | terminal | bank | street | sector | path
+ * bar | arena | ready_room | drop_room | headquarters | hub | terminal | bank | street | sector | path | tram
  */
-export type RoomType = 'bar' | 'arena' | 'hub' | 'terminal' | 'bank' | 'street' | 'sector' | 'path' | 'tram';
+export type RoomType =
+  | 'bar'
+  | 'arena'
+  | 'ready_room'
+  | 'drop_room'
+  | 'headquarters'
+  | 'hub'
+  | 'terminal'
+  | 'bank'
+  | 'street'
+  | 'sector'
+  | 'path'
+  | 'tram';
 
 /** One entry from world-map.json, representing navigation data for a single room. */
 export interface WorldMapRoom {

--- a/src/world/world-data.ts
+++ b/src/world/world-data.ts
@@ -289,6 +289,9 @@ function isCompatibleSceneAnchor(
       return anchorRoom.type === 'bar';
     case 'arena':
       return anchorRoom.type === 'arena';
+    case 'ready_room':
+    case 'drop_room':
+      return anchorRoom.type === 'arena';
     case 'terminal':
       return anchorRoom.type === 'terminal'
           || anchorRoom.type === 'street'
@@ -300,6 +303,11 @@ function isCompatibleSceneAnchor(
           || anchorRoom.type === 'hub';
     case 'sector':
       return anchorRoom.type === 'sector' || anchorRoom.type === 'hub';
+    case 'headquarters':
+      return anchorRoom.type === 'hub'
+          || anchorRoom.type === 'sector'
+          || anchorRoom.type === 'street'
+          || anchorRoom.type === 'terminal';
     case 'hub':
       return anchorRoom.type === 'hub' || anchorRoom.type === 'sector';
     case 'tram':

--- a/tools/map-editor-grid.html
+++ b/tools/map-editor-grid.html
@@ -415,12 +415,15 @@ makeGrid(GRID_SIZE);
 function setGridSize(size) {
   const safeSize = Math.max(20, Math.ceil(size));
   const sel = document.getElementById('gridSize');
-  let option = [...sel.options].find(opt => parseInt(opt.value) >= safeSize);
+  let option = [...sel.options].find(opt => parseInt(opt.value) === safeSize);
   if (!option) {
     option = document.createElement('option');
     option.value = String(safeSize);
     option.textContent = `${safeSize}×${safeSize}`;
-    sel.appendChild(option);
+    const nextOption = [...sel.options]
+      .map(opt => ({ opt, value: parseInt(opt.value) }))
+      .find(({ value }) => Number.isFinite(value) && value > safeSize)?.opt;
+    sel.insertBefore(option, nextOption ?? null);
   }
   sel.value = option.value;
   makeGrid(parseInt(option.value));
@@ -1122,9 +1125,7 @@ function validateMapRooms(rooms) {
 
     const col = room._gridCol;
     const row = room._gridRow;
-    if (!Number.isFinite(col) || !Number.isFinite(row)) {
-      addIssue(`${roomRef(room)} is not placed on the editor grid.`, [id]);
-    } else {
+    if (Number.isFinite(col) && Number.isFinite(row)) {
       const key = `${col},${row}`;
       const existing = placedCells.get(key);
       if (existing) {

--- a/tools/map-editor-grid.html
+++ b/tools/map-editor-grid.html
@@ -203,6 +203,7 @@
     <option value="30" selected>30×30</option>
     <option value="40">40×40</option>
     <option value="50">50×50</option>
+    <option value="80">80×80</option>
   </select>
 
   <div class="sep"></div>
@@ -250,10 +251,14 @@
           <option value="street">street</option>
           <option value="path">path</option>
           <option value="arena">arena</option>
+          <option value="ready_room">ready_room</option>
+          <option value="drop_room">drop_room</option>
+          <option value="headquarters">headquarters</option>
           <option value="hub">hub</option>
           <option value="terminal">terminal</option>
           <option value="bar">bar</option>
           <option value="sector">sector</option>
+          <option value="tram">tram</option>
           <option value="bank">bank</option>
         </select>
       </div>
@@ -267,6 +272,10 @@
           <option value="cathay">cathay</option>
           <option value="blackhills">blackhills</option>
         </select>
+      </div>
+      <div class="field">
+        <label>Area</label>
+        <input type="text" id="eArea" placeholder="(none)">
       </div>
       <div class="field">
         <label>Description</label>
@@ -310,8 +319,8 @@ const iconCache = new Map();
 function getIconImg(iconId) {
   if (iconCache.has(iconId)) return iconCache.get(iconId);
   const img = new Image();
-  img.src = `${ASSETS}/icons/I${iconId + 101}.png`;
   img.onload = () => render();
+  img.src = `${ASSETS}/icons/I${iconId + 101}.png`;
   iconCache.set(iconId, img);
   return img;
 }
@@ -351,19 +360,22 @@ const ANCHOR_POS = {
 const TYPE_COLOR = {
   arena:    '#c44', hub:      '#e90', terminal: '#38c',
   bar:      '#4a4', sector:   '#d70', bank:     '#a4a',
-  street:   '#557', path:     '#557',
+  ready_room: '#b65', drop_room: '#966', headquarters: '#c84',
+  tram:     '#0aa', street:   '#557', path:     '#557',
 };
 const TYPE_LETTER = {
   arena: 'A', hub: 'H', terminal: 'T', bar: 'B',
-  sector: 'S', bank: '$', street: '+', path: '+',
+  ready_room: 'R', drop_room: 'D', headquarters: 'Q',
+  sector: 'S', bank: '$', tram: 'M', street: '+', path: '+',
 };
 
 // Icon ID → short label (named locations only; everything else shows type letter)
 const ICON_LABEL = {
-  4: 'STAR', 6: 'SEC', 12: 'FACT', 17: 'LYR',
-  18: 'PRK', 25: 'WST', 26: 'WL', 28: 'ISH',
+  0: 'TRAM', 2: 'BAR', 4: 'STAR', 6: 'SEC',
+  12: 'FACT', 17: 'LYR', 18: 'PRK', 21: 'TERM',
+  25: 'WST', 26: 'PUB', 27: 'PUB', 28: 'ISH',
   29: 'STE', 31: 'JNG', 32: 'DAV', 34: 'SIL',
-  35: 'MON', 36: 'CTH', 37: 'BLK', 43: 'VWP',
+  35: 'HQ', 36: 'CTH', 37: 'BLK', 38: 'KOB', 39: 'SIL', 40: 'MON', 43: 'VWP',
   44: 'BLT', 45: 'GOV', 46: 'WRF', 50: 'MZE', 51: 'SLM',
 };
 
@@ -373,6 +385,8 @@ const ICON_LABEL = {
 let GRID_SIZE = 30;   // cols & rows
 let grid = [];        // GRID_SIZE × GRID_SIZE, row-major
 let selectedCell = null;  // { col, row }
+let validationIssues = [];
+let validationRoomIds = new Set();
 
 let VIEW = { scale: 1, tx: 20, ty: 20 };
 let bgImage = null;
@@ -397,6 +411,29 @@ function makeGrid(size) {
   posById.clear();
 }
 makeGrid(GRID_SIZE);
+
+function setGridSize(size) {
+  const safeSize = Math.max(20, Math.ceil(size));
+  const sel = document.getElementById('gridSize');
+  let option = [...sel.options].find(opt => parseInt(opt.value) >= safeSize);
+  if (!option) {
+    option = document.createElement('option');
+    option.value = String(safeSize);
+    option.textContent = `${safeSize}×${safeSize}`;
+    sel.appendChild(option);
+  }
+  sel.value = option.value;
+  makeGrid(parseInt(option.value));
+}
+
+function ensureGridFitsSavedLayout(rooms) {
+  let maxCoord = GRID_SIZE - 1;
+  for (const room of rooms) {
+    if (typeof room._gridCol === 'number') maxCoord = Math.max(maxCoord, room._gridCol);
+    if (typeof room._gridRow === 'number') maxCoord = Math.max(maxCoord, room._gridRow);
+  }
+  if (maxCoord >= GRID_SIZE) setGridSize(maxCoord + 1);
+}
 
 // ── Canvas ────────────────────────────────────────────────────────────────────
 const wrap   = document.getElementById('canvas-wrap');
@@ -456,13 +493,16 @@ function render() {
       const room = grid[row][col];
       const isSel = selectedCell && selectedCell.col === col && selectedCell.row === row;
       const isNeighbour = isSelectedNeighbour(col, row);
+      const isInvalid = room && validationRoomIds.has(room.roomId);
 
       // Cell fill
       if (room) {
         const baseColor = TYPE_COLOR[room.type] ?? '#557';
-        ctx.fillStyle = isSel
-          ? '#1a2a4a'
-          : isNeighbour ? '#1a1a38' : hexWithAlpha(baseColor, 0.70);
+        ctx.fillStyle = isInvalid
+          ? (isSel ? '#5a2228' : '#5a1518')
+          : (isSel
+              ? '#1a2a4a'
+              : isNeighbour ? '#1a1a38' : hexWithAlpha(baseColor, 0.70));
         ctx.fillRect(x, y, cs, cs);
       } else {
         ctx.fillStyle = isSel ? '#111830' : (isNeighbour ? '#0e0e1e' : 'transparent');
@@ -470,12 +510,14 @@ function render() {
       }
 
       // Border
-      ctx.strokeStyle = isSel
+      ctx.strokeStyle = isInvalid
+        ? '#ff6060'
+        : isSel
         ? '#7ab0e8'
         : (room
             ? (isNeighbour ? '#5580b0' : lighten(TYPE_COLOR[room.type] ?? '#557', 0.5))
             : '#181828');
-      ctx.lineWidth = isSel ? 2 : (room ? 1 : 0.5);
+      ctx.lineWidth = isInvalid ? 2.5 : (isSel ? 2 : (room ? 1 : 0.5));
       ctx.strokeRect(x + 0.5, y + 0.5, cs - 1, cs - 1);
 
       if (!room) continue;
@@ -539,6 +581,14 @@ function render() {
           ctx.fillStyle = '#558';
           ctx.fillText(String(room.roomId), x + cs - 3, y + cs - 3);
         }
+      }
+
+      if (isInvalid && cs >= 18) {
+        const fs = Math.max(10, cs * 0.26);
+        ctx.font = `bold ${fs}px monospace`;
+        ctx.textAlign = 'left';
+        ctx.fillStyle = '#ffb0b0';
+        ctx.fillText('!', x + 3, y + fs);
       }
     }
   }
@@ -629,6 +679,7 @@ function selectCell(col, row) {
   document.getElementById('eDesc').value    = room?.description ?? '';
   document.getElementById('eType').value    = room?.type ?? 'street';
   document.getElementById('eSector').value  = room?.sector ?? 'international';
+  document.getElementById('eArea').value    = room?._area ?? room?.area ?? '';
   document.getElementById('eIcon').value    = room?.icon != null ? room.icon : '';
   document.getElementById('eInferred').checked = !!(room?._inferred);
   updateIconPreview(room?.icon ?? null);
@@ -745,6 +796,7 @@ function applyChanges() {
   const desc  = document.getElementById('eDesc').value.trim();
   const type  = document.getElementById('eType').value;
   const sector = document.getElementById('eSector').value;
+  const area  = document.getElementById('eArea').value.trim();
   const iconRaw = document.getElementById('eIcon').value.trim();
   const icon  = iconRaw !== '' ? parseInt(iconRaw) : null;
   const inferred = document.getElementById('eInferred').checked;
@@ -756,6 +808,7 @@ function applyChanges() {
       roomId: useId,
       _name: name || 'New Room',
       description: desc || undefined,
+      _area: area || undefined,
       type, sector, icon: icon ?? 1, _inferred: inferred || undefined,
       exits: deriveExits(col, row),
     };
@@ -780,6 +833,8 @@ function applyChanges() {
     room.roomId      = newRoomId;
     room._name       = name || undefined;
     room.description = desc || undefined;
+    room._area       = area || undefined;
+    if ('area' in room) room.area = area || undefined;
     room.type        = type;
     room.sector      = sector;
     room.icon        = icon;
@@ -937,42 +992,13 @@ function importPositions() {
     }
   }
 
-  // ── Prune non-adjacent exits ──────────────────────────────────────────────
-  // Any exit whose target isn't exactly 1 cell away is a cycle back-edge that
-  // can't be honoured in a 2D grid.  Remove both directions so the player must
-  // take the longer road path instead of a phantom shortcut.
-  // Rebuild posById first so it reflects the newly placed rooms.
-  rebuildPosById();
-  let pruned = 0;
-  const OPP = { north:'south', south:'north', east:'west', west:'east' };
-  for (let row = 0; row < GRID_SIZE; row++) {
-    for (let col = 0; col < GRID_SIZE; col++) {
-      const room = grid[row][col];
-      if (!room?.exits) continue;
-      for (const dir of Object.keys(room.exits)) {
-        const targetId = room.exits[dir];
-        if (!targetId) continue;
-        const tp = posById.get(targetId);
-        if (!tp) { delete room.exits[dir]; pruned++; continue; }
-        const dist = Math.abs(tp.col - col) + Math.abs(tp.row - row);
-        if (dist > 1) {
-          // Remove forward exit
-          delete room.exits[dir];
-          // Remove reciprocal exit from target
-          const target = grid[tp.row][tp.col];
-          if (target?.exits?.[OPP[dir]] === room.roomId)
-            delete target.exits[OPP[dir]];
-          pruned++;
-        }
-      }
-    }
-  }
-
+  // Rebuild posById so the editor panel can resolve explicit exits. Do not
+  // prune exits here: saved topology is authoritative, even when the visual
+  // overlay is sparse.
   rebuildPosById();
   fitView();
   render();
-  setStatus(`Imported ${placedAt.size} of ${jsonRooms.length} rooms` +
-    (pruned ? ` · ${pruned} non-grid exit(s) removed` : ' · all exits grid-adjacent ✓'));
+  setStatus(`Imported ${placedAt.size} of ${jsonRooms.length} rooms · explicit exits preserved`);
 }
 
 // ── File I/O ──────────────────────────────────────────────────────────────────
@@ -983,11 +1009,13 @@ function loadJson(file) {
       const data = JSON.parse(e.target.result);
       if (!Array.isArray(data.rooms)) throw new Error('"rooms" array not found');
       jsonRooms = data.rooms;
+      clearValidationState();
 
       // Check for saved _gridCol/_gridRow fields
       let hasGrid = jsonRooms.some(r => typeof r._gridCol === 'number');
       if (hasGrid) {
         // Restore saved grid layout
+        ensureGridFitsSavedLayout(jsonRooms);
         makeGrid(GRID_SIZE);
         for (const room of jsonRooms) {
           const col = room._gridCol, row = room._gridRow;
@@ -996,10 +1024,11 @@ function loadJson(file) {
             grid[row][col] = { ...room };
           }
         }
-        // Recompute exits from grid adjacency after restore
+        // Preserve stored exits from JSON. Only infer exits for rooms that do not
+        // already have explicit topology.
         for (let r = 0; r < GRID_SIZE; r++) {
           for (let c = 0; c < GRID_SIZE; c++) {
-            if (grid[r][c]) grid[r][c].exits = deriveExits(c, r);
+            if (grid[r][c] && !grid[r][c].exits) grid[r][c].exits = deriveExits(c, r);
           }
         }
         rebuildPosById();
@@ -1024,6 +1053,223 @@ function loadJson(file) {
     }
   };
   reader.readAsText(file);
+}
+
+const VALIDATION_DIRECTIONS = {
+  north: { dc: 0, dr: -1, opp: 'south' },
+  south: { dc: 0, dr:  1, opp: 'north' },
+  west:  { dc: -1, dr: 0, opp: 'east' },
+  east:  { dc:  1, dr: 0, opp: 'west' },
+};
+
+function clearValidationState() {
+  validationIssues = [];
+  validationRoomIds = new Set();
+}
+
+function validationAreaName(room) {
+  return room?._area ?? room?.area ?? '';
+}
+
+function isGameplayArea(area) {
+  return !!area && area !== 'Sector Overview' && !/ Roads$/.test(area);
+}
+
+function roomRef(room) {
+  if (!room) return 'unknown room';
+  const name = room._name || room.name || room.type || 'Room';
+  return `#${room.roomId} ${name}`;
+}
+
+function exitTargetRooms(room, byId) {
+  return Object.values(room?.exits ?? {})
+    .filter(id => id != null)
+    .map(id => byId.get(id))
+    .filter(Boolean);
+}
+
+function validateMapRooms(rooms) {
+  const issues = [];
+  const issueRoomIds = new Set();
+  const byId = new Map();
+  const roomsBySector = new Map();
+  const roomsByArea = new Map();
+  const placedCells = new Map();
+
+  function addIssue(message, roomIds = []) {
+    issues.push(message);
+    for (const id of roomIds) {
+      if (Number.isFinite(id)) issueRoomIds.add(id);
+    }
+  }
+
+  for (const room of rooms) {
+    const id = room.roomId;
+    if (!Number.isFinite(id) || id <= 0) {
+      addIssue(`${room._name || 'A room'} needs a valid positive room id.`, Number.isFinite(id) ? [id] : []);
+    } else if (byId.has(id)) {
+      addIssue(`Duplicate room id ${id} appears more than once.`, [id]);
+    } else {
+      byId.set(id, room);
+    }
+
+    if (!room.sector) {
+      addIssue(`${roomRef(room)} is missing a sector.`, [id]);
+    } else {
+      if (!roomsBySector.has(room.sector)) roomsBySector.set(room.sector, []);
+      roomsBySector.get(room.sector).push(room);
+    }
+
+    const col = room._gridCol;
+    const row = room._gridRow;
+    if (!Number.isFinite(col) || !Number.isFinite(row)) {
+      addIssue(`${roomRef(room)} is not placed on the editor grid.`, [id]);
+    } else {
+      const key = `${col},${row}`;
+      const existing = placedCells.get(key);
+      if (existing) {
+        addIssue(`${roomRef(room)} shares grid cell (${col}, ${row}) with ${roomRef(existing)}.`, [id, existing.roomId]);
+      } else {
+        placedCells.set(key, room);
+      }
+    }
+
+    const area = validationAreaName(room);
+    if (room.sector && isGameplayArea(area)) {
+      const key = `${room.sector}\u0000${area}`;
+      if (!roomsByArea.has(key)) roomsByArea.set(key, { sector: room.sector, area, rooms: [] });
+      roomsByArea.get(key).rooms.push(room);
+    }
+  }
+
+  for (const room of rooms) {
+    if (!Number.isFinite(room.roomId)) continue;
+    const exits = room.exits ?? {};
+    for (const [dir, spec] of Object.entries(VALIDATION_DIRECTIONS)) {
+      const targetId = exits[dir];
+      if (targetId == null) continue;
+      const target = byId.get(targetId);
+      if (!target) {
+        addIssue(`${roomRef(room)} has a ${dir} exit to missing room #${targetId}.`, [room.roomId]);
+        continue;
+      }
+
+      if (target.exits?.[spec.opp] !== room.roomId) {
+        addIssue(`${roomRef(room)} ${dir} exit to ${roomRef(target)} is not reciprocal.`, [room.roomId, target.roomId]);
+      }
+
+      if (room.sector && target.sector && room.sector !== target.sector) {
+        addIssue(`${roomRef(room)} connects ${room.sector} to ${target.sector}; sectors must not have direct exits.`, [room.roomId, target.roomId]);
+      }
+
+      if (Number.isFinite(room._gridCol) && Number.isFinite(room._gridRow)
+          && Number.isFinite(target._gridCol) && Number.isFinite(target._gridRow)
+          && (target._gridCol !== room._gridCol + spec.dc || target._gridRow !== room._gridRow + spec.dr)) {
+        addIssue(`${roomRef(room)} ${dir} exit points to ${roomRef(target)}, but those rooms are not adjacent on the grid.`, [room.roomId, target.roomId]);
+      }
+    }
+  }
+
+  for (const [sector, sectorRooms] of roomsBySector.entries()) {
+    const sectorIds = new Set(sectorRooms.map(room => room.roomId).filter(Number.isFinite));
+    const seen = new Set();
+    const components = [];
+
+    for (const room of sectorRooms) {
+      if (!Number.isFinite(room.roomId) || seen.has(room.roomId)) continue;
+      const component = [];
+      const stack = [room.roomId];
+      seen.add(room.roomId);
+      while (stack.length) {
+        const id = stack.pop();
+        component.push(id);
+        const cur = byId.get(id);
+        for (const targetId of Object.values(cur?.exits ?? {})) {
+          if (targetId == null || !sectorIds.has(targetId) || seen.has(targetId)) continue;
+          seen.add(targetId);
+          stack.push(targetId);
+        }
+      }
+      components.push(component);
+    }
+
+    if (components.length > 1) {
+      const sizes = components.map(component => component.length).sort((a, b) => b - a).join(', ');
+      addIssue(`Sector "${sector}" is split into ${components.length} disconnected groups (${sizes}).`, sectorRooms.map(room => room.roomId));
+    }
+
+    const tramIds = sectorRooms
+      .filter(room => room.type === 'tram' && Number.isFinite(room.roomId))
+      .map(room => room.roomId);
+    if (!tramIds.length) {
+      addIssue(`Sector "${sector}" has no tram reachable by its rooms.`, sectorRooms.map(room => room.roomId));
+      continue;
+    }
+
+    const tramReachable = new Set(tramIds);
+    const stack = [...tramIds];
+    while (stack.length) {
+      const id = stack.pop();
+      const cur = byId.get(id);
+      for (const targetId of Object.values(cur?.exits ?? {})) {
+        if (targetId == null || !sectorIds.has(targetId) || tramReachable.has(targetId)) continue;
+        tramReachable.add(targetId);
+        stack.push(targetId);
+      }
+    }
+
+    const withoutTramPath = sectorRooms.filter(room => !tramReachable.has(room.roomId));
+    if (withoutTramPath.length) {
+      addIssue(`${withoutTramPath.length} room(s) in sector "${sector}" have no path to a tram.`, withoutTramPath.map(room => room.roomId));
+    }
+  }
+
+  for (const { sector, area, rooms: areaRooms } of roomsByArea.values()) {
+    if (!areaRooms.some(room => room.type === 'tram')) {
+      addIssue(`Area "${area}" in sector "${sector}" has no tram.`, areaRooms.map(room => room.roomId));
+    }
+  }
+
+  const roomsByType = type => rooms.filter(room => room.type === type);
+  const hasExitToType = (room, type) => exitTargetRooms(room, byId).some(target => target.type === type);
+
+  for (const arena of roomsByType('arena')) {
+    const readyRooms = exitTargetRooms(arena, byId).filter(room => room.type === 'ready_room');
+    if (!readyRooms.length) {
+      addIssue(`${roomRef(arena)} is an arena without a connected ready room.`, [arena.roomId]);
+    } else if (!readyRooms.some(ready => hasExitToType(ready, 'drop_room'))) {
+      addIssue(`${roomRef(arena)} has a ready room, but that ready room is not connected to a drop room.`, [arena.roomId, ...readyRooms.map(room => room.roomId)]);
+    }
+  }
+
+  for (const ready of roomsByType('ready_room')) {
+    if (!hasExitToType(ready, 'arena')) {
+      addIssue(`${roomRef(ready)} is a ready room not connected to an arena.`, [ready.roomId]);
+    }
+    if (!hasExitToType(ready, 'drop_room')) {
+      addIssue(`${roomRef(ready)} is a ready room not connected to a drop room.`, [ready.roomId]);
+    }
+  }
+
+  for (const drop of roomsByType('drop_room')) {
+    const linkedToArena = exitTargetRooms(drop, byId)
+      .some(ready => ready.type === 'ready_room' && hasExitToType(ready, 'arena'));
+    if (!linkedToArena) {
+      addIssue(`${roomRef(drop)} is a drop room not connected through a ready room to an arena.`, [drop.roomId]);
+    }
+  }
+
+  return { ok: issues.length === 0, issues, roomIds: issueRoomIds };
+}
+
+function showValidationFailure(result) {
+  validationIssues = result.issues;
+  validationRoomIds = result.roomIds;
+  render();
+  const preview = result.issues.slice(0, 12).map((issue, index) => `${index + 1}. ${issue}`).join('\n');
+  const more = result.issues.length > 12 ? `\n\n...and ${result.issues.length - 12} more.` : '';
+  alert(`Cannot save: map validation failed with ${result.issues.length} issue(s).\n\n${preview}${more}`);
+  setStatus(`Save blocked: ${result.issues.length} validation issue(s)`);
 }
 
 function saveJson() {
@@ -1052,6 +1298,14 @@ function saveJson() {
   for (const room of jsonRooms) {
     if (!seen.has(room.roomId)) out.push({ ...room });
   }
+
+  const validation = validateMapRooms(out);
+  if (!validation.ok) {
+    showValidationFailure(validation);
+    return;
+  }
+  clearValidationState();
+  render();
 
   const json = JSON.stringify({ rooms: out }, null, 2);
   const blob = new Blob([json], { type: 'application/json' });
@@ -1284,8 +1538,8 @@ document.getElementById('chkIcons').addEventListener('change', render);
         cell.className = 'ip-cell';
         cell.dataset.id = i;
         const img = document.createElement('img');
-        img.src = `${ASSETS}/icons/I${i + 101}.png`;
         img.onerror = () => { cell.style.display = 'none'; };
+        img.src = `${ASSETS}/icons/I${i + 101}.png`;
         const lbl = document.createElement('span');
         lbl.textContent = `#${i}`;
         cell.appendChild(img); cell.appendChild(lbl);
@@ -1345,7 +1599,7 @@ document.getElementById('chkIcons').addEventListener('change', render);
 
 // ── Road Icon Tools ──────────────────────────────────────────────────────────
 (function() {
-  const ROAD_ICON_RANGE = Array.from({ length: 13 }, (_, i) => 45 + i); // 45..57
+  const ROAD_ICON_RANGE = [23, 24, 25, ...Array.from({ length: 13 }, (_, i) => 45 + i)];
   const ROAD_TYPES = new Set(['street', 'path']);
   const SECTORS = ['international','kobe','silesia','montenegro','cathay','blackhills'];
 
@@ -1367,7 +1621,7 @@ document.getElementById('chkIcons').addEventListener('change', render);
         </div>
         <div>
           <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:4px">
-            <span style="color:#668;font-size:11px">Icons to use &mdash; click to toggle (${ROAD_ICON_RANGE[0]}&ndash;${ROAD_ICON_RANGE[ROAD_ICON_RANGE.length-1]}):</span>
+            <span style="color:#668;font-size:11px">Road-capable icons &mdash; click to toggle (${ROAD_ICON_RANGE.length} options):</span>
             <span style="display:flex;gap:6px">
               <button id="ri-all" style="font-size:11px;padding:2px 6px">All</button>
               <button id="ri-none" style="font-size:11px;padding:2px 6px">None</button>
@@ -1394,8 +1648,8 @@ document.getElementById('chkIcons').addEventListener('change', render);
         const cell = document.createElement('div');
         cell.className = 'ri-cell' + (selectedIconIds.has(id) ? ' selected' : '');
         const img = document.createElement('img');
-        img.src = `${ASSETS}/icons/I${id + 101}.png`;
         img.onerror = () => { img.style.opacity = '0.2'; };
+        img.src = `${ASSETS}/icons/I${id + 101}.png`;
         const lbl = document.createElement('span');
         lbl.textContent = `#${id}`;
         cell.appendChild(img);

--- a/world-map.json
+++ b/world-map.json
@@ -1,2815 +1,7847 @@
 {
   "rooms": [
     {
-      "roomId": 161,
-      "_name": "Wasteland",
-      "description": "You are in a sad little shop called Froglover's Pizza, which appears to have a dearth of customers. To the south you see a public data terminal. To the west you see the Via Dolorosa.",
-      "type": "street",
+      "type": "tram",
       "sector": "montenegro",
-      "icon": 53,
+      "icon": 0,
       "exits": {
         "north": null,
-        "south": 2132,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 24,
-      "_gridRow": 5,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 151,
-      "_name": "Kobe Slums",
-      "description": "You are relieved of your weapons at the door by a big guy in a fuzzy suit. To the east you see the intersection of Yamato and Proserpina St. To the west you see a data terminal.",
-      "type": "street",
-      "sector": "kobe",
-      "icon": 57,
-      "exits": {
-        "north": null,
-        "south": 2011,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 7,
-      "_gridRow": 6,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 157,
-      "_name": "Factory",
-      "description": "You are in a bar called The Reiver. To the east you see a public data terminal. To the west you see Montenegro Street.",
-      "type": "arena",
-      "sector": "montenegro",
-      "icon": 12,
-      "exits": {
-        "north": null,
-        "south": 2049,
-        "west": 2129,
-        "east": null
-      },
-      "_gridCol": 20,
-      "_gridRow": 6,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 2129,
-      "type": "street",
-      "sector": "montenegro",
-      "exits": {
-        "north": null,
-        "south": 2130,
-        "west": null,
-        "east": 157
-      },
-      "_gridCol": 21,
-      "_gridRow": 6,
-      "icon": 51,
-      "_name": "Montenegro Street"
-    },
-    {
-      "roomId": 2130,
-      "type": "street",
-      "sector": "montenegro",
-      "exits": {
-        "north": 2129,
-        "south": null,
-        "west": null,
-        "east": 2131
-      },
-      "_gridCol": 22,
-      "_gridRow": 6,
-      "icon": 53,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2131,
-      "type": "street",
-      "sector": "montenegro",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2130,
-        "east": 2132
-      },
-      "_gridCol": 23,
-      "_gridRow": 6,
-      "icon": 54,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2132,
-      "type": "street",
-      "sector": "montenegro",
-      "exits": {
-        "north": 161,
-        "south": null,
-        "west": 2131,
-        "east": null
-      },
-      "_gridCol": 24,
-      "_gridRow": 6,
-      "icon": 53,
-      "_name": "Via Dolorosa"
-    },
-    {
-      "roomId": 149,
-      "_name": "White Lotus",
-      "description": "You are in the Snowbird. To the north you see Buckminster Circle. To the east you see a public data terminal.",
-      "type": "bar",
-      "sector": "kobe",
-      "icon": 26,
-      "exits": {
-        "north": 2094,
-        "south": null,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 3,
-      "_gridRow": 7,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 2094,
-      "type": "street",
-      "sector": "kobe",
-      "exits": {
-        "north": null,
-        "south": 149,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 4,
-      "_gridRow": 7,
-      "icon": 50,
-      "_name": "Buckminster Circle"
-    },
-    {
-      "roomId": 2011,
-      "type": "street",
-      "sector": "kobe",
-      "exits": {
-        "north": 151,
-        "south": 2,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 7,
-      "_gridRow": 7,
-      "icon": 53,
-      "_name": "Road"
-    },
-    {
-      "roomId": 148,
-      "_name": "Government House",
-      "description": "You are in the Marauder Bar. To the north you see a public data terminal. To the south you see Yamato St.",
-      "type": "terminal",
-      "sector": "kobe",
-      "icon": 45,
-      "exits": {
-        "north": null,
-        "south": 2005,
-        "west": null,
-        "east": 2088
-      },
-      "_gridCol": 10,
-      "_gridRow": 7,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 2088,
-      "type": "street",
-      "sector": "kobe",
-      "exits": {
-        "north": null,
-        "south": 2046,
-        "west": 148,
-        "east": 2089
-      },
-      "_gridCol": 11,
-      "_gridRow": 7,
-      "icon": 50,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2089,
-      "type": "street",
-      "sector": "kobe",
-      "exits": {
-        "north": null,
-        "south": 2045,
-        "west": 2088,
-        "east": 2090
-      },
-      "_gridCol": 12,
-      "_gridRow": 7,
-      "icon": 56,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2090,
-      "type": "street",
-      "sector": "kobe",
-      "exits": {
-        "north": null,
-        "south": 2044,
-        "west": 2089,
-        "east": 2091
-      },
-      "_gridCol": 13,
-      "_gridRow": 7,
-      "icon": 50,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2091,
-      "type": "street",
-      "sector": "kobe",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2090,
-        "east": null
-      },
-      "_gridCol": 14,
-      "_gridRow": 7,
-      "icon": 55,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2092,
-      "type": "street",
-      "sector": "montenegro",
-      "exits": {
-        "north": null,
-        "south": 2042,
-        "west": null,
-        "east": 2093
-      },
-      "_gridCol": 15,
-      "_gridRow": 7,
-      "icon": 51,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2093,
-      "type": "street",
-      "sector": "montenegro",
-      "exits": {
-        "north": null,
-        "south": 2041,
-        "west": 2092,
-        "east": null
-      },
-      "_gridCol": 16,
-      "_gridRow": 7,
-      "icon": 51,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2049,
-      "type": "street",
-      "sector": "montenegro",
-      "exits": {
-        "north": 157,
-        "south": 2048,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 20,
-      "_gridRow": 7,
-      "icon": 54,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2009,
-      "type": "street",
-      "sector": "kobe",
-      "exits": {
-        "north": null,
-        "south": 2010,
-        "west": null,
-        "east": 2008
-      },
-      "_gridCol": 4,
-      "_gridRow": 8,
-      "icon": 57,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2008,
-      "type": "street",
-      "sector": "kobe",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2009,
-        "east": 2007
-      },
-      "_gridCol": 5,
-      "_gridRow": 8,
-      "icon": 53,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2007,
-      "type": "street",
-      "sector": "kobe",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2008,
-        "east": 2
-      },
-      "_gridCol": 6,
-      "_gridRow": 8,
-      "icon": 57,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2,
-      "_name": "Kobe Sector",
-      "description": "The Kurita sector is beautiful as well as safe. The tourist trade is detoured around those areas with a higher crime rate, and the corruption within Kobe authority is not obvious to the outsider. The fixed arenas in Kobe use desert terrain.",
-      "type": "sector",
-      "sector": "kobe",
-      "icon": 6,
-      "exits": {
-        "north": 2011,
-        "south": null,
-        "west": 2007,
-        "east": 2003
-      },
-      "_gridCol": 7,
-      "_gridRow": 8,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 2003,
-      "type": "street",
-      "sector": "kobe",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2,
-        "east": 2004
-      },
-      "_gridCol": 8,
-      "_gridRow": 8,
-      "icon": 54,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2004,
-      "type": "street",
-      "sector": "kobe",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2003,
-        "east": null
-      },
-      "_gridCol": 9,
-      "_gridRow": 8,
-      "icon": 50,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2005,
-      "type": "street",
-      "sector": "kobe",
-      "exits": {
-        "north": 148,
-        "south": 2006,
-        "west": null,
-        "east": 2046
-      },
-      "_gridCol": 10,
-      "_gridRow": 8,
-      "icon": 50,
-      "_name": "Yamato St"
-    },
-    {
-      "roomId": 2046,
-      "type": "street",
-      "sector": "kobe",
-      "exits": {
-        "north": 2088,
-        "south": null,
-        "west": 2005,
-        "east": 2045
-      },
-      "_gridCol": 11,
-      "_gridRow": 8,
-      "icon": 56,
-      "_name": "Proserpina St"
-    },
-    {
-      "roomId": 2045,
-      "type": "street",
-      "sector": "kobe",
-      "exits": {
-        "north": 2089,
-        "south": null,
-        "west": 2046,
-        "east": 2044
-      },
-      "_gridCol": 12,
-      "_gridRow": 8,
-      "icon": 56,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2044,
-      "type": "street",
-      "sector": "kobe",
-      "exits": {
-        "north": 2090,
-        "south": null,
-        "west": 2045,
-        "east": null
-      },
-      "_gridCol": 13,
-      "_gridRow": 8,
-      "icon": 57,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2043,
-      "type": "street",
-      "sector": "montenegro",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": null,
-        "east": 2042
-      },
-      "_gridCol": 14,
-      "_gridRow": 8,
-      "icon": 54,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2042,
-      "type": "street",
-      "sector": "montenegro",
-      "exits": {
-        "north": 2092,
-        "south": null,
-        "west": 2043,
-        "east": 2041
-      },
-      "_gridCol": 15,
-      "_gridRow": 8,
-      "icon": 53,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2041,
-      "type": "street",
-      "sector": "montenegro",
-      "exits": {
-        "north": 2093,
-        "south": 2050,
-        "west": 2042,
-        "east": 2040
-      },
-      "_gridCol": 16,
-      "_gridRow": 8,
-      "icon": 53,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2040,
-      "type": "street",
-      "sector": "montenegro",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2041,
-        "east": 4
-      },
-      "_gridCol": 17,
-      "_gridRow": 8,
-      "icon": 51,
-      "_name": "Road"
-    },
-    {
-      "roomId": 4,
-      "_name": "Montenegro Sector",
-      "description": "Montenegro is an ugly place, with its abandoned industrial complexes and fierce commercialization. Authorities are far more concerned about maintaining the ties between member-states than improving living and working conditions in the sector. The fixed arenas in Montenegro use tropical terrain.",
-      "type": "sector",
-      "sector": "montenegro",
-      "icon": 35,
-      "exits": {
-        "north": null,
-        "south": 2051,
-        "west": 2040,
-        "east": 2047
-      },
-      "_gridCol": 18,
-      "_gridRow": 8,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 2047,
-      "type": "street",
-      "sector": "montenegro",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 4,
-        "east": 2048
-      },
-      "_gridCol": 19,
-      "_gridRow": 8,
-      "icon": 51,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2048,
-      "type": "street",
-      "sector": "montenegro",
-      "exits": {
-        "north": 2049,
-        "south": 159,
-        "west": 2047,
-        "east": null
-      },
-      "_gridCol": 20,
-      "_gridRow": 8,
-      "icon": 53,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2010,
-      "type": "street",
-      "sector": "kobe",
-      "exits": {
-        "north": 2009,
-        "south": 150,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 4,
-      "_gridRow": 9,
-      "icon": 54,
-      "_name": "Robert Kurita St"
-    },
-    {
-      "roomId": 2006,
-      "type": "street",
-      "sector": "kobe",
-      "exits": {
-        "north": 2005,
-        "south": 147,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 10,
-      "_gridRow": 9,
-      "icon": 50,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2050,
-      "type": "street",
-      "sector": "montenegro",
-      "exits": {
-        "north": 2041,
-        "south": 158,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 16,
-      "_gridRow": 9,
-      "icon": 51,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2051,
-      "type": "street",
-      "sector": "montenegro",
-      "exits": {
-        "north": 4,
-        "south": 2052,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 18,
-      "_gridRow": 9,
-      "icon": 53,
-      "_name": "Road"
-    },
-    {
-      "roomId": 159,
-      "_name": "Allman",
-      "description": "You are in Brit's. To the south you see the Via Dolorosa. To the east you see a public data terminal.",
-      "type": "street",
-      "sector": "montenegro",
-      "icon": 54,
-      "exits": {
-        "north": 2048,
-        "south": null,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 20,
-      "_gridRow": 9,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 150,
-      "_name": "Waterfront",
-      "description": "You are in The Silver Claw. To the north you see Robert Kurita St. To the west you see a public data terminal.",
-      "type": "bar",
-      "sector": "kobe",
-      "icon": 46,
-      "exits": {
-        "north": 2010,
-        "south": null,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 4,
-      "_gridRow": 10,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 2086,
-      "type": "street",
-      "sector": "kobe",
-      "exits": {
-        "north": null,
-        "south": 2087,
-        "west": null,
-        "east": 2085
-      },
-      "_gridCol": 8,
-      "_gridRow": 10,
-      "icon": 54,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2085,
-      "type": "street",
-      "sector": "kobe",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2086,
-        "east": 147
-      },
-      "_gridCol": 9,
-      "_gridRow": 10,
-      "icon": 51,
-      "_name": "Road"
-    },
-    {
-      "roomId": 147,
-      "_name": "Ishiyama Arena",
-      "description": "You are in a bar called The Paradise. To the east you see Theodore Kurita St. To the west you see a public data terminal.",
-      "type": "arena",
-      "sector": "kobe",
-      "icon": 28,
-      "exits": {
-        "north": 2006,
-        "south": 2077,
-        "west": 2085,
-        "east": 2072
-      },
-      "_gridCol": 10,
-      "_gridRow": 10,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 2072,
-      "type": "street",
-      "sector": "kobe",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 147,
-        "east": 2073
-      },
-      "_gridCol": 11,
-      "_gridRow": 10,
-      "icon": 57,
-      "_name": "Theodore Kurita St"
-    },
-    {
-      "roomId": 2073,
-      "type": "street",
-      "sector": "kobe",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2072,
-        "east": 2074
-      },
-      "_gridCol": 12,
-      "_gridRow": 10,
-      "icon": 56,
-      "_name": "North Theodore Kurita St"
-    },
-    {
-      "roomId": 2074,
-      "type": "street",
-      "sector": "kobe",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2073,
-        "east": null
-      },
-      "_gridCol": 13,
-      "_gridRow": 10,
-      "icon": 53,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2075,
-      "type": "street",
-      "sector": "montenegro",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 14,
-      "_gridRow": 10,
-      "icon": 53,
-      "_name": "West Bolivar St"
-    },
-    {
-      "roomId": 2076,
-      "type": "street",
-      "sector": "montenegro",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 158,
-        "east": null
-      },
-      "_gridCol": 15,
-      "_gridRow": 10,
-      "icon": 54,
-      "_name": "Bolivar St"
-    },
-    {
-      "roomId": 158,
-      "_name": "Marik Tower",
-      "description": "You are in The Home Guard Club. To the east you see Bolivar St. To the west you see a public data terminal.",
-      "type": "terminal",
-      "sector": "montenegro",
-      "icon": 17,
-      "exits": {
-        "north": 2050,
-        "south": 2133,
-        "west": null,
-        "east": 2076
-      },
-      "_gridCol": 16,
-      "_gridRow": 10,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 2052,
-      "type": "street",
-      "sector": "montenegro",
-      "exits": {
-        "north": 2051,
-        "south": null,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 18,
-      "_gridRow": 10,
-      "icon": 54,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2087,
-      "type": "street",
-      "sector": "kobe",
-      "exits": {
-        "north": 2086,
-        "south": null,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 8,
-      "_gridRow": 11,
-      "icon": 54,
-      "_name": "Frances Ave"
-    },
-    {
-      "roomId": 2077,
-      "type": "street",
-      "sector": "kobe",
-      "exits": {
-        "north": 147,
-        "south": 2078,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 10,
-      "_gridRow": 11,
-      "icon": 55,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2133,
-      "type": "street",
-      "sector": "montenegro",
-      "exits": {
-        "north": 158,
-        "south": 2134,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 16,
-      "_gridRow": 11,
-      "icon": 53,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2053,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": 2054,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 18,
-      "_gridRow": 11,
-      "icon": 57,
-      "_name": "Road"
-    },
-    {
-      "roomId": 160,
-      "_name": "Riverfront",
-      "description": "You are in Hangar 66. To the north you see Reisman St. To the south you see a public data terminal.",
-      "type": "street",
-      "sector": "montenegro",
-      "icon": 53,
-      "exits": {
-        "north": 2112,
-        "south": null,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 20,
-      "_gridRow": 11,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 2147,
-      "type": "street",
-      "sector": "blackhills",
-      "exits": {
-        "north": null,
-        "south": 2148,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 6,
-      "_gridRow": 12,
-      "icon": 54,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2146,
-      "type": "street",
-      "sector": "kobe",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 7,
-      "_gridRow": 12,
-      "icon": 57,
-      "_name": "Road"
-    },
-    {
-      "roomId": 170,
-      "_name": "Marina",
-      "description": "You are in the Pelican. To the north you see Frances Ave. To the south you see a public data terminal.",
-      "type": "bar",
-      "sector": "blackhills",
-      "icon": 1,
-      "exits": {
-        "north": null,
-        "south": 2141,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 8,
-      "_gridRow": 12,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 2078,
-      "type": "street",
-      "sector": "kobe",
-      "exits": {
-        "north": 2077,
-        "south": 2079,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 10,
-      "_gridRow": 12,
-      "icon": 57,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2134,
-      "type": "street",
-      "sector": "montenegro",
-      "exits": {
-        "north": 2133,
-        "south": null,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 16,
-      "_gridRow": 12,
-      "icon": 51,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2054,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": 2053,
-        "south": null,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 18,
-      "_gridRow": 12,
-      "icon": 47,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2112,
-      "type": "street",
-      "sector": "montenegro",
-      "exits": {
-        "north": null,
-        "south": 160,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 20,
-      "_gridRow": 12,
-      "icon": 52,
-      "_name": "Reisman St"
-    },
-    {
-      "roomId": 2148,
-      "type": "street",
-      "sector": "blackhills",
-      "exits": {
-        "north": 2147,
-        "south": 2149,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 6,
-      "_gridRow": 13,
-      "icon": 52,
-      "_name": "East Frances Ave"
-    },
-    {
-      "roomId": 2079,
-      "type": "street",
-      "sector": "kobe",
-      "exits": {
-        "north": 2078,
-        "south": null,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 10,
-      "_gridRow": 13,
-      "icon": 56,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2080,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": 2123,
-        "west": null,
-        "east": 2081
-      },
-      "_gridCol": 11,
-      "_gridRow": 13,
-      "icon": 48,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2081,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2080,
-        "east": null
-      },
-      "_gridCol": 12,
-      "_gridRow": 13,
-      "icon": 47,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2082,
-      "type": "street",
-      "sector": "montenegro",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": null,
-        "east": 2083
-      },
-      "_gridCol": 13,
-      "_gridRow": 13,
-      "icon": 53,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2083,
-      "type": "street",
-      "sector": "montenegro",
-      "exits": {
-        "north": null,
-        "south": 2120,
-        "west": 2082,
-        "east": 2084
-      },
-      "_gridCol": 14,
-      "_gridRow": 13,
-      "icon": 51,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2084,
-      "type": "street",
-      "sector": "montenegro",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2083,
-        "east": null
-      },
-      "_gridCol": 15,
-      "_gridRow": 13,
-      "icon": 53,
-      "_name": "Capellan St"
-    },
-    {
-      "roomId": 165,
-      "_name": "Rivertown",
-      "description": "You are in the Cobalt Coil. To the east you see Capellan St. To the west you see a public data terminal.",
-      "type": "street",
-      "sector": "cathay",
-      "icon": 51,
-      "exits": {
-        "north": null,
-        "south": 2116,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 16,
-      "_gridRow": 13,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 2055,
-      "type": "street",
-      "sector": "montenegro",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2056,
-        "east": null
-      },
-      "_gridCol": 18,
-      "_gridRow": 13,
-      "icon": 51,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2111,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": 2110,
-        "west": null,
-        "east": 2105
-      },
-      "_gridCol": 20,
-      "_gridRow": 13,
-      "icon": 48,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2105,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": 155,
-        "west": 2111,
-        "east": 2104
-      },
-      "_gridCol": 21,
-      "_gridRow": 13,
-      "icon": 48,
-      "_name": "Fraunstalh St"
-    },
-    {
-      "roomId": 2104,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2105,
-        "east": 2103
-      },
-      "_gridCol": 22,
-      "_gridRow": 13,
-      "icon": 45,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2103,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2104,
-        "east": 153
-      },
-      "_gridCol": 23,
-      "_gridRow": 13,
-      "icon": 51,
-      "_name": "Road"
-    },
-    {
-      "roomId": 153,
-      "_name": "Lyran Building",
-      "description": "You are in the Vindictive Philanthropist, writing bad checks to charity. To the north you see a public data terminal. To the south you see Arnulf St.",
-      "type": "terminal",
-      "sector": "silesia",
-      "icon": 17,
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2103,
-        "east": null
-      },
-      "_gridCol": 24,
-      "_gridRow": 13,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 2149,
-      "type": "street",
-      "sector": "blackhills",
-      "exits": {
-        "north": 2148,
-        "south": 171,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 6,
-      "_gridRow": 14,
-      "icon": 54,
-      "_name": "Laurel Ave"
-    },
-    {
-      "roomId": 2123,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": 2080,
-        "south": null,
-        "west": null,
-        "east": 2122
-      },
-      "_gridCol": 11,
-      "_gridRow": 14,
-      "icon": 47,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2120,
-      "type": "street",
-      "sector": "montenegro",
-      "exits": {
-        "north": 2083,
-        "south": null,
-        "west": null,
-        "east": 2119
-      },
-      "_gridCol": 14,
-      "_gridRow": 14,
-      "icon": 51,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2116,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": 165,
-        "south": 2117,
-        "west": null,
-        "east": 2115
-      },
-      "_gridCol": 16,
-      "_gridRow": 14,
-      "icon": 53,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2115,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": null,
-        "south": 166,
-        "west": 2116,
-        "east": 2114
-      },
-      "_gridCol": 17,
-      "_gridRow": 14,
-      "icon": 48,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2114,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2115,
-        "east": 2113
-      },
-      "_gridCol": 18,
-      "_gridRow": 14,
-      "icon": 57,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2113,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2114,
-        "east": null
-      },
-      "_gridCol": 19,
-      "_gridRow": 14,
-      "icon": 51,
-      "_name": "Alley off Maximilian Ave"
-    },
-    {
-      "roomId": 2110,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": 2111,
-        "south": null,
-        "west": null,
-        "east": 155
-      },
-      "_gridCol": 20,
-      "_gridRow": 14,
-      "icon": 52,
-      "_name": "Road"
-    },
-    {
-      "roomId": 155,
-      "_name": "Riverside",
-      "description": "You are in the Swooping Crane. To the north you see Fraunstalh St. To the south you see a public data terminal.",
-      "type": "bar",
-      "sector": "silesia",
-      "icon": 46,
-      "exits": {
-        "north": 2105,
-        "south": 2028,
-        "west": 2110,
-        "east": null
-      },
-      "_gridCol": 21,
-      "_gridRow": 14,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 171,
-      "_name": "Viewpoint",
-      "description": "You are in the Cryptic Skeptic, though probably not for too much longer...considering. To the north you see a public data terminal. To the west you see a busy pedestrian interchange.",
-      "type": "street",
-      "sector": "blackhills",
-      "icon": 53,
-      "exits": {
-        "north": 2149,
-        "south": null,
-        "west": 2145,
-        "east": null
-      },
-      "_gridCol": 6,
-      "_gridRow": 15,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 2141,
-      "type": "terminal",
-      "sector": "blackhills",
-      "exits": {
-        "north": 170,
-        "south": 2142,
-        "west": null,
-        "east": 167
-      },
-      "_gridCol": 8,
-      "_gridRow": 15,
-      "icon": 17,
-      "_name": "Public Data Terminal"
-    },
-    {
-      "roomId": 2140,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": null,
-        "east": 2139
-      },
-      "_gridCol": 9,
-      "_gridRow": 15,
-      "icon": 48,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2139,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2140,
-        "east": null
-      },
-      "_gridCol": 10,
-      "_gridRow": 15,
-      "icon": 52,
-      "_name": "Road"
-    },
-    {
-      "roomId": 167,
-      "_name": "Davion Arena",
-      "description": "You are in The Sun and Sword, one of the older bars in the city. To the east you see Halloran St. To the west you see a public data terminal.",
-      "type": "arena",
-      "sector": "blackhills",
-      "icon": 32,
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2141,
-        "east": 2138
-      },
-      "_gridCol": 11,
-      "_gridRow": 15,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 2138,
-      "type": "street",
-      "sector": "blackhills",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 167,
-        "east": null
-      },
-      "_gridCol": 12,
-      "_gridRow": 15,
-      "icon": 53,
-      "_name": "Halloran St"
-    },
-    {
-      "roomId": 2137,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": 2121,
-        "south": null,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 13,
-      "_gridRow": 15,
-      "icon": 45,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2136,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": null,
-        "east": 2135
-      },
-      "_gridCol": 14,
-      "_gridRow": 15,
-      "icon": 46,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2135,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2136,
-        "east": 2117
-      },
-      "_gridCol": 15,
-      "_gridRow": 15,
-      "icon": 48,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2117,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": 2116,
-        "south": 2118,
-        "west": 2135,
-        "east": 166
-      },
-      "_gridCol": 16,
-      "_gridRow": 15,
-      "icon": 48,
-      "_name": "Road"
-    },
-    {
-      "roomId": 166,
-      "_name": "Maze",
-      "description": "You are in Belthasar's Hideaway, where you had better keep looking over your shoulder and keep your back to the wall. To the north you see a public data terminal. To the south you see Confederation Ave. running east and west.",
-      "type": "street",
-      "sector": "cathay",
-      "icon": 54,
-      "exits": {
-        "north": 2115,
-        "south": null,
-        "west": 2117,
-        "east": null
-      },
-      "_gridCol": 17,
-      "_gridRow": 15,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 2028,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": 155,
-        "south": 2027,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 21,
-      "_gridRow": 15,
-      "icon": 48,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2145,
-      "type": "street",
-      "sector": "blackhills",
-      "exits": {
-        "north": null,
-        "south": 2144,
-        "west": null,
-        "east": 171
-      },
-      "_gridCol": 6,
-      "_gridRow": 16,
-      "icon": 54,
-      "_name": "Hanse Davion Dr"
-    },
-    {
-      "roomId": 2142,
-      "type": "street",
-      "sector": "blackhills",
-      "exits": {
-        "north": 2141,
-        "south": 169,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 8,
-      "_gridRow": 16,
-      "icon": 52,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2039,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": 2038,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 11,
-      "_gridRow": 16,
-      "icon": 46,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2118,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": 2117,
-        "south": 162,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 16,
-      "_gridRow": 16,
-      "icon": 57,
-      "_name": "Confederation Ave"
-    },
-    {
-      "roomId": 2027,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": 2028,
-        "south": null,
-        "west": 152,
-        "east": null
-      },
-      "_gridCol": 21,
-      "_gridRow": 16,
-      "icon": 47,
-      "_name": "Dusseldorf Street"
-    },
-    {
-      "roomId": 2144,
-      "type": "street",
-      "sector": "blackhills",
-      "exits": {
-        "north": 2145,
-        "south": 2143,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 6,
-      "_gridRow": 17,
-      "icon": 52,
-      "_name": "Road"
-    },
-    {
-      "roomId": 169,
-      "_name": "Guzman Park",
-      "description": "You are in Skippy's Fern Bar. A classy joint where warriors meet to drink and tell lies about their battles. Skippy's is known for serving the best. To the south you see Swift Shore Drive. To the west you see a public data terminal.",
-      "type": "street",
-      "sector": "blackhills",
-      "icon": 53,
-      "exits": {
-        "north": 2142,
-        "south": 2069,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 8,
-      "_gridRow": 17,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 2038,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": 2039,
-        "south": 2037,
-        "west": null,
-        "east": 2102
-      },
-      "_gridCol": 11,
-      "_gridRow": 17,
-      "icon": 46,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2102,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2038,
-        "east": null
-      },
-      "_gridCol": 12,
-      "_gridRow": 17,
-      "icon": 45,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2101,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": null,
-        "east": 2100
-      },
-      "_gridCol": 13,
-      "_gridRow": 17,
-      "icon": 49,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2100,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2101,
-        "east": 2099
-      },
-      "_gridCol": 14,
-      "_gridRow": 17,
-      "icon": 48,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2099,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2100,
-        "east": 162
-      },
-      "_gridCol": 15,
-      "_gridRow": 17,
-      "icon": 48,
-      "_name": "Road"
-    },
-    {
-      "roomId": 162,
-      "_name": "Jungle",
-      "description": "You are in a bar. To the north you see Confederation Ave. To the south you see a public data terminal.",
-      "type": "arena",
-      "sector": "cathay",
-      "icon": 31,
-      "exits": {
-        "north": 2118,
-        "south": 2032,
-        "west": 2099,
-        "east": 2098
-      },
-      "_gridCol": 16,
-      "_gridRow": 17,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 2098,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 162,
-        "east": 2097
-      },
-      "_gridCol": 17,
-      "_gridRow": 17,
-      "icon": 57,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2097,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2098,
-        "east": null
-      },
-      "_gridCol": 18,
-      "_gridRow": 17,
-      "icon": 57,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2096,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": null,
-        "east": 2095
-      },
-      "_gridCol": 19,
-      "_gridRow": 17,
-      "icon": 46,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2095,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2096,
-        "east": 152
-      },
-      "_gridCol": 20,
-      "_gridRow": 17,
-      "icon": 52,
-      "_name": "Road"
-    },
-    {
-      "roomId": 152,
-      "_name": "Steiner Stadium",
-      "description": "You are in a bar called the Copper Coin. To the east you see Dusseldorf Street. To the west you see a public data terminal.",
-      "type": "arena",
-      "sector": "silesia",
-      "icon": 29,
-      "exits": {
-        "north": null,
-        "south": 2021,
-        "west": 2095,
-        "east": 2027
-      },
-      "_gridCol": 21,
-      "_gridRow": 17,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 168,
-      "_name": "Sortek Building",
-      "description": "You are an exclusive establishment called Seventh Heaven. To the south you see Hanse Davion Ave. To the east you see a public data terminal.",
-      "type": "terminal",
-      "sector": "blackhills",
-      "icon": 17,
-      "exits": {
-        "north": null,
-        "south": 2071,
-        "west": null,
-        "east": 2143
-      },
-      "_gridCol": 5,
-      "_gridRow": 18,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 2143,
-      "type": "street",
-      "sector": "blackhills",
-      "exits": {
-        "north": 2144,
-        "south": null,
-        "west": 168,
-        "east": 2069
-      },
-      "_gridCol": 6,
-      "_gridRow": 18,
-      "icon": 52,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2069,
-      "type": "street",
-      "sector": "blackhills",
-      "exits": {
-        "north": 169,
-        "south": 2068,
-        "west": 2143,
-        "east": null
-      },
-      "_gridCol": 8,
-      "_gridRow": 18,
-      "icon": 53,
-      "_name": "Swift Shore Drive"
-    },
-    {
-      "roomId": 2037,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": 2038,
-        "south": 2036,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 11,
-      "_gridRow": 18,
-      "icon": 46,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2032,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": 162,
-        "south": 164,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 16,
-      "_gridRow": 18,
-      "icon": 57,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2021,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": 152,
-        "south": 2020,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 21,
-      "_gridRow": 18,
-      "icon": 53,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2071,
-      "type": "street",
-      "sector": "blackhills",
-      "exits": {
-        "north": 168,
-        "south": null,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 5,
-      "_gridRow": 19,
-      "icon": 53,
-      "_name": "Hanse Davion Ave"
-    },
-    {
-      "roomId": 2068,
-      "type": "street",
-      "sector": "blackhills",
-      "exits": {
-        "north": 2069,
-        "south": 2067,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 8,
-      "_gridRow": 19,
-      "icon": 52,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2036,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": 2037,
-        "south": null,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 11,
-      "_gridRow": 19,
-      "icon": 51,
-      "_name": "Road"
-    },
-    {
-      "roomId": 164,
-      "_name": "Middletown",
-      "description": "You are in The Bitter Pool, where bitterness is not just a state of mind, but a way of life. Whenever you get bitter, come down to The Bitter Pool. To the east you see Solaris Highway One. To the west you see a public data terminal.",
-      "type": "street",
-      "sector": "cathay",
-      "icon": 57,
-      "exits": {
-        "north": 2032,
-        "south": 2016,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 16,
-      "_gridRow": 19,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 2020,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": 2021,
-        "south": 3,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 21,
-      "_gridRow": 19,
-      "icon": 47,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2070,
-      "type": "street",
-      "sector": "international",
-      "exits": {
-        "north": null,
-        "south": 2066,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 5,
-      "_gridRow": 20,
-      "icon": 51,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2067,
-      "type": "street",
-      "sector": "blackhills",
-      "exits": {
-        "north": 2068,
-        "south": 6,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 8,
-      "_gridRow": 20,
-      "icon": 53,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2035,
-      "type": "street",
-      "sector": "blackhills",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 11,
-      "_gridRow": 20,
-      "icon": 53,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2034,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": null,
-        "east": 2033
-      },
-      "_gridCol": 12,
-      "_gridRow": 20,
-      "icon": 48,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2033,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2034,
-        "east": 2018
-      },
-      "_gridCol": 13,
-      "_gridRow": 20,
-      "icon": 48,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2018,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": null,
-        "south": 2019,
-        "west": 2033,
-        "east": 2017
-      },
-      "_gridCol": 14,
-      "_gridRow": 20,
-      "icon": 49,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2017,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2018,
-        "east": 2016
-      },
-      "_gridCol": 15,
-      "_gridRow": 20,
-      "icon": 57,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2016,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": 164,
-        "south": 2063,
-        "west": 2017,
-        "east": 2015
-      },
-      "_gridCol": 16,
-      "_gridRow": 20,
-      "icon": 49,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2015,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2016,
-        "east": null
-      },
-      "_gridCol": 17,
-      "_gridRow": 20,
-      "icon": 48,
-      "_name": "Solaris Highway One"
-    },
-    {
-      "roomId": 2014,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": null,
-        "east": 2013
-      },
-      "_gridCol": 18,
-      "_gridRow": 20,
-      "icon": 46,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2013,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2014,
-        "east": 2012
-      },
-      "_gridCol": 19,
-      "_gridRow": 20,
-      "icon": 53,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2012,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": 2029,
-        "west": 2013,
-        "east": 3
-      },
-      "_gridCol": 20,
-      "_gridRow": 20,
-      "icon": 48,
-      "_name": "Road"
-    },
-    {
-      "roomId": 3,
-      "_name": "Silesia Sector",
-      "description": "Despite official attempts to maintain Silesia as a showpiece of Lyran culture, it suffers the same problems as the rest of the City. The beautiful private estates of the Sector are frequently financed by the very crime that devastates its poorer areas. The fixed arenas in Silesia use temperate terrain.",
-      "type": "sector",
-      "sector": "silesia",
-      "icon": 34,
-      "exits": {
-        "north": 2020,
-        "south": null,
-        "west": 2012,
-        "east": 2022
-      },
-      "_gridCol": 21,
-      "_gridRow": 20,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 2022,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 3,
-        "east": 2023
-      },
-      "_gridCol": 22,
-      "_gridRow": 20,
-      "icon": 57,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2023,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2022,
-        "east": 2024
-      },
-      "_gridCol": 23,
-      "_gridRow": 20,
-      "icon": 57,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2024,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2023,
-        "east": 2025
-      },
-      "_gridCol": 24,
-      "_gridRow": 20,
-      "icon": 57,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2025,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": 2026,
-        "west": 2024,
-        "east": null
-      },
-      "_gridCol": 25,
-      "_gridRow": 20,
-      "icon": 45,
-      "_name": "Road"
-    },
-    {
-      "roomId": 146,
-      "_name": "Solaris Starport",
-      "description": "Click on the stone arch icon to the east for a tutorial if you are new to Solaris City and need help. Click on the tram icon to the south if you know your way around and you're ready to go find a fight. Remember players with [MPBT] in front of their names are the game staff. They will help to teach you the game. Other players that want to train you or that want you to join their group may not have the best intentions.",
-      "type": "hub",
-      "sector": "international",
-      "icon": 4,
-      "exits": {
-        "north": null,
-        "south": 2002,
-        "west": null,
-        "east": 2066
-      },
-      "_gridCol": 4,
-      "_gridRow": 21,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 2066,
-      "type": "street",
-      "sector": "international",
-      "exits": {
-        "north": 2070,
-        "south": null,
-        "west": 146,
-        "east": null
-      },
-      "_gridCol": 5,
-      "_gridRow": 21,
-      "icon": 52,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2065,
-      "type": "street",
-      "sector": "blackhills",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": null,
-        "east": 2064
-      },
-      "_gridCol": 6,
-      "_gridRow": 21,
-      "icon": 53,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2064,
-      "type": "street",
-      "sector": "blackhills",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2065,
-        "east": 6
-      },
-      "_gridCol": 7,
-      "_gridRow": 21,
-      "icon": 52,
-      "_name": "Road"
-    },
-    {
-      "roomId": 6,
-      "_name": "Black Hills Sector",
-      "description": "The Davion sector presents itself as a high-tech bastion of civilization and virtue, but squalor and crime are just as prevalent here as anywhere in the city. The fixed arenas in Black Hills use arctic terrain.",
-      "type": "sector",
-      "sector": "blackhills",
-      "icon": 37,
-      "exits": {
-        "north": 2067,
-        "south": null,
-        "west": 2064,
-        "east": null
-      },
-      "_gridCol": 8,
-      "_gridRow": 21,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 2019,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": 2018,
-        "south": 5,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 14,
-      "_gridRow": 21,
-      "icon": 49,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2063,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": 2016,
-        "south": 2058,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 16,
-      "_gridRow": 21,
-      "icon": 48,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2029,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": 2012,
-        "south": null,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 20,
-      "_gridRow": 21,
-      "icon": 46,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2026,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": 2025,
-        "south": 154,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 25,
-      "_gridRow": 21,
-      "icon": 47,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2002,
-      "type": "street",
-      "sector": "international",
-      "exits": {
-        "north": 146,
-        "south": 2001,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 4,
-      "_gridRow": 22,
-      "icon": 47,
-      "_name": "Road"
-    },
-    {
-      "roomId": 5,
-      "_name": "Cathay Sector",
-      "description": "Cathay displays the sharpest contrasts between the classes. A large body of what are essentially working-class serfs maintain the luxurious splendor of the small upper class. Crime and gang activity is rampant, despite the ruthless efficiency of Cathay Security. The fixed arenas in Cathay use temperate and tropical terrain.",
-      "type": "sector",
-      "sector": "cathay",
-      "icon": 36,
-      "exits": {
-        "north": 2019,
-        "south": null,
-        "west": null,
-        "east": 2057
-      },
-      "_gridCol": 14,
-      "_gridRow": 22,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 2057,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 5,
-        "east": 2058
-      },
-      "_gridCol": 15,
-      "_gridRow": 22,
-      "icon": 49,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2058,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": 2063,
-        "south": 2128,
-        "west": 2057,
-        "east": 2059
-      },
-      "_gridCol": 16,
-      "_gridRow": 22,
-      "icon": 49,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2059,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2058,
-        "east": 2060
-      },
-      "_gridCol": 17,
-      "_gridRow": 22,
-      "icon": 48,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2060,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2059,
-        "east": 2061
-      },
-      "_gridCol": 18,
-      "_gridRow": 22,
-      "icon": 57,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2061,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2060,
-        "east": 2030
-      },
-      "_gridCol": 19,
-      "_gridRow": 22,
-      "icon": 48,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2030,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2061,
-        "east": null
-      },
-      "_gridCol": 20,
-      "_gridRow": 22,
-      "icon": 48,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2109,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": null,
-        "east": 2108
-      },
-      "_gridCol": 21,
-      "_gridRow": 22,
-      "icon": 45,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2108,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2109,
-        "east": 2107
-      },
-      "_gridCol": 22,
-      "_gridRow": 22,
-      "icon": 46,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2107,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2108,
-        "east": 2106
-      },
-      "_gridCol": 23,
-      "_gridRow": 22,
-      "icon": 46,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2106,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2107,
-        "east": 154
-      },
-      "_gridCol": 24,
-      "_gridRow": 22,
-      "icon": 52,
-      "_name": "Vialla Circle"
-    },
-    {
-      "roomId": 154,
-      "_name": "Chahar Park",
-      "description": "You are in Thor's Shieldhall. To the south you see a public data terminal. To the west you see Vialla Circle.",
-      "type": "street",
-      "sector": "silesia",
-      "icon": 45,
-      "exits": {
-        "north": 2026,
-        "south": null,
-        "west": 2106,
-        "east": null
-      },
-      "_gridCol": 25,
-      "_gridRow": 22,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 2001,
-      "type": "street",
-      "sector": "international",
-      "exits": {
-        "north": 2002,
-        "south": 2000,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 4,
-      "_gridRow": 23,
-      "icon": 57,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2062,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": 163,
-        "south": null,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 14,
-      "_gridRow": 23,
-      "icon": 57,
-      "_name": "Maximilian Ave"
-    },
-    {
-      "roomId": 2128,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": 2058,
-        "south": 2127,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 16,
-      "_gridRow": 23,
-      "icon": 48,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2031,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": 156,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 20,
-      "_gridRow": 23,
-      "icon": 48,
-      "_name": "Arnulf St"
-    },
-    {
-      "roomId": 2000,
-      "type": "street",
-      "sector": "international",
-      "exits": {
-        "north": 2001,
-        "south": 1,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 4,
-      "_gridRow": 24,
-      "icon": 55,
-      "_name": "Road"
-    },
-    {
-      "roomId": 163,
-      "_name": "Chancellor's Quarter",
-      "description": "You are in Warrior's Hall. To the south you see Maximilian Ave. To the east you see a public data terminal.",
-      "type": "terminal",
-      "sector": "cathay",
-      "icon": 45,
-      "exits": {
-        "north": null,
-        "south": 2062,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 14,
-      "_gridRow": 24,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 2127,
-      "type": "street",
-      "sector": "cathay",
-      "exits": {
-        "north": 2128,
-        "south": null,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 16,
-      "_gridRow": 24,
-      "icon": 48,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2126,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": null,
-        "east": 2125
-      },
-      "_gridCol": 17,
-      "_gridRow": 24,
-      "icon": 48,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2125,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": null,
-        "west": 2126,
-        "east": 2124
-      },
-      "_gridCol": 18,
-      "_gridRow": 24,
-      "icon": 48,
-      "_name": "North Dusseldorf St"
-    },
-    {
-      "roomId": 2124,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": 156,
-        "south": null,
-        "west": 2125,
-        "east": null
-      },
-      "_gridCol": 19,
-      "_gridRow": 24,
-      "icon": 49,
-      "_name": "Marburg St"
-    },
-    {
-      "roomId": 156,
-      "_name": "Black Thorne",
-      "description": "You are just in time. The mysterious \"Deadhead\" cult is having a reading. Plus, some woman named \"Sunshine\" keeps telling you you're \"beautiful.\" To the north you see a public data terminal. To the south you see the intersection of Arnulf St. and Marburg St.",
-      "type": "street",
-      "sector": "silesia",
-      "icon": 48,
-      "exits": {
-        "north": 2031,
-        "south": 2124,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 20,
-      "_gridRow": 24,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 1,
-      "_name": "International Sector",
-      "description": "This area, composed primarily of public-works installations and tourist areas, is under the direct control of the Solaris central authority. There are no arenas in this sector.",
-      "type": "sector",
-      "sector": "international",
-      "icon": 6,
-      "exits": {
-        "north": 2000,
-        "south": null,
-        "west": null,
-        "east": null
-      },
-      "_gridCol": 4,
-      "_gridRow": 25,
-      "clientMapDescription": true
-    },
-    {
-      "roomId": 2056,
-      "type": "street",
-      "sector": "montenegro",
-      "exits": {
-        "north": null,
-        "south": null,
-        "east": 2055,
+        "south": 157,
+        "east": null,
         "west": null
       },
-      "_gridCol": 17,
-      "_gridRow": 13,
-      "_name": "Road"
+      "roomId": 7401,
+      "_name": "Factory Tram Station",
+      "_area": "Factory",
+      "_gridCol": 56,
+      "_gridRow": 7,
+      "_inferred": true
     },
     {
-      "roomId": 2119,
-      "type": "street",
-      "sector": "montenegro",
+      "type": "hub",
+      "sector": "kobe",
+      "icon": 51,
       "exits": {
         "north": null,
-        "south": null,
-        "east": null,
-        "west": 2120
+        "south": 4211,
+        "east": 4403,
+        "west": null
       },
-      "_gridCol": 15,
-      "_gridRow": 14,
-      "_name": "Road"
+      "roomId": 151,
+      "_name": "Kobe Slums",
+      "_area": "Kobe Slums",
+      "_gridCol": 18,
+      "_gridRow": 8,
+      "description": "Despite Kobe's general high standard of living, some still live in poverty, pursued by the demons of gambling addiction and crime. The street layout is complex.",
+      "_sourceBitmap": "Solaris - Bitmap\\Kobe\\Kobe Slums\\main.bmp"
     },
     {
-      "roomId": 2121,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": 2137,
-        "east": null,
-        "west": 2122
-      },
-      "_gridCol": 13,
-      "_gridRow": 14,
-      "_name": "Road"
-    },
-    {
-      "roomId": 2122,
-      "type": "street",
-      "sector": "silesia",
-      "exits": {
-        "north": null,
-        "south": null,
-        "east": 2121,
-        "west": 2123
-      },
-      "_gridCol": 12,
-      "_gridRow": 14,
-      "_name": "Road"
-    },
-    {
-      "roomId": 9000,
-      "_name": "Tram Station",
-      "description": "Click on the Tram icon for a subway map of Solaris City. The map shows sectors in white and districts in color. From the map, click on a district name and then on \"Travel\" to travel to that district.",
       "type": "tram",
-      "sector": "international",
+      "sector": "kobe",
       "icon": 0,
       "exits": {
         "north": null,
         "south": null,
+        "east": 4215,
+        "west": 151
+      },
+      "roomId": 4403,
+      "_name": "Kobe Slums Tram Station",
+      "_area": "Kobe Slums",
+      "_gridCol": 19,
+      "_gridRow": 8,
+      "_inferred": true
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 52,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4216,
+        "west": 4403
+      },
+      "roomId": 4215,
+      "_name": "North Theodore Kurita St",
+      "_area": "Kobe Slums",
+      "_gridCol": 20,
+      "_gridRow": 8
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 51,
+      "exits": {
+        "north": null,
+        "south": 4217,
+        "east": null,
+        "west": 4215
+      },
+      "roomId": 4216,
+      "_name": "North Theodore Kurita St",
+      "_area": "Kobe Slums",
+      "_gridCol": 21,
+      "_gridRow": 8
+    },
+    {
+      "type": "arena",
+      "sector": "montenegro",
+      "icon": 12,
+      "exits": {
+        "north": 7401,
+        "south": 7220,
+        "east": 7410,
+        "west": null
+      },
+      "roomId": 157,
+      "_name": "Factory",
+      "_area": "Factory",
+      "_gridCol": 56,
+      "_gridRow": 8,
+      "description": "A refitted shuttle production facility, The Factory has enjoyed remarkable success despite its small size and lack of sophistication. Situated within the industrial sector, it draws consistent crowds, who suffer the cramped conditions gladly. The street layout is very simple.",
+      "_sourceBitmap": "Solaris - Bitmap\\Montenegro\\Factory\\main.bmp"
+    },
+    {
+      "type": "ready_room",
+      "sector": "montenegro",
+      "icon": 44,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7411,
+        "west": 157
+      },
+      "roomId": 7410,
+      "_name": "Factory Ready Room",
+      "_area": "Factory",
+      "_sceneRoomId": 157,
+      "_gridCol": 57,
+      "_gridRow": 8,
+      "_inferred": true,
+      "description": "Ready room for Factory arena combatants."
+    },
+    {
+      "type": "drop_room",
+      "sector": "montenegro",
+      "icon": 11,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": null,
+        "west": 7410
+      },
+      "roomId": 7411,
+      "_name": "Factory Drop Room",
+      "_area": "Factory",
+      "_sceneRoomId": 157,
+      "_gridCol": 58,
+      "_gridRow": 8,
+      "_inferred": true,
+      "description": "Drop room connected to the Factory ready room."
+    },
+    {
+      "type": "hub",
+      "sector": "montenegro",
+      "icon": 53,
+      "exits": {
+        "north": null,
+        "south": 7232,
+        "east": 7402,
+        "west": null
+      },
+      "roomId": 161,
+      "_name": "Wasteland",
+      "_area": "Wasteland",
+      "_gridCol": 66,
+      "_gridRow": 8,
+      "description": "This grim, deadly jungle of abandoned manufacturing plants, warehouses, foundries and offices holds only the desperate, luckless and ruthless, who accept the brutal living conditions as the price of a great hiding place. The street layout is complex.",
+      "_sourceBitmap": "Solaris - Bitmap\\Montenegro\\Wasteland\\main.bmp"
+    },
+    {
+      "type": "tram",
+      "sector": "montenegro",
+      "icon": 0,
+      "exits": {
+        "north": null,
+        "south": 7233,
+        "east": null,
+        "west": 161
+      },
+      "roomId": 7402,
+      "_name": "Wasteland Tram Station",
+      "_area": "Wasteland",
+      "_gridCol": 67,
+      "_gridRow": 8,
+      "_inferred": true
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 57,
+      "exits": {
+        "north": 151,
+        "south": 4210,
+        "east": null,
+        "west": null
+      },
+      "roomId": 4211,
+      "_name": "Proserpina St",
+      "_area": "Kobe Slums",
+      "_gridCol": 18,
+      "_gridRow": 9
+    },
+    {
+      "type": "bar",
+      "sector": "kobe",
+      "icon": 27,
+      "exits": {
+        "north": null,
+        "south": 4104,
+        "east": 4217,
+        "west": null
+      },
+      "roomId": 4004,
+      "_name": "Hodie's Hideaway",
+      "_area": "Kobe Slums",
+      "_gridCol": 20,
+      "_gridRow": 9,
+      "description": "You are in Hodie's Hideaway, where Lisa, the chef, will rock your culinary world. To the south you see a data terminal. To the east you see North Theodore Kurita Street.",
+      "_sourceBitmap": "Solaris - Bitmap\\Kobe\\Kobe Slums\\2.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 51,
+      "exits": {
+        "north": 4216,
+        "south": 4218,
+        "east": null,
+        "west": 4004
+      },
+      "roomId": 4217,
+      "_name": "North Theodore Kurita St",
+      "_area": "Kobe Slums",
+      "_gridCol": 21,
+      "_gridRow": 9
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 48,
+      "exits": {
+        "north": null,
+        "south": 7202,
+        "east": 7221,
+        "west": null
+      },
+      "roomId": 7222,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 54,
+      "_gridRow": 9
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 48,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7220,
+        "west": 7222
+      },
+      "roomId": 7221,
+      "_name": "Factory Access Road",
+      "_area": "Factory",
+      "_gridCol": 55,
+      "_gridRow": 9
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 48,
+      "exits": {
+        "north": 157,
+        "south": null,
+        "east": 7223,
+        "west": 7221
+      },
+      "roomId": 7220,
+      "_name": "Factory Access Road",
+      "_area": "Factory",
+      "_gridCol": 56,
+      "_gridRow": 9
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 48,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7224,
+        "west": 7220
+      },
+      "roomId": 7223,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 57,
+      "_gridRow": 9
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 52,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7225,
+        "west": 7223
+      },
+      "roomId": 7224,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 58,
+      "_gridRow": 9
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 48,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7226,
+        "west": 7224
+      },
+      "roomId": 7225,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 59,
+      "_gridRow": 9
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 52,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7227,
+        "west": 7225
+      },
+      "roomId": 7226,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 60,
+      "_gridRow": 9
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 48,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7228,
+        "west": 7226
+      },
+      "roomId": 7227,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 61,
+      "_gridRow": 9
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 52,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7229,
+        "west": 7227
+      },
+      "roomId": 7228,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 62,
+      "_gridRow": 9
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 48,
+      "exits": {
+        "north": null,
+        "south": 7205,
+        "east": 7230,
+        "west": 7228
+      },
+      "roomId": 7229,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 63,
+      "_gridRow": 9
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 52,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7231,
+        "west": 7229
+      },
+      "roomId": 7230,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 64,
+      "_gridRow": 9
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 48,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7232,
+        "west": 7230
+      },
+      "roomId": 7231,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 65,
+      "_gridRow": 9
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 52,
+      "exits": {
+        "north": 161,
+        "south": null,
+        "east": 7233,
+        "west": 7231
+      },
+      "roomId": 7232,
+      "_name": "Bolivar St",
+      "_area": "Montenegro Roads",
+      "_gridCol": 66,
+      "_gridRow": 9
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 51,
+      "exits": {
+        "north": 7402,
+        "south": 7252,
+        "east": 7234,
+        "west": 7232
+      },
+      "roomId": 7233,
+      "_name": "Bolivar St",
+      "_area": "Montenegro Roads",
+      "_gridCol": 67,
+      "_gridRow": 9
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 48,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7235,
+        "west": 7233
+      },
+      "roomId": 7234,
+      "_name": "Bolivar St",
+      "_area": "Montenegro Roads",
+      "_gridCol": 68,
+      "_gridRow": 9
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 52,
+      "exits": {
+        "north": null,
+        "south": 7206,
+        "east": null,
+        "west": 7234
+      },
+      "roomId": 7235,
+      "_name": "Bolivar St",
+      "_area": "Montenegro Roads",
+      "_gridCol": 69,
+      "_gridRow": 9
+    },
+    {
+      "type": "terminal",
+      "sector": "kobe",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4003,
+        "west": null
+      },
+      "roomId": 4103,
+      "_name": "Public Data Terminal",
+      "_area": "Kobe Slums",
+      "_gridCol": 16,
+      "_gridRow": 10
+    },
+    {
+      "type": "bar",
+      "sector": "kobe",
+      "icon": 2,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4210,
+        "west": 4103
+      },
+      "roomId": 4003,
+      "_name": "The Ferro-Fibrous Dinosaur",
+      "_area": "Kobe Slums",
+      "_gridCol": 17,
+      "_gridRow": 10,
+      "description": "You are relieved of your weapons at the door by a big guy in a fuzzy suit. To the east you see the intersection of Yamato and Proserpina St. To the west you see a data terminal.",
+      "_sourceBitmap": "Solaris - Bitmap\\Kobe\\Kobe Slums\\1.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 25,
+      "exits": {
+        "north": 4211,
+        "south": null,
+        "east": null,
+        "west": 4003
+      },
+      "roomId": 4210,
+      "_name": "Yamato St / Proserpina St",
+      "_area": "Kobe Slums",
+      "_gridCol": 18,
+      "_gridRow": 10
+    },
+    {
+      "type": "terminal",
+      "sector": "kobe",
+      "icon": 21,
+      "exits": {
+        "north": 4004,
+        "south": null,
+        "east": null,
+        "west": null
+      },
+      "roomId": 4104,
+      "_name": "Public Data Terminal",
+      "_area": "Kobe Slums",
+      "_gridCol": 20,
+      "_gridRow": 10
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 52,
+      "exits": {
+        "north": 4217,
+        "south": 4222,
+        "east": null,
+        "west": null
+      },
+      "roomId": 4218,
+      "_name": "North Theodore Kurita St",
+      "_area": "Kobe Slums",
+      "_gridCol": 21,
+      "_gridRow": 10
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 47,
+      "exits": {
+        "north": 7222,
+        "south": 7260,
+        "east": 7002,
+        "west": null
+      },
+      "roomId": 7202,
+      "_name": "Montenegro Street",
+      "_area": "Factory",
+      "_gridCol": 54,
+      "_gridRow": 10
+    },
+    {
+      "type": "bar",
+      "sector": "montenegro",
+      "icon": 26,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7102,
+        "west": 7202
+      },
+      "roomId": 7002,
+      "_name": "The Reiver",
+      "_area": "Factory",
+      "_gridCol": 55,
+      "_gridRow": 10,
+      "description": "You are in a bar called The Reiver. To the east you see a public data terminal. To the west you see Montenegro Street.",
+      "_sourceBitmap": "Solaris - Bitmap\\Montenegro\\Factory\\1.bmp"
+    },
+    {
+      "type": "terminal",
+      "sector": "montenegro",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": null,
+        "west": 7002
+      },
+      "roomId": 7102,
+      "_name": "Public Data Terminal",
+      "_area": "Factory",
+      "_gridCol": 56,
+      "_gridRow": 10
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 46,
+      "exits": {
+        "north": 7229,
+        "south": null,
+        "east": 7005,
+        "west": null
+      },
+      "roomId": 7205,
+      "_name": "Via Dolorosa",
+      "_area": "Wasteland",
+      "_gridCol": 63,
+      "_gridRow": 10
+    },
+    {
+      "type": "bar",
+      "sector": "montenegro",
+      "icon": 2,
+      "exits": {
+        "north": null,
+        "south": 7105,
+        "east": null,
+        "west": 7205
+      },
+      "roomId": 7005,
+      "_name": "Froglover's Pizza",
+      "_area": "Wasteland",
+      "_gridCol": 64,
+      "_gridRow": 10,
+      "description": "You are in a sad little shop called Froglover's Pizza, which appears to have a dearth of customers. To the south you see a public data terminal. To the west you see the Via Dolorosa.",
+      "_sourceBitmap": "Solaris - Bitmap\\Montenegro\\Wasteland\\1.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 56,
+      "exits": {
+        "north": 7233,
+        "south": 7250,
+        "east": null,
+        "west": null
+      },
+      "roomId": 7252,
+      "_name": "West Bolivar St",
+      "_area": "Wasteland",
+      "_gridCol": 67,
+      "_gridRow": 10
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 48,
+      "exits": {
+        "north": 7235,
+        "south": 7006,
+        "east": null,
+        "west": null
+      },
+      "roomId": 7206,
+      "_name": "Bolivar St",
+      "_area": "Wasteland",
+      "_gridCol": 69,
+      "_gridRow": 10
+    },
+    {
+      "type": "terminal",
+      "sector": "kobe",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": 4005,
+        "east": null,
+        "west": null
+      },
+      "roomId": 4105,
+      "_name": "Public Data Terminal",
+      "_area": "Kobe Slums",
+      "_gridCol": 18,
+      "_gridRow": 11
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 51,
+      "exits": {
+        "north": 4218,
+        "south": 4223,
+        "east": null,
+        "west": null
+      },
+      "roomId": 4222,
+      "_name": "North Theodore Kurita St",
+      "_area": "Kobe Slums",
+      "_gridCol": 21,
+      "_gridRow": 11
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 48,
+      "exits": {
+        "north": 7202,
+        "south": 7261,
+        "east": null,
+        "west": null
+      },
+      "roomId": 7260,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 54,
+      "_gridRow": 11
+    },
+    {
+      "type": "terminal",
+      "sector": "montenegro",
+      "icon": 21,
+      "exits": {
+        "north": 7005,
+        "south": null,
+        "east": null,
+        "west": null
+      },
+      "roomId": 7105,
+      "_name": "Public Data Terminal",
+      "_area": "Wasteland",
+      "_gridCol": 64,
+      "_gridRow": 11
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 55,
+      "exits": {
+        "north": 7252,
+        "south": 7207,
+        "east": null,
+        "west": null
+      },
+      "roomId": 7250,
+      "_name": "West Bolivar St",
+      "_area": "Wasteland",
+      "_gridCol": 67,
+      "_gridRow": 11
+    },
+    {
+      "type": "terminal",
+      "sector": "montenegro",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7006,
+        "west": null
+      },
+      "roomId": 7106,
+      "_name": "Public Data Terminal",
+      "_area": "Wasteland",
+      "_gridCol": 68,
+      "_gridRow": 11
+    },
+    {
+      "type": "bar",
+      "sector": "montenegro",
+      "icon": 27,
+      "exits": {
+        "north": 7206,
+        "south": null,
+        "east": null,
+        "west": 7106
+      },
+      "roomId": 7006,
+      "_name": "Shizuka's House of Pain",
+      "_area": "Wasteland",
+      "_gridCol": 69,
+      "_gridRow": 11,
+      "description": "You are sure you understand the bar's name after having your first drink. To the north you see Bolivar St., a small promenade closed to motor traffic. To the west you see a public data terminal.",
+      "_sourceBitmap": "Solaris - Bitmap\\Montenegro\\Wasteland\\2.bmp"
+    },
+    {
+      "type": "bar",
+      "sector": "kobe",
+      "icon": 27,
+      "exits": {
+        "north": 4105,
+        "south": 4219,
+        "east": null,
+        "west": null
+      },
+      "roomId": 4005,
+      "_name": "The Iron Throne",
+      "_area": "Kobe Slums",
+      "_gridCol": 18,
+      "_gridRow": 12,
+      "description": "You are in The Iron Throne, where equanimous patrons are sipping drinks and watching fight telecasts. To the north you see a data terminal. To the south you see a set of marble steps sweeping up towards the Snowbird.",
+      "_sourceBitmap": "Solaris - Bitmap\\Kobe\\Kobe Slums\\3.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 53,
+      "exits": {
+        "north": 4222,
+        "south": 4224,
+        "east": null,
+        "west": null
+      },
+      "roomId": 4223,
+      "_name": "North Theodore Kurita St",
+      "_area": "Kobe Slums",
+      "_gridCol": 21,
+      "_gridRow": 12
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 52,
+      "exits": {
+        "north": 7260,
+        "south": 7262,
+        "east": null,
+        "west": null
+      },
+      "roomId": 7261,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 54,
+      "_gridRow": 12
+    },
+    {
+      "type": "terminal",
+      "sector": "montenegro",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7007,
+        "west": null
+      },
+      "roomId": 7107,
+      "_name": "Public Data Terminal",
+      "_area": "Wasteland",
+      "_gridCol": 65,
+      "_gridRow": 12
+    },
+    {
+      "type": "bar",
+      "sector": "montenegro",
+      "icon": 2,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7207,
+        "west": 7107
+      },
+      "roomId": 7007,
+      "_name": "The Bubbling Kettel",
+      "_area": "Wasteland",
+      "_gridCol": 66,
+      "_gridRow": 12,
+      "description": "You are in The Bubbling Kettel, where Gregg, the jolly proprietor, is constantly and mercilessly cheerful. To the east you see West Bolivar St. To the west you see a public data terminal.",
+      "_sourceBitmap": "Solaris - Bitmap\\Montenegro\\Wasteland\\3.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 56,
+      "exits": {
+        "north": 7250,
+        "south": null,
+        "east": 7251,
+        "west": 7007
+      },
+      "roomId": 7207,
+      "_name": "West Bolivar St",
+      "_area": "Wasteland",
+      "_gridCol": 67,
+      "_gridRow": 12
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 56,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7208,
+        "west": 7207
+      },
+      "roomId": 7251,
+      "_name": "West Bolivar St",
+      "_area": "Wasteland",
+      "_gridCol": 68,
+      "_gridRow": 12
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 54,
+      "exits": {
+        "north": null,
+        "south": 7008,
+        "east": null,
+        "west": 7251
+      },
+      "roomId": 7208,
+      "_name": "Montenegro Nightlife",
+      "_area": "Wasteland",
+      "_gridCol": 69,
+      "_gridRow": 12
+    },
+    {
+      "type": "hub",
+      "sector": "kobe",
+      "icon": 57,
+      "exits": {
+        "north": null,
+        "south": 4405,
+        "east": 4250,
+        "west": null
+      },
+      "roomId": 149,
+      "_name": "White Lotus",
+      "_area": "White Lotus",
+      "_gridCol": 9,
+      "_gridRow": 13,
+      "description": "The standard of living in White Lotus is second only to the Chancellor's Quarter in Cathay, and security in the district is the best on the planet. The street layout is of average complexity.",
+      "_sourceBitmap": "Solaris - Bitmap\\Kobe\\White Lotus\\main.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 48,
+      "exits": {
+        "north": null,
+        "south": 4007,
+        "east": 4251,
+        "west": 149
+      },
+      "roomId": 4250,
+      "_name": "Buckminster Circle",
+      "_area": "White Lotus",
+      "_gridCol": 10,
+      "_gridRow": 13
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 48,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4252,
+        "west": 4250
+      },
+      "roomId": 4251,
+      "_name": "Buckminster Circle",
+      "_area": "White Lotus",
+      "_gridCol": 11,
+      "_gridRow": 13
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 57,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4253,
+        "west": 4251
+      },
+      "roomId": 4252,
+      "_name": "Buckminster Circle",
+      "_area": "White Lotus",
+      "_gridCol": 12,
+      "_gridRow": 13
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 49,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4254,
+        "west": 4252
+      },
+      "roomId": 4253,
+      "_name": "Buckminster Circle",
+      "_area": "White Lotus",
+      "_gridCol": 13,
+      "_gridRow": 13
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 48,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4255,
+        "west": 4253
+      },
+      "roomId": 4254,
+      "_name": "Buckminster Circle",
+      "_area": "White Lotus",
+      "_gridCol": 14,
+      "_gridRow": 13
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 57,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4256,
+        "west": 4254
+      },
+      "roomId": 4255,
+      "_name": "Buckminster Circle",
+      "_area": "White Lotus",
+      "_gridCol": 15,
+      "_gridRow": 13
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 49,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4257,
+        "west": 4255
+      },
+      "roomId": 4256,
+      "_name": "Buckminster Circle",
+      "_area": "White Lotus",
+      "_gridCol": 16,
+      "_gridRow": 13
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 48,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4219,
+        "west": 4256
+      },
+      "roomId": 4257,
+      "_name": "Buckminster Circle",
+      "_area": "White Lotus",
+      "_gridCol": 17,
+      "_gridRow": 13
+    },
+    {
+      "type": "path",
+      "sector": "kobe",
+      "icon": 46,
+      "exits": {
+        "north": 4005,
+        "south": null,
+        "east": 4220,
+        "west": 4257
+      },
+      "roomId": 4219,
+      "_name": "Marble Steps to Snowbird",
+      "_area": "Kobe Slums",
+      "_gridCol": 18,
+      "_gridRow": 13,
+      "_sourceBitmap": "Solaris - Bitmap\\Kobe\\Kobe Slums\\3.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 46,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4221,
+        "west": 4219
+      },
+      "roomId": 4220,
+      "_name": "Marble Steps to Snowbird",
+      "_area": "Kobe Slums",
+      "_gridCol": 19,
+      "_gridRow": 13
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 46,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4224,
+        "west": 4220
+      },
+      "roomId": 4221,
+      "_name": "Marble Steps to Snowbird",
+      "_area": "Kobe Slums",
+      "_gridCol": 20,
+      "_gridRow": 13
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 52,
+      "exits": {
+        "north": 4223,
+        "south": null,
+        "east": 4225,
+        "west": 4221
+      },
+      "roomId": 4224,
+      "_name": "North Theodore Kurita St",
+      "_area": "Kobe Slums",
+      "_gridCol": 21,
+      "_gridRow": 13
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 25,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4226,
+        "west": 4224
+      },
+      "roomId": 4225,
+      "_name": "Proserpina St",
+      "_area": "Kobe Slums",
+      "_gridCol": 22,
+      "_gridRow": 13
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 57,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4227,
+        "west": 4225
+      },
+      "roomId": 4226,
+      "_name": "Proserpina St",
+      "_area": "Kobe Slums",
+      "_gridCol": 23,
+      "_gridRow": 13
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 49,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4228,
+        "west": 4226
+      },
+      "roomId": 4227,
+      "_name": "Proserpina St",
+      "_area": "Kobe Slums",
+      "_gridCol": 24,
+      "_gridRow": 13
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 45,
+      "exits": {
+        "north": null,
+        "south": 148,
+        "east": null,
+        "west": 4227
+      },
+      "roomId": 4228,
+      "_name": "Government House Approach",
+      "_area": "Kobe Roads",
+      "_gridCol": 25,
+      "_gridRow": 13
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 48,
+      "exits": {
+        "north": 7261,
+        "south": 7263,
+        "east": null,
+        "west": null
+      },
+      "roomId": 7262,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 54,
+      "_gridRow": 13
+    },
+    {
+      "type": "terminal",
+      "sector": "montenegro",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7008,
+        "west": null
+      },
+      "roomId": 7108,
+      "_name": "Public Data Terminal",
+      "_area": "Wasteland",
+      "_gridCol": 68,
+      "_gridRow": 13
+    },
+    {
+      "type": "bar",
+      "sector": "montenegro",
+      "icon": 27,
+      "exits": {
+        "north": 7208,
+        "south": null,
+        "east": null,
+        "west": 7108
+      },
+      "roomId": 7008,
+      "_name": "Boot's House of Boot",
+      "_area": "Wasteland",
+      "_gridCol": 69,
+      "_gridRow": 13,
+      "description": "You are in Boot's House of Boot, where 'boot' is the word, man. Can you dig? Yeah, have another beer. To the north you see the thick of Montenegro's nightlife. To the west you see a public data terminal.",
+      "_sourceBitmap": "Solaris - Bitmap\\Montenegro\\Wasteland\\4.bmp"
+    },
+    {
+      "type": "tram",
+      "sector": "kobe",
+      "icon": 0,
+      "exits": {
+        "north": 149,
+        "south": null,
+        "east": null,
+        "west": null
+      },
+      "roomId": 4405,
+      "_name": "White Lotus Tram Station",
+      "_area": "White Lotus",
+      "_gridCol": 9,
+      "_gridRow": 14,
+      "_inferred": true
+    },
+    {
+      "type": "bar",
+      "sector": "kobe",
+      "icon": 27,
+      "exits": {
+        "north": 4250,
+        "south": null,
+        "east": 4107,
+        "west": null
+      },
+      "roomId": 4007,
+      "_name": "The Snowbird",
+      "_area": "White Lotus",
+      "_gridCol": 10,
+      "_gridRow": 14,
+      "description": "You are in the Snowbird. To the north you see Buckminster Circle. To the east you see a public data terminal.",
+      "_sourceBitmap": "Solaris - Bitmap\\Kobe\\White Lotus\\1.bmp"
+    },
+    {
+      "type": "terminal",
+      "sector": "kobe",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": null,
+        "west": 4007
+      },
+      "roomId": 4107,
+      "_name": "Public Data Terminal",
+      "_area": "White Lotus",
+      "_gridCol": 11,
+      "_gridRow": 14
+    },
+    {
+      "type": "terminal",
+      "sector": "kobe",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": 4001,
+        "east": null,
+        "west": null
+      },
+      "roomId": 4101,
+      "_name": "Public Data Terminal",
+      "_area": "Government House",
+      "_gridCol": 24,
+      "_gridRow": 14
+    },
+    {
+      "type": "headquarters",
+      "sector": "kobe",
+      "icon": 45,
+      "exits": {
+        "north": 4228,
+        "south": 4261,
+        "east": 4401,
+        "west": null
+      },
+      "roomId": 148,
+      "_name": "Government House",
+      "_area": "Government House",
+      "_gridCol": 25,
+      "_gridRow": 14,
+      "description": "With a sweeping view of War Memorial Park, this district is the center of civil administration for the sector. The stately white Government House is the official home of the Kobe governor. The street layout is simple.",
+      "_sourceBitmap": "Solaris - Bitmap\\Kobe\\Government House\\main.bmp"
+    },
+    {
+      "type": "tram",
+      "sector": "kobe",
+      "icon": 0,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": null,
+        "west": 148
+      },
+      "roomId": 4401,
+      "_name": "Government House Tram Station",
+      "_area": "Government House",
+      "_gridCol": 26,
+      "_gridRow": 14,
+      "_inferred": true
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 52,
+      "exits": {
+        "north": 7262,
+        "south": 7264,
+        "east": null,
+        "west": null
+      },
+      "roomId": 7263,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 54,
+      "_gridRow": 14
+    },
+    {
+      "type": "bar",
+      "sector": "kobe",
+      "icon": 2,
+      "exits": {
+        "north": 4101,
+        "south": 4201,
+        "east": null,
+        "west": null
+      },
+      "roomId": 4001,
+      "_name": "The Marauder Bar",
+      "_area": "Government House",
+      "_gridCol": 24,
+      "_gridRow": 15,
+      "description": "You are in the Marauder Bar. To the north you see a public data terminal. To the south you see Yamato St.",
+      "_sourceBitmap": "Solaris - Bitmap\\Kobe\\Government House\\1.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 57,
+      "exits": {
+        "north": 148,
+        "south": 4262,
+        "east": null,
+        "west": null
+      },
+      "roomId": 4261,
+      "_name": "Government House Approach",
+      "_area": "Kobe Roads",
+      "_gridCol": 25,
+      "_gridRow": 15
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 48,
+      "exits": {
+        "north": 7263,
+        "south": null,
+        "east": 4,
+        "west": null
+      },
+      "roomId": 7264,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 54,
+      "_gridRow": 15
+    },
+    {
+      "type": "sector",
+      "sector": "montenegro",
+      "icon": 40,
+      "exits": {
+        "north": null,
+        "south": 7270,
+        "east": null,
+        "west": 7264
+      },
+      "roomId": 4,
+      "_name": "Montenegro Sector",
+      "_area": "Sector Overview",
+      "_gridCol": 55,
+      "_gridRow": 15,
+      "description": "Montenegro is an ugly place, with its abandoned industrial complexes and fierce commercialization. Authorities are far more concerned about maintaining the ties between member-states than improving living and working conditions in the sector. The fixed arenas in Montenegro use tropical terrain.",
+      "_sourceBitmap": "Solaris - Bitmap\\Montenegro\\main.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 24,
+      "exits": {
+        "north": 4001,
+        "south": 4202,
+        "east": 4262,
+        "west": null
+      },
+      "roomId": 4201,
+      "_name": "Yamato St",
+      "_area": "Government House",
+      "_gridCol": 24,
+      "_gridRow": 16
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 49,
+      "exits": {
+        "north": 4261,
+        "south": 4263,
+        "east": null,
+        "west": 4201
+      },
+      "roomId": 4262,
+      "_name": "Government House Approach",
+      "_area": "Kobe Roads",
+      "_gridCol": 25,
+      "_gridRow": 16
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 48,
+      "exits": {
+        "north": 4,
+        "south": 7271,
+        "east": null,
+        "west": null
+      },
+      "roomId": 7270,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 55,
+      "_gridRow": 16
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 50,
+      "exits": {
+        "north": 4201,
+        "south": 4203,
+        "east": 4263,
+        "west": null
+      },
+      "roomId": 4202,
+      "_name": "Yamato St",
+      "_area": "Kobe Roads",
+      "_gridCol": 24,
+      "_gridRow": 17
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 24,
+      "exits": {
+        "north": 4262,
+        "south": null,
+        "east": null,
+        "west": 4202
+      },
+      "roomId": 4263,
+      "_name": "Yamato St",
+      "_area": "Kobe Roads",
+      "_gridCol": 25,
+      "_gridRow": 17
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 52,
+      "exits": {
+        "north": 7270,
+        "south": 7272,
+        "east": null,
+        "west": null
+      },
+      "roomId": 7271,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 55,
+      "_gridRow": 17
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 47,
+      "exits": {
+        "north": null,
+        "south": 4248,
+        "east": 4265,
+        "west": null
+      },
+      "roomId": 4249,
+      "_name": "Waterfront Road",
+      "_area": "Waterfront",
+      "_gridCol": 15,
+      "_gridRow": 18
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 54,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 2,
+        "west": 4249
+      },
+      "roomId": 4265,
+      "_name": "Kobe Road",
+      "_area": "Kobe Roads",
+      "_gridCol": 16,
+      "_gridRow": 18
+    },
+    {
+      "type": "sector",
+      "sector": "kobe",
+      "icon": 38,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4266,
+        "west": 4265
+      },
+      "roomId": 2,
+      "_name": "Kobe Sector",
+      "_area": "Sector Overview",
+      "_gridCol": 17,
+      "_gridRow": 18,
+      "description": "The Kurita sector is beautiful as well as safe. The tourist trade is detoured around those areas with a higher crime rate, and the corruption within Kobe authority is not obvious to the outsider. The fixed arenas in Kobe use desert terrain.",
+      "_sourceBitmap": "Solaris - Bitmap\\Kobe\\main.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 54,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4267,
+        "west": 2
+      },
+      "roomId": 4266,
+      "_name": "Kobe Road",
+      "_area": "Kobe Roads",
+      "_gridCol": 18,
+      "_gridRow": 18
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 56,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4268,
+        "west": 4266
+      },
+      "roomId": 4267,
+      "_name": "Kobe Road",
+      "_area": "Kobe Roads",
+      "_gridCol": 19,
+      "_gridRow": 18
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 55,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4269,
+        "west": 4267
+      },
+      "roomId": 4268,
+      "_name": "Kobe Road",
+      "_area": "Kobe Roads",
+      "_gridCol": 20,
+      "_gridRow": 18
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 54,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4270,
+        "west": 4268
+      },
+      "roomId": 4269,
+      "_name": "Kobe Road",
+      "_area": "Kobe Roads",
+      "_gridCol": 21,
+      "_gridRow": 18
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 56,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4271,
+        "west": 4269
+      },
+      "roomId": 4270,
+      "_name": "Kobe Road",
+      "_area": "Kobe Roads",
+      "_gridCol": 22,
+      "_gridRow": 18
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 55,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4203,
+        "west": 4270
+      },
+      "roomId": 4271,
+      "_name": "Kobe Road",
+      "_area": "Kobe Roads",
+      "_gridCol": 23,
+      "_gridRow": 18
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 24,
+      "exits": {
+        "north": 4202,
+        "south": null,
+        "east": 4204,
+        "west": 4271
+      },
+      "roomId": 4203,
+      "_name": "Yamato St",
+      "_area": "Kobe Roads",
+      "_gridCol": 24,
+      "_gridRow": 18
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 53,
+      "exits": {
+        "north": null,
+        "south": 4264,
+        "east": null,
+        "west": 4203
+      },
+      "roomId": 4204,
+      "_name": "Theodore Kurita St",
+      "_area": "Kobe Roads",
+      "_gridCol": 25,
+      "_gridRow": 18
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 48,
+      "exits": {
+        "north": 7271,
+        "south": 7273,
+        "east": null,
+        "west": null
+      },
+      "roomId": 7272,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 55,
+      "_gridRow": 18
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 51,
+      "exits": {
+        "north": null,
+        "south": 4006,
+        "east": 4241,
+        "west": null
+      },
+      "roomId": 4240,
+      "_name": "Robert Kurita St",
+      "_area": "Waterfront",
+      "_gridCol": 11,
+      "_gridRow": 19
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 51,
+      "exits": {
+        "north": null,
+        "south": 4242,
+        "east": null,
+        "west": 4240
+      },
+      "roomId": 4241,
+      "_name": "Robert Kurita St",
+      "_area": "Waterfront",
+      "_gridCol": 12,
+      "_gridRow": 19
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 47,
+      "exits": {
+        "north": 4249,
+        "south": 4247,
+        "east": null,
+        "west": null
+      },
+      "roomId": 4248,
+      "_name": "Waterfront Road",
+      "_area": "Waterfront",
+      "_gridCol": 15,
+      "_gridRow": 19
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 51,
+      "exits": {
+        "north": 4204,
+        "south": 4205,
+        "east": null,
+        "west": null
+      },
+      "roomId": 4264,
+      "_name": "Theodore Kurita St",
+      "_area": "Kobe Roads",
+      "_gridCol": 25,
+      "_gridRow": 19
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 52,
+      "exits": {
+        "north": 7272,
+        "south": 7274,
+        "east": null,
+        "west": null
+      },
+      "roomId": 7273,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 55,
+      "_gridRow": 19
+    },
+    {
+      "type": "terminal",
+      "sector": "kobe",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4006,
+        "west": null
+      },
+      "roomId": 4106,
+      "_name": "Public Data Terminal",
+      "_area": "Waterfront",
+      "_gridCol": 10,
+      "_gridRow": 20
+    },
+    {
+      "type": "bar",
+      "sector": "kobe",
+      "icon": 27,
+      "exits": {
+        "north": 4240,
+        "south": null,
+        "east": null,
+        "west": 4106
+      },
+      "roomId": 4006,
+      "_name": "The Silver Clan",
+      "_area": "Waterfront",
+      "_gridCol": 11,
+      "_gridRow": 20,
+      "description": "You are in The Silver Clan. To the north you see Robert Kurita St. To the west you see a public data terminal.",
+      "_sourceBitmap": "Solaris - Bitmap\\Kobe\\Waterfront\\1.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 55,
+      "exits": {
+        "north": 4241,
+        "south": 4243,
+        "east": null,
+        "west": null
+      },
+      "roomId": 4242,
+      "_name": "Robert Kurita St",
+      "_area": "Waterfront",
+      "_gridCol": 12,
+      "_gridRow": 20
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 47,
+      "exits": {
+        "north": 4248,
+        "south": 4246,
+        "east": null,
+        "west": null
+      },
+      "roomId": 4247,
+      "_name": "Waterfront Road",
+      "_area": "Waterfront",
+      "_gridCol": 15,
+      "_gridRow": 20
+    },
+    {
+      "type": "terminal",
+      "sector": "kobe",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4002,
+        "west": null
+      },
+      "roomId": 4102,
+      "_name": "Public Data Terminal",
+      "_area": "Ishiyama Arena",
+      "_gridCol": 23,
+      "_gridRow": 20
+    },
+    {
+      "type": "bar",
+      "sector": "kobe",
+      "icon": 27,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4205,
+        "west": 4102
+      },
+      "roomId": 4002,
+      "_name": "The Paradise Bar",
+      "_area": "Ishiyama Arena",
+      "_gridCol": 24,
+      "_gridRow": 20,
+      "description": "You are in a bar called The Paradise. To the east you see Theodore Kurita St. To the west you see a public data terminal.",
+      "_sourceBitmap": "Solaris - Bitmap\\Kobe\\Ishiyama Arena\\1.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 51,
+      "exits": {
+        "north": 4264,
+        "south": 147,
+        "east": null,
+        "west": 4002
+      },
+      "roomId": 4205,
+      "_name": "Theodore Kurita St",
+      "_area": "Ishiyama Arena",
+      "_gridCol": 25,
+      "_gridRow": 20
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 48,
+      "exits": {
+        "north": 7273,
+        "south": 7276,
+        "east": 7275,
+        "west": null
+      },
+      "roomId": 7274,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 55,
+      "_gridRow": 20
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 55,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 159,
+        "west": 7274
+      },
+      "roomId": 7275,
+      "_name": "Allman Road",
+      "_area": "Allman",
+      "_gridCol": 56,
+      "_gridRow": 20
+    },
+    {
+      "type": "hub",
+      "sector": "montenegro",
+      "icon": 54,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7403,
+        "west": 7275
+      },
+      "roomId": 159,
+      "_name": "Allman",
+      "_area": "Allman",
+      "_gridCol": 57,
+      "_gridRow": 20,
+      "description": "The common people's residential area is every bit as bleak and charmless as the rest of Montenegro, with anonymous high-rises and row houses as the rule. The street layout is of average complexity.",
+      "_sourceBitmap": "Solaris - Bitmap\\Montenegro\\Allman\\main.bmp"
+    },
+    {
+      "type": "tram",
+      "sector": "montenegro",
+      "icon": 0,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": null,
+        "west": 159
+      },
+      "roomId": 7403,
+      "_name": "Allman Tram Station",
+      "_area": "Allman",
+      "_gridCol": 58,
+      "_gridRow": 20,
+      "_inferred": true
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 47,
+      "exits": {
+        "north": 4242,
+        "south": 150,
+        "east": 4244,
+        "west": null
+      },
+      "roomId": 4243,
+      "_name": "Waterfront Road",
+      "_area": "Waterfront",
+      "_gridCol": 12,
+      "_gridRow": 21
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 46,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4245,
+        "west": 4243
+      },
+      "roomId": 4244,
+      "_name": "Waterfront Road",
+      "_area": "Waterfront",
+      "_gridCol": 13,
+      "_gridRow": 21
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 48,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4246,
+        "west": 4244
+      },
+      "roomId": 4245,
+      "_name": "Waterfront Road",
+      "_area": "Waterfront",
+      "_gridCol": 14,
+      "_gridRow": 21
+    },
+    {
+      "type": "street",
+      "sector": "kobe",
+      "icon": 47,
+      "exits": {
+        "north": 4247,
+        "south": null,
+        "east": null,
+        "west": 4245
+      },
+      "roomId": 4246,
+      "_name": "Waterfront Road",
+      "_area": "Waterfront",
+      "_gridCol": 15,
+      "_gridRow": 21
+    },
+    {
+      "type": "drop_room",
+      "sector": "kobe",
+      "icon": 11,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 4410,
+        "west": null
+      },
+      "roomId": 4411,
+      "_name": "Ishiyama Arena Drop Room",
+      "_area": "Ishiyama Arena",
+      "_sceneRoomId": 147,
+      "_gridCol": 23,
+      "_gridRow": 21,
+      "_inferred": true,
+      "description": "Drop room connected to the Ishiyama Arena ready room."
+    },
+    {
+      "type": "ready_room",
+      "sector": "kobe",
+      "icon": 44,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 147,
+        "west": 4411
+      },
+      "roomId": 4410,
+      "_name": "Ishiyama Arena Ready Room",
+      "_area": "Ishiyama Arena",
+      "_sceneRoomId": 147,
+      "_gridCol": 24,
+      "_gridRow": 21,
+      "_inferred": true,
+      "description": "Ready room for Ishiyama Arena combatants."
+    },
+    {
+      "type": "arena",
+      "sector": "kobe",
+      "icon": 28,
+      "exits": {
+        "north": 4205,
+        "south": null,
+        "east": 4402,
+        "west": 4410
+      },
+      "roomId": 147,
+      "_name": "Ishiyama Arena",
+      "_area": "Ishiyama Arena",
+      "_gridCol": 25,
+      "_gridRow": 21,
+      "description": "Iron Mountain, the centerpiece of Kobe and the destination of thousands of game fans each week, stands here. Ishiyama is perhaps the most feared arena by MechWarriors, perhaps accounting for its consistently high ratings and huge waiting list. The street layout is very simple.",
+      "_sourceBitmap": "Solaris - Bitmap\\Kobe\\Ishiyama Arena\\main.bmp"
+    },
+    {
+      "type": "tram",
+      "sector": "kobe",
+      "icon": 0,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": null,
+        "west": 147
+      },
+      "roomId": 4402,
+      "_name": "Ishiyama Arena Tram Station",
+      "_area": "Ishiyama Arena",
+      "_gridCol": 26,
+      "_gridRow": 21,
+      "_inferred": true
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 47,
+      "exits": {
+        "north": 7274,
+        "south": 7277,
+        "east": null,
+        "west": null
+      },
+      "roomId": 7276,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 55,
+      "_gridRow": 21
+    },
+    {
+      "type": "hub",
+      "sector": "kobe",
+      "icon": 46,
+      "exits": {
+        "north": 4243,
+        "south": null,
+        "east": 4404,
+        "west": null
+      },
+      "roomId": 150,
+      "_name": "Waterfront",
+      "_area": "Waterfront",
+      "_gridCol": 12,
+      "_gridRow": 22,
+      "description": "Shrines, parks and statuary line the immaculate waterfront of Kobe. The high security is used to advantage by the crime bosses for their meetings, much to the exasperation of the Kobe upper-class. The street layout is of average complexity.",
+      "_sourceBitmap": "Solaris - Bitmap\\Kobe\\Waterfront\\main.bmp"
+    },
+    {
+      "type": "tram",
+      "sector": "kobe",
+      "icon": 0,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": null,
+        "west": 150
+      },
+      "roomId": 4404,
+      "_name": "Waterfront Tram Station",
+      "_area": "Waterfront",
+      "_gridCol": 13,
+      "_gridRow": 22,
+      "_inferred": true
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 51,
+      "exits": {
+        "north": 7276,
+        "south": 7278,
+        "east": null,
+        "west": null
+      },
+      "roomId": 7277,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 55,
+      "_gridRow": 22
+    },
+    {
+      "type": "bar",
+      "sector": "montenegro",
+      "icon": 2,
+      "exits": {
+        "north": null,
+        "south": 7201,
+        "east": 7101,
+        "west": null
+      },
+      "roomId": 7001,
+      "_name": "Brit's",
+      "_area": "Allman",
+      "_gridCol": 57,
+      "_gridRow": 22,
+      "description": "You are in Brit's. To the south you see the Via Dolorosa. To the east you see a public data terminal.",
+      "_sourceBitmap": "Solaris - Bitmap\\Montenegro\\Allman\\1.bmp"
+    },
+    {
+      "type": "terminal",
+      "sector": "montenegro",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": null,
+        "west": 7001
+      },
+      "roomId": 7101,
+      "_name": "Public Data Terminal",
+      "_area": "Allman",
+      "_gridCol": 58,
+      "_gridRow": 22
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 47,
+      "exits": {
+        "north": 7277,
+        "south": 7279,
+        "east": 7290,
+        "west": null
+      },
+      "roomId": 7278,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 55,
+      "_gridRow": 23
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 47,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7201,
+        "west": 7278
+      },
+      "roomId": 7290,
+      "_name": "Via Dolorosa",
+      "_area": "Allman",
+      "_gridCol": 56,
+      "_gridRow": 23
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 46,
+      "exits": {
+        "north": 7001,
+        "south": null,
+        "east": null,
+        "west": 7290
+      },
+      "roomId": 7201,
+      "_name": "Via Dolorosa",
+      "_area": "Allman",
+      "_gridCol": 57,
+      "_gridRow": 23
+    },
+    {
+      "type": "tram",
+      "sector": "montenegro",
+      "icon": 0,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 158,
+        "west": null
+      },
+      "roomId": 7404,
+      "_name": "Marik Tower Tram Station",
+      "_area": "Marik Tower",
+      "_gridCol": 47,
+      "_gridRow": 24,
+      "_inferred": true
+    },
+    {
+      "type": "headquarters",
+      "sector": "montenegro",
+      "icon": 17,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7295,
+        "west": 7404
+      },
+      "roomId": 158,
+      "_name": "Marik Tower",
+      "_area": "Marik Tower",
+      "_gridCol": 48,
+      "_gridRow": 24,
+      "description": "This brand-new mountain of glass and steel bears the Marik eagle proudly over its main entrance, and is the center of Montenegro civic authority, as well as the diplomatic and governmental quarter of the sector. The street layout is simple.",
+      "_sourceBitmap": "Solaris - Bitmap\\Montenegro\\Marik Tower\\main.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 45,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7296,
+        "west": 158
+      },
+      "roomId": 7295,
+      "_name": "Marik Tower Approach",
+      "_area": "Marik Tower",
+      "_gridCol": 49,
+      "_gridRow": 24
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 45,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7297,
+        "west": 7295
+      },
+      "roomId": 7296,
+      "_name": "Marik Tower Approach",
+      "_area": "Marik Tower",
+      "_gridCol": 50,
+      "_gridRow": 24
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 45,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7298,
+        "west": 7296
+      },
+      "roomId": 7297,
+      "_name": "Marik Tower Approach",
+      "_area": "Marik Tower",
+      "_gridCol": 51,
+      "_gridRow": 24
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 45,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7299,
+        "west": 7297
+      },
+      "roomId": 7298,
+      "_name": "Marik Tower Approach",
+      "_area": "Marik Tower",
+      "_gridCol": 52,
+      "_gridRow": 24
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 45,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7300,
+        "west": 7298
+      },
+      "roomId": 7299,
+      "_name": "Marik Tower Approach",
+      "_area": "Marik Tower",
+      "_gridCol": 53,
+      "_gridRow": 24
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 45,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7279,
+        "west": 7299
+      },
+      "roomId": 7300,
+      "_name": "Marik Tower Approach",
+      "_area": "Marik Tower",
+      "_gridCol": 54,
+      "_gridRow": 24
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 51,
+      "exits": {
+        "north": 7278,
+        "south": 7280,
+        "east": null,
+        "west": 7300
+      },
+      "roomId": 7279,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 55,
+      "_gridRow": 24
+    },
+    {
+      "type": "terminal",
+      "sector": "montenegro",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7003,
+        "west": null
+      },
+      "roomId": 7103,
+      "_name": "Public Data Terminal",
+      "_area": "Marik Tower",
+      "_gridCol": 48,
+      "_gridRow": 25
+    },
+    {
+      "type": "bar",
+      "sector": "montenegro",
+      "icon": 27,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7203,
+        "west": 7103
+      },
+      "roomId": 7003,
+      "_name": "The Home Guard Club",
+      "_area": "Marik Tower",
+      "_gridCol": 49,
+      "_gridRow": 25,
+      "description": "You are in The Home Guard Club. To the east you see Bolivar St. To the west you see a public data terminal.",
+      "_sourceBitmap": "Solaris - Bitmap\\Montenegro\\Marik Tower\\1.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 51,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7291,
+        "west": 7003
+      },
+      "roomId": 7203,
+      "_name": "Bolivar St",
+      "_area": "Marik Tower",
+      "_gridCol": 50,
+      "_gridRow": 25
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 52,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7292,
+        "west": 7203
+      },
+      "roomId": 7291,
+      "_name": "Bolivar St",
+      "_area": "Marik Tower",
+      "_gridCol": 51,
+      "_gridRow": 25
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 51,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7293,
+        "west": 7291
+      },
+      "roomId": 7292,
+      "_name": "Bolivar St",
+      "_area": "Marik Tower",
+      "_gridCol": 52,
+      "_gridRow": 25
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 48,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7294,
+        "west": 7292
+      },
+      "roomId": 7293,
+      "_name": "Bolivar St",
+      "_area": "Marik Tower",
+      "_gridCol": 53,
+      "_gridRow": 25
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 52,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7280,
+        "west": 7293
+      },
+      "roomId": 7294,
+      "_name": "Bolivar St",
+      "_area": "Marik Tower",
+      "_gridCol": 54,
+      "_gridRow": 25
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 47,
+      "exits": {
+        "north": 7279,
+        "south": 7281,
+        "east": null,
+        "west": 7294
+      },
+      "roomId": 7280,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 55,
+      "_gridRow": 25
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 51,
+      "exits": {
+        "north": 7280,
+        "south": 7282,
+        "east": null,
+        "west": null
+      },
+      "roomId": 7281,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 55,
+      "_gridRow": 26
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 47,
+      "exits": {
+        "north": 7281,
+        "south": 7283,
+        "east": 7301,
+        "west": null
+      },
+      "roomId": 7282,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 55,
+      "_gridRow": 27
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 52,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7302,
+        "west": 7282
+      },
+      "roomId": 7301,
+      "_name": "Reisman St",
+      "_area": "Riverfront",
+      "_gridCol": 56,
+      "_gridRow": 27
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 51,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7303,
+        "west": 7301
+      },
+      "roomId": 7302,
+      "_name": "Reisman St",
+      "_area": "Riverfront",
+      "_gridCol": 57,
+      "_gridRow": 27
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 53,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7204,
+        "west": 7302
+      },
+      "roomId": 7303,
+      "_name": "Reisman St",
+      "_area": "Riverfront",
+      "_gridCol": 58,
+      "_gridRow": 27
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 51,
+      "exits": {
+        "north": null,
+        "south": 7004,
+        "east": null,
+        "west": 7303
+      },
+      "roomId": 7204,
+      "_name": "Reisman St",
+      "_area": "Riverfront",
+      "_gridCol": 59,
+      "_gridRow": 27
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 51,
+      "exits": {
+        "north": 7282,
+        "south": 7284,
+        "east": null,
+        "west": null
+      },
+      "roomId": 7283,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 55,
+      "_gridRow": 28
+    },
+    {
+      "type": "bar",
+      "sector": "montenegro",
+      "icon": 2,
+      "exits": {
+        "north": 7204,
+        "south": 7104,
+        "east": null,
+        "west": null
+      },
+      "roomId": 7004,
+      "_name": "Hangar 66",
+      "_area": "Riverfront",
+      "_gridCol": 59,
+      "_gridRow": 28,
+      "description": "You are in Hangar 66. To the north you see Reisman St. To the south you see a public data terminal.",
+      "_sourceBitmap": "Solaris - Bitmap\\Montenegro\\Riverfront\\1.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 47,
+      "exits": {
+        "north": 7283,
+        "south": null,
+        "east": 7305,
+        "west": null
+      },
+      "roomId": 7284,
+      "_name": "Montenegro Street",
+      "_area": "Montenegro Roads",
+      "_gridCol": 55,
+      "_gridRow": 29
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 47,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 7304,
+        "west": 7284
+      },
+      "roomId": 7305,
+      "_name": "Riverfront Road",
+      "_area": "Riverfront",
+      "_gridCol": 56,
+      "_gridRow": 29
+    },
+    {
+      "type": "street",
+      "sector": "montenegro",
+      "icon": 47,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 160,
+        "west": 7305
+      },
+      "roomId": 7304,
+      "_name": "Riverfront Road",
+      "_area": "Riverfront",
+      "_gridCol": 57,
+      "_gridRow": 29
+    },
+    {
+      "type": "hub",
+      "sector": "montenegro",
+      "icon": 46,
+      "exits": {
+        "north": null,
+        "south": 7405,
+        "east": null,
+        "west": 7304
+      },
+      "roomId": 160,
+      "_name": "Riverfront",
+      "_area": "Riverfront",
+      "_gridCol": 58,
+      "_gridRow": 29,
+      "description": "A place of burned-out warehouses and the twisted remains of dock cranes and loaders, the Riverfront, like the Wasteland, is home to numerous gangs, squatters and other criminals. The street layout is of average complexity.",
+      "_sourceBitmap": "Solaris - Bitmap\\Montenegro\\Riverfront\\main.bmp"
+    },
+    {
+      "type": "terminal",
+      "sector": "montenegro",
+      "icon": 21,
+      "exits": {
+        "north": 7004,
+        "south": null,
+        "east": null,
+        "west": null
+      },
+      "roomId": 7104,
+      "_name": "Public Data Terminal",
+      "_area": "Riverfront",
+      "_gridCol": 59,
+      "_gridRow": 29
+    },
+    {
+      "type": "tram",
+      "sector": "montenegro",
+      "icon": 0,
+      "exits": {
+        "north": 160,
+        "south": null,
+        "east": null,
+        "west": null
+      },
+      "roomId": 7405,
+      "_name": "Riverfront Tram Station",
+      "_area": "Riverfront",
+      "_gridCol": 58,
+      "_gridRow": 30,
+      "_inferred": true
+    },
+    {
+      "roomId": 170,
+      "_name": "Marina",
+      "type": "hub",
+      "sector": "blackhills",
+      "_area": "Marina",
+      "icon": 1,
+      "exits": {
+        "north": null,
+        "south": 3203,
         "west": null,
         "east": null
       },
-      "_gridCol": 4,
-      "_gridRow": 22
+      "_gridCol": 20,
+      "_gridRow": 32,
+      "description": "This opulent district is the resort of many wealthy Davions, who keep their yachts (or floating palaces) here for parties and getaways. The street layout is of average complexity.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Marina\\main.bmp"
+    },
+    {
+      "roomId": 3261,
+      "_name": "Frances Ave",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 24,
+      "exits": {
+        "north": null,
+        "south": 3262,
+        "west": null,
+        "east": 3260
+      },
+      "_gridCol": 18,
+      "_gridRow": 33
+    },
+    {
+      "roomId": 3260,
+      "_name": "Frances Ave",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 24,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": 3261,
+        "east": 3203
+      },
+      "_gridCol": 19,
+      "_gridRow": 33
+    },
+    {
+      "roomId": 3203,
+      "_name": "Frances Ave",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Marina",
+      "icon": 54,
+      "exits": {
+        "north": 170,
+        "south": 3003,
+        "west": 3260,
+        "east": 3401
+      },
+      "_gridCol": 20,
+      "_gridRow": 33,
+      "description": "Frances Ave in the Marina district.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Marina\\1.bmp"
+    },
+    {
+      "sector": "blackhills",
+      "icon": 0,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": null,
+        "west": 3203
+      },
+      "roomId": 3401,
+      "_name": "Marina Tram Station",
+      "type": "tram",
+      "_area": "Marina",
+      "_gridCol": 21,
+      "_gridRow": 33,
+      "_inferred": true
+    },
+    {
+      "type": "tram",
+      "sector": "cathay",
+      "icon": 0,
+      "exits": {
+        "north": null,
+        "south": 165,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5401,
+      "_name": "Rivertown Tram Station",
+      "_area": "Rivertown",
+      "_gridCol": 41,
+      "_gridRow": 33,
+      "_inferred": true
+    },
+    {
+      "type": "terminal",
+      "sector": "silesia",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": 6003,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6103,
+      "_name": "Public Data Terminal",
+      "_area": "Black Thorne",
+      "_gridCol": 67,
+      "_gridRow": 33
+    },
+    {
+      "roomId": 3262,
+      "_name": "Frances Ave",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 25,
+      "exits": {
+        "north": 3261,
+        "south": 3263,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 18,
+      "_gridRow": 34
+    },
+    {
+      "roomId": 3003,
+      "_name": "The Pelican",
+      "type": "bar",
+      "sector": "blackhills",
+      "_area": "Marina",
+      "icon": 26,
+      "exits": {
+        "north": 3203,
+        "south": 3103,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 20,
+      "_gridRow": 34,
+      "description": "You are in the Pelican. To the north you see Frances Ave. To the south you see a public data terminal.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Marina\\1.bmp",
+      "_screen": 1,
+      "clientMapDescription": true
+    },
+    {
+      "type": "hub",
+      "sector": "cathay",
+      "icon": 51,
+      "exits": {
+        "north": 5401,
+        "south": 5210,
+        "east": null,
+        "west": null
+      },
+      "roomId": 165,
+      "_name": "Rivertown",
+      "_area": "Rivertown",
+      "_gridCol": 41,
+      "_gridRow": 34,
+      "description": "The lowest level of the Cathay slums lies along this filthy stretch of water, and the houseboats and shacks on rickety piers frequently crowd as many as ten adults into a single cramped room. The street layout is of average complexity.",
+      "_sourceBitmap": "Solaris - Bitmap\\Cathay\\Rivertown\\main.bmp"
+    },
+    {
+      "type": "bar",
+      "sector": "silesia",
+      "icon": 26,
+      "exits": {
+        "north": 6103,
+        "south": 153,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6003,
+      "_name": "Y.B.Y.A.",
+      "_area": "Black Thorne",
+      "_gridCol": 67,
+      "_gridRow": 34,
+      "description": "You are in Y.B.Y.A., amongst about 30 drunken MechWarriors raucously betting on the latest fights. Shades, the owner, is watching you. To the north you see a public data terminal. To the south you see the administrative center of Silesia Sector.",
+      "_sourceBitmap": "Solaris - Bitmap\\Silesia\\Black Thorne\\3.bmp"
+    },
+    {
+      "roomId": 3263,
+      "_name": "Frances Ave",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 54,
+      "exits": {
+        "north": 3262,
+        "south": 3264,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 18,
+      "_gridRow": 35
+    },
+    {
+      "roomId": 3103,
+      "_name": "Public Data Terminal",
+      "type": "terminal",
+      "sector": "blackhills",
+      "_area": "Marina",
+      "icon": 21,
+      "exits": {
+        "north": 3003,
+        "south": null,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 20,
+      "_gridRow": 35,
+      "description": "A public data terminal beside The Pelican.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Marina\\1.bmp"
+    },
+    {
+      "type": "terminal",
+      "sector": "cathay",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 5010,
+        "west": null
+      },
+      "roomId": 5110,
+      "_name": "Public Data Terminal",
+      "_area": "Rivertown",
+      "_gridCol": 39,
+      "_gridRow": 35
+    },
+    {
+      "type": "bar",
+      "sector": "cathay",
+      "icon": 27,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 5210,
+        "west": 5110
+      },
+      "roomId": 5010,
+      "_name": "The Cobalt Coil",
+      "_area": "Rivertown",
+      "_gridCol": 40,
+      "_gridRow": 35,
+      "description": "You are in the Cobalt Coil. To the east you see Capellan St. To the west you see a public data terminal.",
+      "_sourceBitmap": "Solaris - Bitmap\\Cathay\\Rivertown\\1.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 54,
+      "exits": {
+        "north": 165,
+        "south": null,
+        "east": 5220,
+        "west": 5010
+      },
+      "roomId": 5210,
+      "_name": "Capellan St",
+      "_area": "Rivertown",
+      "_gridCol": 41,
+      "_gridRow": 35
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 54,
+      "exits": {
+        "north": null,
+        "south": 5221,
+        "east": null,
+        "west": 5210
+      },
+      "roomId": 5220,
+      "_name": "Solaris Highway One",
+      "_area": "Cathay Roads",
+      "_gridCol": 42,
+      "_gridRow": 35
+    },
+    {
+      "type": "tram",
+      "sector": "silesia",
+      "icon": 0,
+      "exits": {
+        "north": null,
+        "south": 155,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6402,
+      "_name": "Riverside Tram Station",
+      "_area": "Riverside",
+      "_gridCol": 57,
+      "_gridRow": 35,
+      "_inferred": true
+    },
+    {
+      "type": "terminal",
+      "sector": "silesia",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": 6007,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6107,
+      "_name": "Public Data Terminal",
+      "_area": "Lyran Building",
+      "_gridCol": 66,
+      "_gridRow": 35
+    },
+    {
+      "type": "headquarters",
+      "sector": "silesia",
+      "icon": 17,
+      "exits": {
+        "north": 6003,
+        "south": 6217,
+        "east": 6401,
+        "west": null
+      },
+      "roomId": 153,
+      "_name": "Lyran Building",
+      "_area": "Lyran Building",
+      "_gridCol": 67,
+      "_gridRow": 35,
+      "description": "The armored fist of House Steiner graces the entrance to this grim, gray structure, where Lyran officials administer their sector of Solaris. The street layout is of average complexity.",
+      "_sourceBitmap": "Solaris - Bitmap\\Silesia\\Lyran Building\\main.bmp"
+    },
+    {
+      "type": "tram",
+      "sector": "silesia",
+      "icon": 0,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": null,
+        "west": 153
+      },
+      "roomId": 6401,
+      "_name": "Lyran Building Tram Station",
+      "_area": "Lyran Building",
+      "_gridCol": 68,
+      "_gridRow": 35,
+      "_inferred": true
+    },
+    {
+      "roomId": 3264,
+      "_name": "Frances Ave",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 24,
+      "exits": {
+        "north": 3263,
+        "south": 3265,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 18,
+      "_gridRow": 36
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 56,
+      "exits": {
+        "north": 5220,
+        "south": 5222,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5221,
+      "_name": "Solaris Highway One",
+      "_area": "Cathay Roads",
+      "_gridCol": 42,
+      "_gridRow": 36
+    },
+    {
+      "type": "hub",
+      "sector": "silesia",
+      "icon": 46,
+      "exits": {
+        "north": 6402,
+        "south": null,
+        "east": 6208,
+        "west": null
+      },
+      "roomId": 155,
+      "_name": "Riverside",
+      "_area": "Riverside",
+      "_gridCol": 57,
+      "_gridRow": 36,
+      "description": "Within sight of Cathay River Town, the Silesian waterfront is the location of numerous high-class hotels and condominiums. The street layout is of average complexity.",
+      "_sourceBitmap": "Solaris - Bitmap\\Silesia\\Riverside\\main.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 47,
+      "exits": {
+        "north": null,
+        "south": 6008,
+        "east": 6210,
+        "west": 155
+      },
+      "roomId": 6208,
+      "_name": "Fraunstalh St",
+      "_area": "Riverside",
+      "_gridCol": 58,
+      "_gridRow": 36
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 48,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6211,
+        "west": 6208
+      },
+      "roomId": 6210,
+      "_name": "Fraunstalh St",
+      "_area": "Riverside",
+      "_gridCol": 59,
+      "_gridRow": 36
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 47,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6212,
+        "west": 6210
+      },
+      "roomId": 6211,
+      "_name": "Fraunstalh St",
+      "_area": "Riverside",
+      "_gridCol": 60,
+      "_gridRow": 36
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 46,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6213,
+        "west": 6211
+      },
+      "roomId": 6212,
+      "_name": "Fraunstalh St",
+      "_area": "Silesia Roads",
+      "_gridCol": 61,
+      "_gridRow": 36
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 48,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6214,
+        "west": 6212
+      },
+      "roomId": 6213,
+      "_name": "Fraunstalh St",
+      "_area": "Silesia Roads",
+      "_gridCol": 62,
+      "_gridRow": 36
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 47,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6215,
+        "west": 6213
+      },
+      "roomId": 6214,
+      "_name": "Fraunstalh St",
+      "_area": "Silesia Roads",
+      "_gridCol": 63,
+      "_gridRow": 36
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 46,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6216,
+        "west": 6214
+      },
+      "roomId": 6215,
+      "_name": "Fraunstalh St",
+      "_area": "Silesia Roads",
+      "_gridCol": 64,
+      "_gridRow": 36
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 48,
+      "exits": {
+        "north": null,
+        "south": 6218,
+        "east": null,
+        "west": 6215
+      },
+      "roomId": 6216,
+      "_name": "Fraunstalh St",
+      "_area": "Silesia Roads",
+      "_gridCol": 65,
+      "_gridRow": 36
+    },
+    {
+      "type": "bar",
+      "sector": "silesia",
+      "icon": 26,
+      "exits": {
+        "north": 6107,
+        "south": 6207,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6007,
+      "_name": "The Vindictive Philanthropist",
+      "_area": "Lyran Building",
+      "_gridCol": 66,
+      "_gridRow": 36,
+      "description": "You are in the Vindictive Philanthropist, writing bad checks to charity. To the north you see a public data terminal. To the south you see Arnulf St.",
+      "_sourceBitmap": "Solaris - Bitmap\\Silesia\\Lyran Building\\1.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 45,
+      "exits": {
+        "north": 153,
+        "south": 6219,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6217,
+      "_name": "Lyran Building Approach",
+      "_area": "Lyran Building",
+      "_gridCol": 67,
+      "_gridRow": 36
+    },
+    {
+      "roomId": 3265,
+      "_name": "East Frances Ave",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 47,
+      "exits": {
+        "north": 3264,
+        "south": 3266,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 18,
+      "_gridRow": 37
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 48,
+      "exits": {
+        "north": 5221,
+        "south": 5223,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5222,
+      "_name": "Solaris Highway One",
+      "_area": "Cathay Roads",
+      "_gridCol": 42,
+      "_gridRow": 37
+    },
+    {
+      "type": "bar",
+      "sector": "silesia",
+      "icon": 26,
+      "exits": {
+        "north": 6208,
+        "south": 6108,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6008,
+      "_name": "The Swooping Crane",
+      "_area": "Riverside",
+      "_gridCol": 58,
+      "_gridRow": 37,
+      "description": "You are in the Swooping Crane. To the north you see Fraunstalh St. To the south you see a public data terminal.",
+      "_sourceBitmap": "Solaris - Bitmap\\Silesia\\Riverside\\1.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 51,
+      "exits": {
+        "north": null,
+        "south": 6224,
+        "east": 6222,
+        "west": null
+      },
+      "roomId": 6223,
+      "_name": "Dusseldorf Street",
+      "_area": "Silesia Roads",
+      "_gridCol": 61,
+      "_gridRow": 37
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 51,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6221,
+        "west": 6223
+      },
+      "roomId": 6222,
+      "_name": "Dusseldorf Street",
+      "_area": "Silesia Roads",
+      "_gridCol": 62,
+      "_gridRow": 37
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 51,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6220,
+        "west": 6222
+      },
+      "roomId": 6221,
+      "_name": "Dusseldorf Street",
+      "_area": "Silesia Roads",
+      "_gridCol": 63,
+      "_gridRow": 37
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 51,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6218,
+        "west": 6221
+      },
+      "roomId": 6220,
+      "_name": "Dusseldorf Street",
+      "_area": "Silesia Roads",
+      "_gridCol": 64,
+      "_gridRow": 37
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 52,
+      "exits": {
+        "north": 6216,
+        "south": null,
+        "east": 6207,
+        "west": 6220
+      },
+      "roomId": 6218,
+      "_name": "Arnulf St",
+      "_area": "Lyran Building",
+      "_gridCol": 65,
+      "_gridRow": 37
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 24,
+      "exits": {
+        "north": 6007,
+        "south": null,
+        "east": 6219,
+        "west": 6218
+      },
+      "roomId": 6207,
+      "_name": "Arnulf St",
+      "_area": "Lyran Building",
+      "_gridCol": 66,
+      "_gridRow": 37
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 49,
+      "exits": {
+        "north": 6217,
+        "south": null,
+        "east": null,
+        "west": 6207
+      },
+      "roomId": 6219,
+      "_name": "Lyran Building Approach",
+      "_area": "Lyran Building",
+      "_gridCol": 67,
+      "_gridRow": 37
+    },
+    {
+      "roomId": 3214,
+      "_name": "Laurel Ave",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 52,
+      "exits": {
+        "north": null,
+        "south": 3213,
+        "west": null,
+        "east": 3215
+      },
+      "_gridCol": 15,
+      "_gridRow": 38
+    },
+    {
+      "roomId": 3215,
+      "_name": "East Frances Ave",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 47,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": 3214,
+        "east": 3210
+      },
+      "_gridCol": 16,
+      "_gridRow": 38
+    },
+    {
+      "roomId": 3210,
+      "_name": "East Frances Ave",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Viewpoint",
+      "icon": 55,
+      "exits": {
+        "north": null,
+        "south": 3007,
+        "west": 3215,
+        "east": 3266
+      },
+      "_gridCol": 17,
+      "_gridRow": 38,
+      "description": "East Frances Ave above The Mystery Meat House.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Viewpoint\\3.bmp"
+    },
+    {
+      "roomId": 3266,
+      "_name": "East Frances Ave",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 55,
+      "exits": {
+        "north": 3265,
+        "south": null,
+        "west": 3210,
+        "east": null
+      },
+      "_gridCol": 18,
+      "_gridRow": 38
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 55,
+      "exits": {
+        "north": 5222,
+        "south": 5224,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5223,
+      "_name": "Solaris Highway One",
+      "_area": "Cathay Roads",
+      "_gridCol": 42,
+      "_gridRow": 38
+    },
+    {
+      "type": "terminal",
+      "sector": "silesia",
+      "icon": 21,
+      "exits": {
+        "north": 6008,
+        "south": null,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6108,
+      "_name": "Public Data Terminal",
+      "_area": "Riverside",
+      "_gridCol": 58,
+      "_gridRow": 38
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 53,
+      "exits": {
+        "north": 6223,
+        "south": 6225,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6224,
+      "_name": "Dusseldorf Street",
+      "_area": "Silesia Roads",
+      "_gridCol": 61,
+      "_gridRow": 38
+    },
+    {
+      "roomId": 3213,
+      "_name": "Laurel Ave",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 52,
+      "exits": {
+        "north": 3214,
+        "south": 3212,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 15,
+      "_gridRow": 39
+    },
+    {
+      "roomId": 3007,
+      "_name": "The Mystery Meat House",
+      "type": "bar",
+      "sector": "blackhills",
+      "_area": "Viewpoint",
+      "icon": 26,
+      "exits": {
+        "north": 3210,
+        "south": 3107,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 17,
+      "_gridRow": 39,
+      "description": "You are a fool, but a starving one, apparently. You are served a moderately quiescent slab of unidentifiable meat in an uncertain sauce. To the north you see East Frances Ave. To the south you see a public data terminal.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Viewpoint\\3.bmp",
+      "_screen": 3,
+      "clientMapDescription": true
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 24,
+      "exits": {
+        "north": 5223,
+        "south": 166,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5224,
+      "_name": "Solaris Highway One",
+      "_area": "Cathay Roads",
+      "_gridCol": 42,
+      "_gridRow": 39
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 52,
+      "exits": {
+        "north": 6224,
+        "south": 6226,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6225,
+      "_name": "Dusseldorf Street",
+      "_area": "Silesia Roads",
+      "_gridCol": 61,
+      "_gridRow": 39
+    },
+    {
+      "roomId": 3212,
+      "_name": "Laurel Ave",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 52,
+      "exits": {
+        "north": 3213,
+        "south": 3211,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 15,
+      "_gridRow": 40
+    },
+    {
+      "roomId": 3107,
+      "_name": "Public Data Terminal",
+      "type": "terminal",
+      "sector": "blackhills",
+      "_area": "Viewpoint",
+      "icon": 21,
+      "exits": {
+        "north": 3007,
+        "south": null,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 17,
+      "_gridRow": 40,
+      "description": "A public data terminal beside The Mystery Meat House.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Viewpoint\\3.bmp"
+    },
+    {
+      "type": "hub",
+      "sector": "cathay",
+      "icon": 54,
+      "exits": {
+        "north": 5224,
+        "south": 5225,
+        "east": 5402,
+        "west": null
+      },
+      "roomId": 166,
+      "_name": "Maze",
+      "_area": "Maze",
+      "_gridCol": 42,
+      "_gridRow": 40,
+      "description": "The absolute center of Cathay's crime and poverty, this twisting labyrinth of streets, burned-out storefronts, decayed shacks, tottering tenements, bars and opium dens is home to many of the area's major gangs and crime families. The street layout is complex.",
+      "_sourceBitmap": "Solaris - Bitmap\\Cathay\\Maze\\main.bmp"
+    },
+    {
+      "type": "tram",
+      "sector": "cathay",
+      "icon": 0,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": null,
+        "west": 166
+      },
+      "roomId": 5402,
+      "_name": "Maze Tram Station",
+      "_area": "Maze",
+      "_gridCol": 43,
+      "_gridRow": 40,
+      "_inferred": true
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 51,
+      "exits": {
+        "north": 6225,
+        "south": 6227,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6226,
+      "_name": "Dusseldorf Street",
+      "_area": "Silesia Roads",
+      "_gridCol": 61,
+      "_gridRow": 40
+    },
+    {
+      "sector": "blackhills",
+      "icon": 0,
+      "exits": {
+        "north": null,
+        "south": 3234,
+        "east": null,
+        "west": null
+      },
+      "roomId": 3402,
+      "_name": "Viewpoint Tram Station",
+      "type": "tram",
+      "_area": "Viewpoint",
+      "_gridCol": 14,
+      "_gridRow": 41,
+      "_inferred": true
+    },
+    {
+      "roomId": 3211,
+      "_name": "Laurel Ave",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 52,
+      "exits": {
+        "north": 3212,
+        "south": 171,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 15,
+      "_gridRow": 41
+    },
+    {
+      "roomId": 3105,
+      "_name": "Public Data Terminal",
+      "type": "terminal",
+      "sector": "blackhills",
+      "_area": "Viewpoint",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": 3005,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 17,
+      "_gridRow": 41,
+      "description": "A public data terminal beside The Cryptic Skeptic.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Viewpoint\\1.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 55,
+      "exits": {
+        "north": 166,
+        "south": 5226,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5225,
+      "_name": "Solaris Highway One",
+      "_area": "Cathay Roads",
+      "_gridCol": 42,
+      "_gridRow": 41
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 53,
+      "exits": {
+        "north": 6226,
+        "south": 6228,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6227,
+      "_name": "Dusseldorf Street",
+      "_area": "Silesia Roads",
+      "_gridCol": 61,
+      "_gridRow": 41
+    },
+    {
+      "roomId": 3233,
+      "_name": "Hanse Davion Dr",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 45,
+      "exits": {
+        "north": null,
+        "south": 3232,
+        "west": null,
+        "east": 3234
+      },
+      "_gridCol": 13,
+      "_gridRow": 42
+    },
+    {
+      "roomId": 3234,
+      "_name": "Viewpoint Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 23,
+      "exits": {
+        "north": 3402,
+        "south": null,
+        "west": 3233,
+        "east": 171
+      },
+      "_gridCol": 14,
+      "_gridRow": 42
+    },
+    {
+      "roomId": 171,
+      "_name": "Viewpoint",
+      "type": "hub",
+      "sector": "blackhills",
+      "_area": "Viewpoint",
+      "icon": 43,
+      "exits": {
+        "north": 3211,
+        "south": 3006,
+        "west": 3234,
+        "east": 3330
+      },
+      "_gridCol": 15,
+      "_gridRow": 42,
+      "description": "This magnificent vantage point looks out over the whole of Solaris City, and plaques and memorials point out the sights to the masses of tourists. The street layout is complex.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Viewpoint\\main.bmp"
+    },
+    {
+      "sector": "blackhills",
+      "icon": 23,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 3005,
+        "west": 171
+      },
+      "roomId": 3330,
+      "_name": "Busy Pedestrian Interchange",
+      "type": "path",
+      "_area": "Viewpoint",
+      "_gridCol": 16,
+      "_gridRow": 42,
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Viewpoint\\1.bmp",
+      "description": "A busy pedestrian interchange west of the Cryptic Skeptic."
+    },
+    {
+      "roomId": 3005,
+      "_name": "The Cryptic Skeptic",
+      "type": "bar",
+      "sector": "blackhills",
+      "_area": "Viewpoint",
+      "icon": 27,
+      "exits": {
+        "north": 3105,
+        "south": null,
+        "west": 3330,
+        "east": null
+      },
+      "_gridCol": 17,
+      "_gridRow": 42,
+      "description": "You are in the Cryptic Skeptic, though probably not for too much longer...considering. To the north you see a public data terminal. To the west you see a busy pedestrian interchange.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Viewpoint\\1.bmp",
+      "_screen": 1,
+      "clientMapDescription": true
+    },
+    {
+      "sector": "blackhills",
+      "icon": 11,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 3410,
+        "west": null
+      },
+      "roomId": 3411,
+      "_name": "Davion Arena Drop Room",
+      "type": "drop_room",
+      "_area": "Davion Arena",
+      "_sceneRoomId": 167,
+      "_gridCol": 29,
+      "_gridRow": 42,
+      "_inferred": true,
+      "description": "Drop room connected to the Davion Arena ready room."
+    },
+    {
+      "sector": "blackhills",
+      "icon": 44,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 167,
+        "west": 3411
+      },
+      "roomId": 3410,
+      "_name": "Davion Arena Ready Room",
+      "type": "ready_room",
+      "_area": "Davion Arena",
+      "_sceneRoomId": 167,
+      "_gridCol": 30,
+      "_gridRow": 42,
+      "_inferred": true,
+      "description": "Ready room for Davion Arena combatants."
+    },
+    {
+      "roomId": 167,
+      "_name": "Davion Arena",
+      "type": "arena",
+      "sector": "blackhills",
+      "_area": "Davion Arena",
+      "icon": 32,
+      "exits": {
+        "north": null,
+        "south": 3201,
+        "west": 3410,
+        "east": 3403
+      },
+      "_gridCol": 31,
+      "_gridRow": 42,
+      "description": "The Davion Arena is the largest and most sophisticated Arena on Solaris, seating half again as many as its nearest rival. This ultra-modern edifice towers over the defunct industrial park in which it was built. The street layout is very simple.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Davion Arena\\main.bmp"
+    },
+    {
+      "sector": "blackhills",
+      "icon": 0,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": null,
+        "west": 167
+      },
+      "roomId": 3403,
+      "_name": "Davion Arena Tram Station",
+      "type": "tram",
+      "_area": "Davion Arena",
+      "_gridCol": 32,
+      "_gridRow": 42,
+      "_inferred": true
+    },
+    {
+      "type": "bar",
+      "sector": "cathay",
+      "icon": 2,
+      "exits": {
+        "north": null,
+        "south": 5104,
+        "east": 5226,
+        "west": null
+      },
+      "roomId": 5004,
+      "_name": "The Green Sausage",
+      "_area": "Maze",
+      "_gridCol": 41,
+      "_gridRow": 42,
+      "description": "You are in The Green Sausage, surrounded by camaraderie and good cheer (and full-scale bar brawls, but mostly camaraderie and good cheer). To the south you see a public data terminal. To the east you see more of Solaris Highway One.",
+      "_sourceBitmap": "Solaris - Bitmap\\Cathay\\Maze\\2.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 51,
+      "exits": {
+        "north": 5225,
+        "south": 5227,
+        "east": 5005,
+        "west": 5004
+      },
+      "roomId": 5226,
+      "_name": "Solaris Highway One",
+      "_area": "Cathay Roads",
+      "_gridCol": 42,
+      "_gridRow": 42
+    },
+    {
+      "type": "bar",
+      "sector": "cathay",
+      "icon": 26,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 5105,
+        "west": 5226
+      },
+      "roomId": 5005,
+      "_name": "Brass Lily",
+      "_area": "Maze",
+      "_gridCol": 43,
+      "_gridRow": 42,
+      "description": "You are in the Brass Lily. Roaches check in, but they don't check out. To the east you see a public data terminal. To the west you see more of Solaris Highway One.",
+      "_sourceBitmap": "Solaris - Bitmap\\Cathay\\Maze\\3.bmp"
+    },
+    {
+      "type": "terminal",
+      "sector": "cathay",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": null,
+        "west": 5005
+      },
+      "roomId": 5105,
+      "_name": "Public Data Terminal",
+      "_area": "Maze",
+      "_gridCol": 44,
+      "_gridRow": 42
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 52,
+      "exits": {
+        "north": 6227,
+        "south": 6229,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6228,
+      "_name": "Dusseldorf Street",
+      "_area": "Silesia Roads",
+      "_gridCol": 61,
+      "_gridRow": 42
+    },
+    {
+      "roomId": 3232,
+      "_name": "Hanse Davion Dr",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 45,
+      "exits": {
+        "north": 3233,
+        "south": 3231,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 13,
+      "_gridRow": 43
+    },
+    {
+      "roomId": 3106,
+      "_name": "Public Data Terminal",
+      "type": "terminal",
+      "sector": "blackhills",
+      "_area": "Viewpoint",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": null,
+        "east": 3006
+      },
+      "_gridCol": 14,
+      "_gridRow": 43,
+      "description": "A public data terminal beside Keith's House of Mummery.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Viewpoint\\2.bmp"
+    },
+    {
+      "roomId": 3006,
+      "_name": "Keith's House of Mummery",
+      "type": "bar",
+      "sector": "blackhills",
+      "_area": "Viewpoint",
+      "icon": 27,
+      "exits": {
+        "north": 171,
+        "south": null,
+        "west": 3106,
+        "east": null
+      },
+      "_gridCol": 15,
+      "_gridRow": 43,
+      "description": "You are in Keith's House of Mummery. The tranquil atmosphere could almost lull you to sleep. To the north you see Viewpoint, just off of Laurel Ave. Lovely sight. To the west you see a public data terminal.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Viewpoint\\2.bmp",
+      "_screen": 2,
+      "clientMapDescription": true
+    },
+    {
+      "roomId": 3101,
+      "_name": "Public Data Terminal",
+      "type": "terminal",
+      "sector": "blackhills",
+      "_area": "Davion Arena",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": null,
+        "east": 3001
+      },
+      "_gridCol": 29,
+      "_gridRow": 43,
+      "description": "A public data terminal beside The Sun and Sword.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Davion Arena\\1.bmp"
+    },
+    {
+      "roomId": 3001,
+      "_name": "The Sun and Sword",
+      "type": "bar",
+      "sector": "blackhills",
+      "_area": "Davion Arena",
+      "icon": 26,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": 3101,
+        "east": 3201
+      },
+      "_gridCol": 30,
+      "_gridRow": 43,
+      "description": "You are in The Sun and Sword, one of the older bars in the city. To the east you see Halloran St. To the west you see a public data terminal.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Davion Arena\\1.bmp",
+      "_screen": 1,
+      "clientMapDescription": true
+    },
+    {
+      "roomId": 3201,
+      "_name": "Halloran St",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Davion Arena",
+      "icon": 50,
+      "exits": {
+        "north": 167,
+        "south": 3268,
+        "west": 3001,
+        "east": null
+      },
+      "_gridCol": 31,
+      "_gridRow": 43,
+      "description": "Halloran St near the Davion Arena district.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Davion Arena\\1.bmp"
+    },
+    {
+      "type": "terminal",
+      "sector": "cathay",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": 5003,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5103,
+      "_name": "Public Data Terminal",
+      "_area": "Maze",
+      "_gridCol": 39,
+      "_gridRow": 43
+    },
+    {
+      "type": "terminal",
+      "sector": "cathay",
+      "icon": 21,
+      "exits": {
+        "north": 5004,
+        "south": null,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5104,
+      "_name": "Public Data Terminal",
+      "_area": "Maze",
+      "_gridCol": 41,
+      "_gridRow": 43
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 54,
+      "exits": {
+        "north": 5226,
+        "south": 5228,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5227,
+      "_name": "Solaris Highway One",
+      "_area": "Cathay Roads",
+      "_gridCol": 42,
+      "_gridRow": 43
+    },
+    {
+      "type": "terminal",
+      "sector": "cathay",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": 5006,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5106,
+      "_name": "Public Data Terminal",
+      "_area": "Maze",
+      "_gridCol": 43,
+      "_gridRow": 43
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 51,
+      "exits": {
+        "north": 6228,
+        "south": 6230,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6229,
+      "_name": "Dusseldorf Street",
+      "_area": "Silesia Roads",
+      "_gridCol": 61,
+      "_gridRow": 43
+    },
+    {
+      "roomId": 3231,
+      "_name": "Hanse Davion Dr",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 45,
+      "exits": {
+        "north": 3232,
+        "south": 3230,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 13,
+      "_gridRow": 44
+    },
+    {
+      "roomId": 3268,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 51,
+      "exits": {
+        "north": 3201,
+        "south": 3267,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 31,
+      "_gridRow": 44
+    },
+    {
+      "type": "bar",
+      "sector": "cathay",
+      "icon": 27,
+      "exits": {
+        "north": 5103,
+        "south": 5203,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5003,
+      "_name": "Belthasar's Hideaway",
+      "_area": "Maze",
+      "_gridCol": 39,
+      "_gridRow": 44,
+      "description": "You are in Belthasar's Hideaway, where you had better keep looking over your shoulder and keep your back to the wall. To the north you see a public data terminal. To the south you see Confederation Ave. running east and west.",
+      "_sourceBitmap": "Solaris - Bitmap\\Cathay\\Maze\\1.bmp"
+    },
+    {
+      "type": "terminal",
+      "sector": "cathay",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 5007,
+        "west": null
+      },
+      "roomId": 5107,
+      "_name": "Public Data Terminal",
+      "_area": "Maze",
+      "_gridCol": 40,
+      "_gridRow": 44
+    },
+    {
+      "type": "bar",
+      "sector": "cathay",
+      "icon": 2,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 5228,
+        "west": 5107
+      },
+      "roomId": 5007,
+      "_name": "The Rampaging Squidherd",
+      "_area": "Maze",
+      "_gridCol": 41,
+      "_gridRow": 44,
+      "description": "You are in a filthy little hole called The Rampaging Squidherd, which caters to the basest of tastes. To the east you see Solaris Highway One, receding into the distance. To the west you see a public data terminal.",
+      "_sourceBitmap": "Solaris - Bitmap\\Cathay\\Maze\\5.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 24,
+      "exits": {
+        "north": 5227,
+        "south": 5229,
+        "east": 5006,
+        "west": 5007
+      },
+      "roomId": 5228,
+      "_name": "Solaris Highway One",
+      "_area": "Cathay Roads",
+      "_gridCol": 42,
+      "_gridRow": 44
+    },
+    {
+      "type": "bar",
+      "sector": "cathay",
+      "icon": 2,
+      "exits": {
+        "north": 5106,
+        "south": null,
+        "east": null,
+        "west": 5228
+      },
+      "roomId": 5006,
+      "_name": "The Suspenseful Turkey",
+      "_area": "Maze",
+      "_gridCol": 43,
+      "_gridRow": 44,
+      "description": "You are The Suspenseful Turkey, surrounded by sullen and intoxicated local residents. You don't feel cherished. To the north you see a public data terminal. To the west you see Solaris Highway One continuing.",
+      "_sourceBitmap": "Solaris - Bitmap\\Cathay\\Maze\\4.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 53,
+      "exits": {
+        "north": 6229,
+        "south": 6231,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6230,
+      "_name": "Dusseldorf Street",
+      "_area": "Silesia Roads",
+      "_gridCol": 61,
+      "_gridRow": 44
+    },
+    {
+      "roomId": 3230,
+      "_name": "Hanse Davion Dr",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Viewpoint",
+      "icon": 45,
+      "exits": {
+        "north": 3231,
+        "south": 3226,
+        "west": null,
+        "east": 3008
+      },
+      "_gridCol": 13,
+      "_gridRow": 45,
+      "description": "The south end of Hanse Davion Dr.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Viewpoint\\4.bmp"
+    },
+    {
+      "roomId": 3008,
+      "_name": "Yarmoor's House of Doom",
+      "type": "bar",
+      "sector": "blackhills",
+      "_area": "Viewpoint",
+      "icon": 26,
+      "exits": {
+        "north": null,
+        "south": 3108,
+        "west": 3230,
+        "east": null
+      },
+      "_gridCol": 14,
+      "_gridRow": 45,
+      "description": "You are at the bar with a tough looking crowd. Yarmoor cleans glasses and makes faces at the patrons. To the south you see a public data terminal. To the west you see the south end of Hanse Davion Dr.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Viewpoint\\4.bmp",
+      "_screen": 4,
+      "clientMapDescription": true
+    },
+    {
+      "roomId": 3267,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 47,
+      "exits": {
+        "north": 3268,
+        "south": 3259,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 31,
+      "_gridRow": 45
+    },
+    {
+      "type": "terminal",
+      "sector": "cathay",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": 5008,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5108,
+      "_name": "Public Data Terminal",
+      "_area": "Maze",
+      "_gridCol": 37,
+      "_gridRow": 45
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 53,
+      "exits": {
+        "north": 5003,
+        "south": null,
+        "east": 5240,
+        "west": null
+      },
+      "roomId": 5203,
+      "_name": "Confederation Ave",
+      "_area": "Maze",
+      "_gridCol": 39,
+      "_gridRow": 45
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 51,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 5241,
+        "west": 5203
+      },
+      "roomId": 5240,
+      "_name": "Confederation Ave",
+      "_area": "Maze",
+      "_gridCol": 40,
+      "_gridRow": 45
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 53,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 5229,
+        "west": 5240
+      },
+      "roomId": 5241,
+      "_name": "Confederation Ave",
+      "_area": "Maze",
+      "_gridCol": 41,
+      "_gridRow": 45
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 48,
+      "exits": {
+        "north": 5228,
+        "south": 5230,
+        "east": 5242,
+        "west": 5241
+      },
+      "roomId": 5229,
+      "_name": "Solaris Highway One / Confederation Ave",
+      "_area": "Cathay Roads",
+      "_gridCol": 42,
+      "_gridRow": 45
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 53,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 5243,
+        "west": 5229
+      },
+      "roomId": 5242,
+      "_name": "Confederation Ave",
+      "_area": "Maze",
+      "_gridCol": 43,
+      "_gridRow": 45
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 52,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 5202,
+        "west": 5242
+      },
+      "roomId": 5243,
+      "_name": "Confederation Ave",
+      "_area": "Maze",
+      "_gridCol": 44,
+      "_gridRow": 45
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 51,
+      "exits": {
+        "north": null,
+        "south": 5002,
+        "east": 5244,
+        "west": 5243
+      },
+      "roomId": 5202,
+      "_name": "Confederation Ave",
+      "_area": "Jungle",
+      "_gridCol": 45,
+      "_gridRow": 45
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 52,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 5245,
+        "west": 5202
+      },
+      "roomId": 5244,
+      "_name": "Confederation Ave",
+      "_area": "Jungle",
+      "_gridCol": 46,
+      "_gridRow": 45
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 51,
+      "exits": {
+        "north": null,
+        "south": 5246,
+        "east": null,
+        "west": 5244
+      },
+      "roomId": 5245,
+      "_name": "Confederation Ave",
+      "_area": "Jungle",
+      "_gridCol": 47,
+      "_gridRow": 45
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 52,
+      "exits": {
+        "north": 6230,
+        "south": 6232,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6231,
+      "_name": "Dusseldorf Street",
+      "_area": "Silesia Roads",
+      "_gridCol": 61,
+      "_gridRow": 45
+    },
+    {
+      "roomId": 3226,
+      "_name": "Hanse Davion Dr",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 48,
+      "exits": {
+        "north": 3230,
+        "south": 3225,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 13,
+      "_gridRow": 46
+    },
+    {
+      "roomId": 3108,
+      "_name": "Public Data Terminal",
+      "type": "terminal",
+      "sector": "blackhills",
+      "_area": "Viewpoint",
+      "icon": 21,
+      "exits": {
+        "north": 3008,
+        "south": null,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 14,
+      "_gridRow": 46,
+      "description": "A public data terminal beside Yarmoor's House of Doom.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Viewpoint\\4.bmp"
+    },
+    {
+      "roomId": 3102,
+      "_name": "Public Data Terminal",
+      "type": "terminal",
+      "sector": "blackhills",
+      "_area": "Guzman Park",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": null,
+        "east": 3002
+      },
+      "_gridCol": 22,
+      "_gridRow": 46,
+      "description": "A public data terminal beside Skippy's Fern Bar.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Guzman Park\\1.bmp"
+    },
+    {
+      "roomId": 3002,
+      "_name": "Skippy's Fern Bar",
+      "type": "bar",
+      "sector": "blackhills",
+      "_area": "Guzman Park",
+      "icon": 27,
+      "exits": {
+        "north": null,
+        "south": 3202,
+        "west": 3102,
+        "east": null
+      },
+      "_gridCol": 23,
+      "_gridRow": 46,
+      "description": "You are in Skippy's Fern Bar. A classy joint where warriors meet to drink and tell lies about their battles. Skippy's is known for serving the best. To the south you see Swift Shore Drive. To the west you see a public data terminal.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Guzman Park\\1.bmp",
+      "_screen": 1,
+      "clientMapDescription": true
+    },
+    {
+      "roomId": 3259,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 51,
+      "exits": {
+        "north": 3267,
+        "south": 3258,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 31,
+      "_gridRow": 46
+    },
+    {
+      "type": "bar",
+      "sector": "cathay",
+      "icon": 26,
+      "exits": {
+        "north": 5108,
+        "south": 5208,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5008,
+      "_name": "Rule #6",
+      "_area": "Maze",
+      "_gridCol": 37,
+      "_gridRow": 46,
+      "description": "You are sure Rule #6 was here, but you can't seem to find it. Too bad, Bruce. To the north you see a public data terminal. To the south you see an alley off of Maximilian Ave.",
+      "_sourceBitmap": "Solaris - Bitmap\\Cathay\\Maze\\6.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 55,
+      "exits": {
+        "north": 5229,
+        "south": 5231,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5230,
+      "_name": "Solaris Highway One",
+      "_area": "Cathay Roads",
+      "_gridCol": 42,
+      "_gridRow": 46
+    },
+    {
+      "type": "bar",
+      "sector": "cathay",
+      "icon": 2,
+      "exits": {
+        "north": 5202,
+        "south": 5102,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5002,
+      "_name": "The Screaming Calf",
+      "_area": "Jungle",
+      "_gridCol": 45,
+      "_gridRow": 46,
+      "description": "You are in a bar. To the north you see Confederation Ave. To the south you see a public data terminal.",
+      "_sourceBitmap": "Solaris - Bitmap\\Cathay\\Jungle\\1.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 53,
+      "exits": {
+        "north": 5245,
+        "south": 5247,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5246,
+      "_name": "Jungle Approach",
+      "_area": "Jungle",
+      "_gridCol": 47,
+      "_gridRow": 46
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 51,
+      "exits": {
+        "north": 6231,
+        "south": 6233,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6232,
+      "_name": "Dusseldorf Street",
+      "_area": "Silesia Roads",
+      "_gridCol": 61,
+      "_gridRow": 46
+    },
+    {
+      "roomId": 3225,
+      "_name": "Hanse Davion Dr",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 48,
+      "exits": {
+        "north": 3226,
+        "south": 3224,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 13,
+      "_gridRow": 47
+    },
+    {
+      "roomId": 3202,
+      "_name": "Swift Shore Drive",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Guzman Park",
+      "icon": 25,
+      "exits": {
+        "north": 3002,
+        "south": 3251,
+        "west": null,
+        "east": 169
+      },
+      "_gridCol": 23,
+      "_gridRow": 47,
+      "description": "Swift Shore Drive through Guzman Park.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Guzman Park\\1.bmp"
+    },
+    {
+      "roomId": 169,
+      "_name": "Guzman Park",
+      "type": "hub",
+      "sector": "blackhills",
+      "_area": "Guzman Park",
+      "icon": 18,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": 3202,
+        "east": 3252
+      },
+      "_gridCol": 24,
+      "_gridRow": 47,
+      "description": "The centerpiece of the Black Hills residential district, the winding trails and sports fields of this heavily forested park become virtual battlegrounds after dark as slum gangs fight their turf wars. The street layout is of average complexity.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Guzman Park\\main.bmp"
+    },
+    {
+      "roomId": 3252,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 52,
+      "exits": {
+        "north": null,
+        "south": 3404,
+        "west": 169,
+        "east": 3253
+      },
+      "_gridCol": 25,
+      "_gridRow": 47
+    },
+    {
+      "roomId": 3253,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 46,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": 3252,
+        "east": 3254
+      },
+      "_gridCol": 26,
+      "_gridRow": 47
+    },
+    {
+      "roomId": 3254,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 55,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": 3253,
+        "east": 3255
+      },
+      "_gridCol": 27,
+      "_gridRow": 47
+    },
+    {
+      "roomId": 3255,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 49,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": 3254,
+        "east": 3256
+      },
+      "_gridCol": 28,
+      "_gridRow": 47
+    },
+    {
+      "roomId": 3256,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 24,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": 3255,
+        "east": 3257
+      },
+      "_gridCol": 29,
+      "_gridRow": 47
+    },
+    {
+      "roomId": 3257,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 53,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": 3256,
+        "east": 3258
+      },
+      "_gridCol": 30,
+      "_gridRow": 47
+    },
+    {
+      "roomId": 3258,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 47,
+      "exits": {
+        "north": 3259,
+        "south": null,
+        "west": 3257,
+        "east": null
+      },
+      "_gridCol": 31,
+      "_gridRow": 47
+    },
+    {
+      "type": "path",
+      "sector": "cathay",
+      "icon": 53,
+      "exits": {
+        "north": 5008,
+        "south": 5250,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5208,
+      "_name": "Alley off Maximilian Ave",
+      "_area": "Maze",
+      "_gridCol": 37,
+      "_gridRow": 47
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 24,
+      "exits": {
+        "north": 5230,
+        "south": 5232,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5231,
+      "_name": "Solaris Highway One",
+      "_area": "Cathay Roads",
+      "_gridCol": 42,
+      "_gridRow": 47
+    },
+    {
+      "type": "terminal",
+      "sector": "cathay",
+      "icon": 21,
+      "exits": {
+        "north": 5002,
+        "south": null,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5102,
+      "_name": "Public Data Terminal",
+      "_area": "Jungle",
+      "_gridCol": 45,
+      "_gridRow": 47
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 52,
+      "exits": {
+        "north": 5246,
+        "south": 162,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5247,
+      "_name": "Jungle Approach",
+      "_area": "Jungle",
+      "_gridCol": 47,
+      "_gridRow": 47
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 48,
+      "exits": {
+        "north": null,
+        "south": 6238,
+        "east": 6236,
+        "west": null
+      },
+      "roomId": 6237,
+      "_name": "Silesia Road",
+      "_area": "Silesia Roads",
+      "_gridCol": 57,
+      "_gridRow": 47
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 48,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6235,
+        "west": 6237
+      },
+      "roomId": 6236,
+      "_name": "Silesia Road",
+      "_area": "Silesia Roads",
+      "_gridCol": 58,
+      "_gridRow": 47
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 48,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6234,
+        "west": 6236
+      },
+      "roomId": 6235,
+      "_name": "Silesia Road",
+      "_area": "Silesia Roads",
+      "_gridCol": 59,
+      "_gridRow": 47
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 48,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6233,
+        "west": 6235
+      },
+      "roomId": 6234,
+      "_name": "Silesia Road",
+      "_area": "Silesia Roads",
+      "_gridCol": 60,
+      "_gridRow": 47
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 53,
+      "exits": {
+        "north": 6232,
+        "south": 6209,
+        "east": null,
+        "west": 6234
+      },
+      "roomId": 6233,
+      "_name": "Dusseldorf Street",
+      "_area": "Silesia Roads",
+      "_gridCol": 61,
+      "_gridRow": 47
+    },
+    {
+      "roomId": 3224,
+      "_name": "Hanse Davion Dr",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 48,
+      "exits": {
+        "north": 3225,
+        "south": 3223,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 13,
+      "_gridRow": 48
+    },
+    {
+      "roomId": 3251,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 47,
+      "exits": {
+        "north": 3202,
+        "south": 3250,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 23,
+      "_gridRow": 48
+    },
+    {
+      "sector": "blackhills",
+      "icon": 0,
+      "exits": {
+        "north": 3252,
+        "south": null,
+        "east": null,
+        "west": null
+      },
+      "roomId": 3404,
+      "_name": "Guzman Park Tram Station",
+      "type": "tram",
+      "_area": "Guzman Park",
+      "_gridCol": 25,
+      "_gridRow": 48,
+      "_inferred": true
+    },
+    {
+      "type": "path",
+      "sector": "cathay",
+      "icon": 53,
+      "exits": {
+        "north": 5208,
+        "south": 5251,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5250,
+      "_name": "Alley off Maximilian Ave",
+      "_area": "Cathay Roads",
+      "_gridCol": 37,
+      "_gridRow": 48
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 54,
+      "exits": {
+        "north": 5231,
+        "south": 5233,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5232,
+      "_name": "Solaris Highway One",
+      "_area": "Cathay Roads",
+      "_gridCol": 42,
+      "_gridRow": 48
+    },
+    {
+      "type": "arena",
+      "sector": "cathay",
+      "icon": 31,
+      "exits": {
+        "north": 5247,
+        "south": 5403,
+        "east": 5410,
+        "west": null
+      },
+      "roomId": 162,
+      "_name": "Jungle",
+      "_area": "Jungle",
+      "_gridCol": 47,
+      "_gridRow": 48,
+      "description": "The Jungle rises above the Cathay slums, a tribute to the greatness of House Liao amid the pathetic tenements of the teeming masses. Its lush interior is in stark contrast to the intimidating bulk of this massive ferrocrete pyramidal stadium. The street layout is very simple.",
+      "_sourceBitmap": "Solaris - Bitmap\\Cathay\\Jungle\\main.bmp"
+    },
+    {
+      "type": "ready_room",
+      "sector": "cathay",
+      "icon": 44,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 5411,
+        "west": 162
+      },
+      "roomId": 5410,
+      "_name": "Jungle Ready Room",
+      "_area": "Jungle",
+      "_sceneRoomId": 162,
+      "_gridCol": 48,
+      "_gridRow": 48,
+      "_inferred": true,
+      "description": "Ready room for Jungle arena combatants."
+    },
+    {
+      "type": "drop_room",
+      "sector": "cathay",
+      "icon": 11,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": null,
+        "west": 5410
+      },
+      "roomId": 5411,
+      "_name": "Jungle Drop Room",
+      "_area": "Jungle",
+      "_sceneRoomId": 162,
+      "_gridCol": 49,
+      "_gridRow": 48,
+      "_inferred": true,
+      "description": "Drop room connected to the Jungle ready room."
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 47,
+      "exits": {
+        "north": 6237,
+        "south": 6239,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6238,
+      "_name": "Silesia Road",
+      "_area": "Silesia Roads",
+      "_gridCol": 57,
+      "_gridRow": 48
+    },
+    {
+      "type": "terminal",
+      "sector": "silesia",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6009,
+        "west": null
+      },
+      "roomId": 6109,
+      "_name": "Public Data Terminal",
+      "_area": "Steiner Stadium",
+      "_gridCol": 59,
+      "_gridRow": 48
+    },
+    {
+      "type": "bar",
+      "sector": "silesia",
+      "icon": 2,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6209,
+        "west": 6109
+      },
+      "roomId": 6009,
+      "_name": "The Copper Coin",
+      "_area": "Steiner Stadium",
+      "_gridCol": 60,
+      "_gridRow": 48,
+      "description": "You are in a bar called the Copper Coin. To the east you see Dusseldorf Street. To the west you see a public data terminal.",
+      "_sourceBitmap": "Solaris - Bitmap\\Silesia\\Steiner Stadium\\1.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 51,
+      "exits": {
+        "north": 6233,
+        "south": 152,
+        "east": null,
+        "west": 6009
+      },
+      "roomId": 6209,
+      "_name": "Dusseldorf Street",
+      "_area": "Steiner Stadium",
+      "_gridCol": 61,
+      "_gridRow": 48
+    },
+    {
+      "roomId": 3004,
+      "_name": "Seventh Heaven",
+      "type": "bar",
+      "sector": "blackhills",
+      "_area": "Sortek Building",
+      "icon": 27,
+      "exits": {
+        "north": null,
+        "south": 3220,
+        "west": null,
+        "east": 3104
+      },
+      "_gridCol": 11,
+      "_gridRow": 49,
+      "description": "You are an exclusive establishment called Seventh Heaven. To the south you see Hanse Davion Ave. To the east you see a public data terminal.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Sortek Building\\1.bmp",
+      "_screen": 1,
+      "clientMapDescription": true
+    },
+    {
+      "roomId": 3104,
+      "_name": "Public Data Terminal",
+      "type": "terminal",
+      "sector": "blackhills",
+      "_area": "Sortek Building",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": 3004,
+        "east": null
+      },
+      "_gridCol": 12,
+      "_gridRow": 49,
+      "description": "A public data terminal beside Seventh Heaven.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Sortek Building\\1.bmp"
+    },
+    {
+      "roomId": 3223,
+      "_name": "Hanse Davion Dr",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 48,
+      "exits": {
+        "north": 3224,
+        "south": 3222,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 13,
+      "_gridRow": 49
+    },
+    {
+      "roomId": 3250,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 24,
+      "exits": {
+        "north": 3251,
+        "south": 3249,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 23,
+      "_gridRow": 49
+    },
+    {
+      "type": "path",
+      "sector": "cathay",
+      "icon": 52,
+      "exits": {
+        "north": 5250,
+        "south": 5252,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5251,
+      "_name": "Alley off Maximilian Ave",
+      "_area": "Cathay Roads",
+      "_gridCol": 37,
+      "_gridRow": 49
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 56,
+      "exits": {
+        "north": 5232,
+        "south": 5234,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5233,
+      "_name": "Solaris Highway One",
+      "_area": "Cathay Roads",
+      "_gridCol": 42,
+      "_gridRow": 49
+    },
+    {
+      "type": "tram",
+      "sector": "cathay",
+      "icon": 0,
+      "exits": {
+        "north": 162,
+        "south": null,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5403,
+      "_name": "Jungle Tram Station",
+      "_area": "Jungle",
+      "_gridCol": 47,
+      "_gridRow": 49,
+      "_inferred": true
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 46,
+      "exits": {
+        "north": 6238,
+        "south": 6240,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6239,
+      "_name": "Silesia Road",
+      "_area": "Silesia Roads",
+      "_gridCol": 57,
+      "_gridRow": 49
+    },
+    {
+      "type": "arena",
+      "sector": "silesia",
+      "icon": 29,
+      "exits": {
+        "north": 6209,
+        "south": 6403,
+        "east": 6410,
+        "west": null
+      },
+      "roomId": 152,
+      "_name": "Steiner Stadium",
+      "_area": "Steiner Stadium",
+      "_gridCol": 61,
+      "_gridRow": 49,
+      "description": "Looking like a tremendous Roman coliseum, Steiner Stadium is the only arena to offer seating within the actual arena for spectators, and utilizes lostech to protect them from weapons fire and explosions from the fierce battles taking place within this neoclassical edifice. The street layout is very simple.",
+      "_sourceBitmap": "Solaris - Bitmap\\Silesia\\Steiner Stadium\\main.bmp"
+    },
+    {
+      "type": "ready_room",
+      "sector": "silesia",
+      "icon": 44,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6411,
+        "west": 152
+      },
+      "roomId": 6410,
+      "_name": "Steiner Stadium Ready Room",
+      "_area": "Steiner Stadium",
+      "_sceneRoomId": 152,
+      "_gridCol": 62,
+      "_gridRow": 49,
+      "_inferred": true,
+      "description": "Ready room for Steiner Stadium combatants."
+    },
+    {
+      "type": "drop_room",
+      "sector": "silesia",
+      "icon": 11,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": null,
+        "west": 6410
+      },
+      "roomId": 6411,
+      "_name": "Steiner Stadium Drop Room",
+      "_area": "Steiner Stadium",
+      "_sceneRoomId": 152,
+      "_gridCol": 63,
+      "_gridRow": 49,
+      "_inferred": true,
+      "description": "Drop room connected to the Steiner Stadium ready room."
+    },
+    {
+      "roomId": 168,
+      "_name": "Sortek Building",
+      "type": "hub",
+      "sector": "blackhills",
+      "_area": "Sortek Building",
+      "icon": 56,
+      "exits": {
+        "north": null,
+        "south": 3405,
+        "west": null,
+        "east": 3220
+      },
+      "_gridCol": 10,
+      "_gridRow": 50,
+      "description": "The ugly brick Sortek Building characterizes much of this district, heavy on administrative muscle and rather short on style. The street layout is simple.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Sortek Building\\main.bmp"
+    },
+    {
+      "roomId": 3220,
+      "_name": "Hanse Davion Ave",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Sortek Building",
+      "icon": 25,
+      "exits": {
+        "north": 3004,
+        "south": null,
+        "west": 168,
+        "east": 3221
+      },
+      "_gridCol": 11,
+      "_gridRow": 50,
+      "description": "Hanse Davion Ave by the Sortek Building.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\Sortek Building\\1.bmp"
+    },
+    {
+      "roomId": 3221,
+      "_name": "Hanse Davion Ave",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 57,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": 3220,
+        "east": 3222
+      },
+      "_gridCol": 12,
+      "_gridRow": 50
+    },
+    {
+      "roomId": 3222,
+      "_name": "Hanse Davion Ave",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 25,
+      "exits": {
+        "north": 3223,
+        "south": null,
+        "west": 3221,
+        "east": 3240
+      },
+      "_gridCol": 13,
+      "_gridRow": 50
+    },
+    {
+      "roomId": 3240,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 47,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": 3222,
+        "east": 3241
+      },
+      "_gridCol": 14,
+      "_gridRow": 50
+    },
+    {
+      "roomId": 3241,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 56,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": 3240,
+        "east": 3242
+      },
+      "_gridCol": 15,
+      "_gridRow": 50
+    },
+    {
+      "roomId": 3242,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 51,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": 3241,
+        "east": 3243
+      },
+      "_gridCol": 16,
+      "_gridRow": 50
+    },
+    {
+      "roomId": 3243,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 25,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": 3242,
+        "east": 3244
+      },
+      "_gridCol": 17,
+      "_gridRow": 50
+    },
+    {
+      "roomId": 3244,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 54,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": 3243,
+        "east": 3245
+      },
+      "_gridCol": 18,
+      "_gridRow": 50
+    },
+    {
+      "roomId": 3245,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 48,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": 3244,
+        "east": 3246
+      },
+      "_gridCol": 19,
+      "_gridRow": 50
+    },
+    {
+      "roomId": 3246,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 57,
+      "exits": {
+        "north": null,
+        "south": 3307,
+        "west": 3245,
+        "east": 3247
+      },
+      "_gridCol": 20,
+      "_gridRow": 50
+    },
+    {
+      "roomId": 3247,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 52,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": 3246,
+        "east": 3248
+      },
+      "_gridCol": 21,
+      "_gridRow": 50
+    },
+    {
+      "roomId": 3248,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 46,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": 3247,
+        "east": 3249
+      },
+      "_gridCol": 22,
+      "_gridRow": 50
+    },
+    {
+      "roomId": 3249,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 55,
+      "exits": {
+        "north": 3250,
+        "south": null,
+        "west": 3248,
+        "east": null
+      },
+      "_gridCol": 23,
+      "_gridRow": 50
+    },
+    {
+      "type": "path",
+      "sector": "cathay",
+      "icon": 55,
+      "exits": {
+        "north": 5251,
+        "south": 5253,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5252,
+      "_name": "Alley off Maximilian Ave",
+      "_area": "Cathay Roads",
+      "_gridCol": 37,
+      "_gridRow": 50
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 48,
+      "exits": {
+        "north": 5233,
+        "south": 5235,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5234,
+      "_name": "Solaris Highway One",
+      "_area": "Cathay Roads",
+      "_gridCol": 42,
+      "_gridRow": 50
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 48,
+      "exits": {
+        "north": 6239,
+        "south": 6241,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6240,
+      "_name": "Silesia Road",
+      "_area": "Silesia Roads",
+      "_gridCol": 57,
+      "_gridRow": 50
+    },
+    {
+      "type": "tram",
+      "sector": "silesia",
+      "icon": 0,
+      "exits": {
+        "north": 152,
+        "south": null,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6403,
+      "_name": "Steiner Stadium Tram Station",
+      "_area": "Steiner Stadium",
+      "_gridCol": 61,
+      "_gridRow": 50,
+      "_inferred": true
+    },
+    {
+      "sector": "blackhills",
+      "icon": 0,
+      "exits": {
+        "north": 168,
+        "south": null,
+        "east": null,
+        "west": null
+      },
+      "roomId": 3405,
+      "_name": "Sortek Building Tram Station",
+      "type": "tram",
+      "_area": "Sortek Building",
+      "_gridCol": 10,
+      "_gridRow": 51,
+      "_inferred": true
+    },
+    {
+      "roomId": 3307,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 51,
+      "exits": {
+        "north": 3246,
+        "south": 3306,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 20,
+      "_gridRow": 51
+    },
+    {
+      "type": "path",
+      "sector": "cathay",
+      "icon": 53,
+      "exits": {
+        "north": 5252,
+        "south": 5254,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5253,
+      "_name": "Alley off Maximilian Ave",
+      "_area": "Cathay Roads",
+      "_gridCol": 37,
+      "_gridRow": 51
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 55,
+      "exits": {
+        "north": 5234,
+        "south": 5236,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5235,
+      "_name": "Solaris Highway One",
+      "_area": "Cathay Roads",
+      "_gridCol": 42,
+      "_gridRow": 51
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 47,
+      "exits": {
+        "north": 6240,
+        "south": 6242,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6241,
+      "_name": "Silesia Road",
+      "_area": "Silesia Roads",
+      "_gridCol": 57,
+      "_gridRow": 51
+    },
+    {
+      "roomId": 3306,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 47,
+      "exits": {
+        "north": 3307,
+        "south": 3305,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 20,
+      "_gridRow": 52
+    },
+    {
+      "type": "path",
+      "sector": "cathay",
+      "icon": 52,
+      "exits": {
+        "north": 5253,
+        "south": 5255,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5254,
+      "_name": "Alley off Maximilian Ave",
+      "_area": "Cathay Roads",
+      "_gridCol": 37,
+      "_gridRow": 52
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 24,
+      "exits": {
+        "north": 5235,
+        "south": 5237,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5236,
+      "_name": "Solaris Highway One",
+      "_area": "Cathay Roads",
+      "_gridCol": 42,
+      "_gridRow": 52
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 46,
+      "exits": {
+        "north": 6241,
+        "south": 6243,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6242,
+      "_name": "Silesia Road",
+      "_area": "Silesia Roads",
+      "_gridCol": 57,
+      "_gridRow": 52
+    },
+    {
+      "roomId": 3305,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 24,
+      "exits": {
+        "north": 3306,
+        "south": 3304,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 20,
+      "_gridRow": 53
+    },
+    {
+      "type": "path",
+      "sector": "cathay",
+      "icon": 55,
+      "exits": {
+        "north": 5254,
+        "south": 5256,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5255,
+      "_name": "Alley off Maximilian Ave",
+      "_area": "Cathay Roads",
+      "_gridCol": 37,
+      "_gridRow": 53
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 54,
+      "exits": {
+        "north": 5236,
+        "south": 5238,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5237,
+      "_name": "Solaris Highway One",
+      "_area": "Cathay Roads",
+      "_gridCol": 42,
+      "_gridRow": 53
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 48,
+      "exits": {
+        "north": 6242,
+        "south": 6244,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6243,
+      "_name": "Silesia Road",
+      "_area": "Silesia Roads",
+      "_gridCol": 57,
+      "_gridRow": 53
+    },
+    {
+      "roomId": 3304,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 55,
+      "exits": {
+        "north": 3305,
+        "south": 3303,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 20,
+      "_gridRow": 54
+    },
+    {
+      "type": "path",
+      "sector": "cathay",
+      "icon": 53,
+      "exits": {
+        "north": 5255,
+        "south": 5257,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5256,
+      "_name": "Alley off Maximilian Ave",
+      "_area": "Cathay Roads",
+      "_gridCol": 37,
+      "_gridRow": 54
+    },
+    {
+      "type": "terminal",
+      "sector": "cathay",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 5009,
+        "west": null
+      },
+      "roomId": 5109,
+      "_name": "Public Data Terminal",
+      "_area": "Middletown",
+      "_gridCol": 40,
+      "_gridRow": 54
+    },
+    {
+      "type": "bar",
+      "sector": "cathay",
+      "icon": 26,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 5238,
+        "west": 5109
+      },
+      "roomId": 5009,
+      "_name": "The Bitter Pool",
+      "_area": "Middletown",
+      "_gridCol": 41,
+      "_gridRow": 54,
+      "description": "You are in The Bitter Pool, where bitterness is not just a state of mind, but a way of life. Whenever you get bitter, come down to The Bitter Pool. To the east you see Solaris Highway One. To the west you see a public data terminal.",
+      "_sourceBitmap": "Solaris - Bitmap\\Cathay\\Middletown\\1.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 54,
+      "exits": {
+        "north": 5237,
+        "south": 5239,
+        "east": null,
+        "west": 5009
+      },
+      "roomId": 5238,
+      "_name": "Solaris Highway One",
+      "_area": "Middletown",
+      "_gridCol": 42,
+      "_gridRow": 54
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 47,
+      "exits": {
+        "north": 6243,
+        "south": 6245,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6244,
+      "_name": "Silesia Road",
+      "_area": "Silesia Roads",
+      "_gridCol": 57,
+      "_gridRow": 54
+    },
+    {
+      "roomId": 3303,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 52,
+      "exits": {
+        "north": 3304,
+        "south": 3302,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 20,
+      "_gridRow": 55
+    },
+    {
+      "type": "path",
+      "sector": "cathay",
+      "icon": 52,
+      "exits": {
+        "north": 5256,
+        "south": 5258,
+        "east": 5283,
+        "west": null
+      },
+      "roomId": 5257,
+      "_name": "Alley off Maximilian Ave",
+      "_area": "Cathay Roads",
+      "_gridCol": 37,
+      "_gridRow": 55
+    },
+    {
+      "sector": "cathay",
+      "type": "path",
+      "_area": "Cathay Roads",
+      "icon": 53,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 5284,
+        "west": 5257
+      },
+      "roomId": 5283,
+      "_name": "Middletown Alley",
+      "_gridCol": 38,
+      "_gridRow": 55
+    },
+    {
+      "sector": "cathay",
+      "type": "path",
+      "_area": "Cathay Roads",
+      "icon": 52,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 5285,
+        "west": 5283
+      },
+      "roomId": 5284,
+      "_name": "Middletown Alley",
+      "_gridCol": 39,
+      "_gridRow": 55
+    },
+    {
+      "sector": "cathay",
+      "type": "path",
+      "_area": "Cathay Roads",
+      "icon": 53,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 5286,
+        "west": 5284
+      },
+      "roomId": 5285,
+      "_name": "Middletown Alley",
+      "_gridCol": 40,
+      "_gridRow": 55
+    },
+    {
+      "sector": "cathay",
+      "type": "path",
+      "_area": "Cathay Roads",
+      "icon": 55,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 5239,
+        "west": 5285
+      },
+      "roomId": 5286,
+      "_name": "Middletown Alley",
+      "_gridCol": 41,
+      "_gridRow": 55
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 48,
+      "exits": {
+        "north": 5238,
+        "south": 5271,
+        "east": 5287,
+        "west": 5286
+      },
+      "roomId": 5239,
+      "_name": "Solaris Highway One",
+      "_area": "Cathay Roads",
+      "_gridCol": 42,
+      "_gridRow": 55
+    },
+    {
+      "sector": "cathay",
+      "type": "path",
+      "_area": "Cathay Roads",
+      "icon": 52,
+      "exits": {
+        "north": null,
+        "south": 164,
+        "east": null,
+        "west": 5239
+      },
+      "roomId": 5287,
+      "_name": "North Middletown Path",
+      "_gridCol": 43,
+      "_gridRow": 55
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 46,
+      "exits": {
+        "north": 6244,
+        "south": 6246,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6245,
+      "_name": "Silesia Road",
+      "_area": "Silesia Roads",
+      "_gridCol": 57,
+      "_gridRow": 55
+    },
+    {
+      "type": "terminal",
+      "sector": "silesia",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": 6002,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6102,
+      "_name": "Public Data Terminal",
+      "_area": "Black Thorne",
+      "_gridCol": 58,
+      "_gridRow": 55
+    },
+    {
+      "type": "terminal",
+      "sector": "silesia",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6004,
+        "west": null
+      },
+      "roomId": 6104,
+      "_name": "Public Data Terminal",
+      "_area": "Black Thorne",
+      "_gridCol": 61,
+      "_gridRow": 55
+    },
+    {
+      "type": "bar",
+      "sector": "silesia",
+      "icon": 26,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6204,
+        "west": 6104
+      },
+      "roomId": 6004,
+      "_name": "Uncle Skippy's House of Madness",
+      "_area": "Black Thorne",
+      "_gridCol": 62,
+      "_gridRow": 55,
+      "description": "You are endangering your sanity! Leave while you can! To the east you see North Dusseldorf St. To the west you see a public data terminal.",
+      "_sourceBitmap": "Solaris - Bitmap\\Silesia\\Black Thorne\\4.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 51,
+      "exits": {
+        "north": null,
+        "south": 6251,
+        "east": null,
+        "west": 6004
+      },
+      "roomId": 6204,
+      "_name": "North Dusseldorf St",
+      "_area": "Black Thorne",
+      "_gridCol": 63,
+      "_gridRow": 55
+    },
+    {
+      "roomId": 3302,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 48,
+      "exits": {
+        "north": 3303,
+        "south": 3301,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 20,
+      "_gridRow": 56
+    },
+    {
+      "type": "path",
+      "sector": "cathay",
+      "icon": 55,
+      "exits": {
+        "north": 5257,
+        "south": 5259,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5258,
+      "_name": "Alley off Maximilian Ave",
+      "_area": "Cathay Roads",
+      "_gridCol": 37,
+      "_gridRow": 56
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "_area": "Cathay Roads",
+      "icon": 55,
+      "exits": {
+        "north": 5239,
+        "south": null,
+        "east": 164,
+        "west": null
+      },
+      "roomId": 5271,
+      "_name": "Solaris Highway One",
+      "_gridCol": 42,
+      "_gridRow": 56
+    },
+    {
+      "type": "hub",
+      "sector": "cathay",
+      "icon": 57,
+      "exits": {
+        "north": 5287,
+        "south": 5272,
+        "east": 5404,
+        "west": 5271
+      },
+      "roomId": 164,
+      "_name": "Middletown",
+      "_area": "Middletown",
+      "_gridCol": 43,
+      "_gridRow": 56,
+      "description": "The middle class of Cathay enjoy a relatively comfortable existence here, positioned between the crime and poverty of the slums and the wealth and influence of the upper-class Liaoists. The street layout is of average complexity.",
+      "_sourceBitmap": "Solaris - Bitmap\\Cathay\\Middletown\\main.bmp"
+    },
+    {
+      "type": "tram",
+      "sector": "cathay",
+      "icon": 0,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": null,
+        "west": 164
+      },
+      "roomId": 5404,
+      "_name": "Middletown Tram Station",
+      "_area": "Middletown",
+      "_gridCol": 44,
+      "_gridRow": 56,
+      "_inferred": true
+    },
+    {
+      "type": "terminal",
+      "sector": "silesia",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": 6001,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6101,
+      "_name": "Public Data Terminal",
+      "_area": "Black Thorne",
+      "_gridCol": 56,
+      "_gridRow": 56
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 48,
+      "exits": {
+        "north": 6245,
+        "south": 6247,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6246,
+      "_name": "Silesia Road",
+      "_area": "Silesia Roads",
+      "_gridCol": 57,
+      "_gridRow": 56
+    },
+    {
+      "type": "bar",
+      "sector": "silesia",
+      "icon": 27,
+      "exits": {
+        "north": 6102,
+        "south": 6202,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6002,
+      "_name": "Solrac's House of Death",
+      "_area": "Black Thorne",
+      "_gridCol": 58,
+      "_gridRow": 56,
+      "description": "You are in Solrac's House of Death. Graphic memorials to the great fallen MechWarriors cover the walls. To the north you see a public data terminal. To the south you see the end of Arnulf St., south of Solrac's House of Death.",
+      "_sourceBitmap": "Solaris - Bitmap\\Silesia\\Black Thorne\\2.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 52,
+      "exits": {
+        "north": 6204,
+        "south": 6252,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6251,
+      "_name": "North Dusseldorf St",
+      "_area": "Black Thorne",
+      "_gridCol": 63,
+      "_gridRow": 56
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 48,
+      "exits": {
+        "north": null,
+        "south": 154,
+        "east": 6006,
+        "west": null
+      },
+      "roomId": 6206,
+      "_name": "Vialla Circle",
+      "_area": "Chahar Park",
+      "_gridCol": 68,
+      "_gridRow": 56
+    },
+    {
+      "type": "bar",
+      "sector": "silesia",
+      "icon": 26,
+      "exits": {
+        "north": null,
+        "south": 6106,
+        "east": null,
+        "west": 6206
+      },
+      "roomId": 6006,
+      "_name": "Thor's Shieldhall",
+      "_area": "Chahar Park",
+      "_gridCol": 69,
+      "_gridRow": 56,
+      "description": "You are in Thor's Shieldhall. To the south you see a public data terminal. To the west you see Vialla Circle.",
+      "_sourceBitmap": "Solaris - Bitmap\\Silesia\\Chahar Park\\1.bmp"
+    },
+    {
+      "roomId": 3301,
+      "_name": "Black Hills Road",
+      "type": "street",
+      "sector": "blackhills",
+      "_area": "Black Hills Roads",
+      "icon": 25,
+      "exits": {
+        "north": 3302,
+        "south": 6,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 20,
+      "_gridRow": 57
+    },
+    {
+      "type": "path",
+      "sector": "cathay",
+      "icon": 53,
+      "exits": {
+        "north": 5258,
+        "south": 5260,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5259,
+      "_name": "Alley off Maximilian Ave",
+      "_area": "Cathay Roads",
+      "_gridCol": 37,
+      "_gridRow": 57
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "_area": "Cathay Roads",
+      "icon": 56,
+      "exits": {
+        "north": 164,
+        "south": 5273,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5272,
+      "_name": "Middletown Connector",
+      "_gridCol": 43,
+      "_gridRow": 57
+    },
+    {
+      "type": "bar",
+      "sector": "silesia",
+      "icon": 26,
+      "exits": {
+        "north": 6101,
+        "south": 6201,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6001,
+      "_name": "The Grateful Burger",
+      "_area": "Black Thorne",
+      "_gridCol": 56,
+      "_gridRow": 57,
+      "description": "You are just in time. The mysterious \"Deadhead\" cult is having a reading. Plus, some woman named \"Sunshine\" keeps telling you you are \"beautiful.\" To the north you see a public data terminal. To the south you see the intersection of Arnulf St. and Marburg St.",
+      "_sourceBitmap": "Solaris - Bitmap\\Silesia\\Black Thorne\\1.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 47,
+      "exits": {
+        "north": 6246,
+        "south": 6248,
+        "east": 6202,
+        "west": null
+      },
+      "roomId": 6247,
+      "_name": "Silesia Road",
+      "_area": "Silesia Roads",
+      "_gridCol": 57,
+      "_gridRow": 57
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 24,
+      "exits": {
+        "north": 6002,
+        "south": null,
+        "east": 6256,
+        "west": 6247
+      },
+      "roomId": 6202,
+      "_name": "Arnulf St",
+      "_area": "Black Thorne",
+      "_gridCol": 58,
+      "_gridRow": 57
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 51,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6255,
+        "west": 6202
+      },
+      "roomId": 6256,
+      "_name": "North Dusseldorf St",
+      "_area": "Black Thorne",
+      "_gridCol": 59,
+      "_gridRow": 57
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 51,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6254,
+        "west": 6256
+      },
+      "roomId": 6255,
+      "_name": "North Dusseldorf St",
+      "_area": "Black Thorne",
+      "_gridCol": 60,
+      "_gridRow": 57
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 51,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6253,
+        "west": 6255
+      },
+      "roomId": 6254,
+      "_name": "North Dusseldorf St",
+      "_area": "Black Thorne",
+      "_gridCol": 61,
+      "_gridRow": 57
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 51,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6252,
+        "west": 6254
+      },
+      "roomId": 6253,
+      "_name": "North Dusseldorf St",
+      "_area": "Black Thorne",
+      "_gridCol": 62,
+      "_gridRow": 57
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 51,
+      "exits": {
+        "north": 6251,
+        "south": null,
+        "east": 6257,
+        "west": 6253
+      },
+      "roomId": 6252,
+      "_name": "North Dusseldorf St",
+      "_area": "Black Thorne",
+      "_gridCol": 63,
+      "_gridRow": 57
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 23,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6258,
+        "west": 6252
+      },
+      "roomId": 6257,
+      "_name": "Marburg St",
+      "_area": "Black Thorne",
+      "_gridCol": 64,
+      "_gridRow": 57
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 49,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6259,
+        "west": 6257
+      },
+      "roomId": 6258,
+      "_name": "Marburg St",
+      "_area": "Black Thorne",
+      "_gridCol": 65,
+      "_gridRow": 57
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 24,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6260,
+        "west": 6258
+      },
+      "roomId": 6259,
+      "_name": "Marburg St",
+      "_area": "Black Thorne",
+      "_gridCol": 66,
+      "_gridRow": 57
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 23,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 154,
+        "west": 6259
+      },
+      "roomId": 6260,
+      "_name": "Marburg St",
+      "_area": "Black Thorne",
+      "_gridCol": 67,
+      "_gridRow": 57
+    },
+    {
+      "type": "hub",
+      "sector": "silesia",
+      "icon": 18,
+      "exits": {
+        "north": 6206,
+        "south": 6405,
+        "east": null,
+        "west": 6260
+      },
+      "roomId": 154,
+      "_name": "Chahar Park",
+      "_area": "Chahar Park",
+      "_gridCol": 68,
+      "_gridRow": 57,
+      "description": "The man-made lake at the center of the park is well-loved by boaters and picnickers, but night brings muggers and drug dealers, who have thus far resisted the stepped-up patrols instituted by Steiner security forces. The street layout is simple.",
+      "_sourceBitmap": "Solaris - Bitmap\\Silesia\\Chahar Park\\main.bmp"
+    },
+    {
+      "type": "terminal",
+      "sector": "silesia",
+      "icon": 21,
+      "exits": {
+        "north": 6006,
+        "south": null,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6106,
+      "_name": "Public Data Terminal",
+      "_area": "Chahar Park",
+      "_gridCol": 69,
+      "_gridRow": 57
+    },
+    {
+      "roomId": 6,
+      "_name": "Black Hills Sector",
+      "type": "sector",
+      "sector": "blackhills",
+      "_area": "Sector Overview",
+      "icon": 37,
+      "exits": {
+        "north": 3301,
+        "south": null,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 20,
+      "_gridRow": 58,
+      "description": "The Davion sector presents itself as a high-tech bastion of civilization and virtue, but squalor and crime are just as prevalent here as anywhere in the city. The fixed arenas in Black Hills use arctic terrain.",
+      "_sourceBitmap": "Solaris - Bitmap\\Black Hills\\main.bmp"
+    },
+    {
+      "type": "path",
+      "sector": "cathay",
+      "icon": 52,
+      "exits": {
+        "north": 5259,
+        "south": 5261,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5260,
+      "_name": "Alley off Maximilian Ave",
+      "_area": "Cathay Roads",
+      "_gridCol": 37,
+      "_gridRow": 58
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "_area": "Cathay Roads",
+      "icon": 55,
+      "exits": {
+        "north": 5272,
+        "south": 5274,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5273,
+      "_name": "Middletown Connector",
+      "_gridCol": 43,
+      "_gridRow": 58
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 23,
+      "exits": {
+        "north": 6001,
+        "south": null,
+        "east": 6248,
+        "west": null
+      },
+      "roomId": 6201,
+      "_name": "Arnulf St / Marburg St",
+      "_area": "Black Thorne",
+      "_gridCol": 56,
+      "_gridRow": 58
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 46,
+      "exits": {
+        "north": 6247,
+        "south": 6249,
+        "east": null,
+        "west": 6201
+      },
+      "roomId": 6248,
+      "_name": "Silesia Road",
+      "_area": "Silesia Roads",
+      "_gridCol": 57,
+      "_gridRow": 58
+    },
+    {
+      "type": "tram",
+      "sector": "silesia",
+      "icon": 0,
+      "exits": {
+        "north": 154,
+        "south": null,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6405,
+      "_name": "Chahar Park Tram Station",
+      "_area": "Chahar Park",
+      "_gridCol": 68,
+      "_gridRow": 58,
+      "_inferred": true
+    },
+    {
+      "type": "path",
+      "sector": "cathay",
+      "icon": 55,
+      "exits": {
+        "north": 5260,
+        "south": 5262,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5261,
+      "_name": "Alley off Maximilian Ave",
+      "_area": "Cathay Roads",
+      "_gridCol": 37,
+      "_gridRow": 59
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "_area": "Cathay Roads",
+      "icon": 56,
+      "exits": {
+        "north": 5273,
+        "south": 5275,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5274,
+      "_name": "Middletown Connector",
+      "_gridCol": 43,
+      "_gridRow": 59
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 48,
+      "exits": {
+        "north": 6248,
+        "south": 6250,
+        "east": 6205,
+        "west": null
+      },
+      "roomId": 6249,
+      "_name": "Silesia Road",
+      "_area": "Silesia Roads",
+      "_gridCol": 57,
+      "_gridRow": 59
+    },
+    {
+      "type": "path",
+      "sector": "silesia",
+      "icon": 52,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6005,
+        "west": 6249
+      },
+      "roomId": 6205,
+      "_name": "Dark Alley",
+      "_area": "Black Thorne",
+      "_gridCol": 58,
+      "_gridRow": 59
+    },
+    {
+      "type": "bar",
+      "sector": "silesia",
+      "icon": 2,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6105,
+        "west": 6205
+      },
+      "roomId": 6005,
+      "_name": "Stingy's Bathhouse",
+      "_area": "Black Thorne",
+      "_gridCol": 59,
+      "_gridRow": 59,
+      "description": "You are in Stingy's Bathhouse, and the rumors about the gang wars in the hot tubs are totally false. Really. To the east you see a public data terminal. To the west you see a dark and forbidding alley.",
+      "_sourceBitmap": "Solaris - Bitmap\\Silesia\\Black Thorne\\5.bmp"
+    },
+    {
+      "type": "terminal",
+      "sector": "silesia",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": null,
+        "west": 6005
+      },
+      "roomId": 6105,
+      "_name": "Public Data Terminal",
+      "_area": "Black Thorne",
+      "_gridCol": 60,
+      "_gridRow": 59
+    },
+    {
+      "type": "path",
+      "sector": "cathay",
+      "icon": 53,
+      "exits": {
+        "north": 5261,
+        "south": 5263,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5262,
+      "_name": "Alley off Maximilian Ave",
+      "_area": "Cathay Roads",
+      "_gridCol": 37,
+      "_gridRow": 60
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "_area": "Cathay Roads",
+      "icon": 55,
+      "exits": {
+        "north": 5274,
+        "south": 5276,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5275,
+      "_name": "Middletown Connector",
+      "_gridCol": 43,
+      "_gridRow": 60
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 47,
+      "exits": {
+        "north": 6249,
+        "south": 156,
+        "east": null,
+        "west": null
+      },
+      "roomId": 6250,
+      "_name": "Silesia Road",
+      "_area": "Silesia Roads",
+      "_gridCol": 57,
+      "_gridRow": 60
+    },
+    {
+      "type": "path",
+      "sector": "cathay",
+      "icon": 52,
+      "exits": {
+        "north": 5262,
+        "south": 5278,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5263,
+      "_name": "Alley off Maximilian Ave",
+      "_area": "Cathay Roads",
+      "_gridCol": 37,
+      "_gridRow": 61
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "_area": "Cathay Roads",
+      "icon": 56,
+      "exits": {
+        "north": 5275,
+        "south": 5277,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5276,
+      "_name": "Middletown Connector",
+      "_gridCol": 43,
+      "_gridRow": 61
+    },
+    {
+      "type": "tram",
+      "sector": "silesia",
+      "icon": 0,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 156,
+        "west": null
+      },
+      "roomId": 6404,
+      "_name": "Black Thorne Tram Station",
+      "_area": "Black Thorne",
+      "_gridCol": 56,
+      "_gridRow": 61,
+      "_inferred": true
+    },
+    {
+      "type": "hub",
+      "sector": "silesia",
+      "icon": 48,
+      "exits": {
+        "north": 6250,
+        "south": null,
+        "east": 6261,
+        "west": 6404
+      },
+      "roomId": 156,
+      "_name": "Black Thorne",
+      "_area": "Black Thorne",
+      "_gridCol": 57,
+      "_gridRow": 61,
+      "description": "Parts of this district live in relative comfort, but other areas still experience a high crime rate, and many citizens arm themselves for protection against the organized crime triads. The street layout is complex.",
+      "_sourceBitmap": "Solaris - Bitmap\\Silesia\\Black Thorne\\main.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 56,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6262,
+        "west": 156
+      },
+      "roomId": 6261,
+      "_name": "Silesia Sector Road",
+      "_area": "Silesia Roads",
+      "_gridCol": 58,
+      "_gridRow": 61
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 56,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6263,
+        "west": 6261
+      },
+      "roomId": 6262,
+      "_name": "Silesia Sector Road",
+      "_area": "Silesia Roads",
+      "_gridCol": 59,
+      "_gridRow": 61
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 56,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6264,
+        "west": 6262
+      },
+      "roomId": 6263,
+      "_name": "Silesia Sector Road",
+      "_area": "Silesia Roads",
+      "_gridCol": 60,
+      "_gridRow": 61
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 56,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6265,
+        "west": 6263
+      },
+      "roomId": 6264,
+      "_name": "Silesia Sector Road",
+      "_area": "Silesia Roads",
+      "_gridCol": 61,
+      "_gridRow": 61
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 56,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6266,
+        "west": 6264
+      },
+      "roomId": 6265,
+      "_name": "Silesia Sector Road",
+      "_area": "Silesia Roads",
+      "_gridCol": 62,
+      "_gridRow": 61
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 56,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6267,
+        "west": 6265
+      },
+      "roomId": 6266,
+      "_name": "Silesia Sector Road",
+      "_area": "Silesia Roads",
+      "_gridCol": 63,
+      "_gridRow": 61
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 56,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 6268,
+        "west": 6266
+      },
+      "roomId": 6267,
+      "_name": "Silesia Sector Road",
+      "_area": "Silesia Roads",
+      "_gridCol": 64,
+      "_gridRow": 61
+    },
+    {
+      "type": "street",
+      "sector": "silesia",
+      "icon": 56,
+      "exits": {
+        "north": null,
+        "south": 3,
+        "east": null,
+        "west": 6267
+      },
+      "roomId": 6268,
+      "_name": "Silesia Sector Road",
+      "_area": "Silesia Roads",
+      "_gridCol": 65,
+      "_gridRow": 61
+    },
+    {
+      "type": "path",
+      "sector": "cathay",
+      "_area": "Cathay Roads",
+      "icon": 53,
+      "exits": {
+        "north": 5263,
+        "south": null,
+        "east": 5264,
+        "west": null
+      },
+      "roomId": 5278,
+      "_name": "Alley off Maximilian Ave",
+      "_gridCol": 37,
+      "_gridRow": 62
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 51,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 5265,
+        "west": 5278
+      },
+      "roomId": 5264,
+      "_name": "Maximilian Ave",
+      "_area": "Chancellor's Quarter",
+      "_gridCol": 38,
+      "_gridRow": 62
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 53,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 163,
+        "west": 5264
+      },
+      "roomId": 5265,
+      "_name": "Maximilian Ave",
+      "_area": "Chancellor's Quarter",
+      "_gridCol": 39,
+      "_gridRow": 62
+    },
+    {
+      "type": "headquarters",
+      "sector": "cathay",
+      "icon": 45,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 5266,
+        "west": 5265
+      },
+      "roomId": 163,
+      "_name": "Chancellor's Quarter",
+      "_area": "Chancellor's Quarter",
+      "_gridCol": 40,
+      "_gridRow": 62,
+      "description": "A stark contrast to the slums below, the Chancellor's Quarter is home to Cathay's elite. Boasting the highest standard of living in Solaris City, gleaming towers and rambling estates are the rule here. The street layout is simple.",
+      "_sourceBitmap": "Solaris - Bitmap\\Cathay\\Chancellor's Quarter\\main.bmp"
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 52,
+      "exits": {
+        "north": null,
+        "south": 5405,
+        "east": 5267,
+        "west": 163
+      },
+      "roomId": 5266,
+      "_name": "Maximilian Ave",
+      "_area": "Chancellor's Quarter",
+      "_gridCol": 41,
+      "_gridRow": 62
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 57,
+      "exits": {
+        "north": null,
+        "south": 5268,
+        "east": 5277,
+        "west": 5266
+      },
+      "roomId": 5267,
+      "_name": "Maximilian Ave",
+      "_area": "Chancellor's Quarter",
+      "_gridCol": 42,
+      "_gridRow": 62
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "_area": "Cathay Roads",
+      "icon": 55,
+      "exits": {
+        "north": 5276,
+        "south": null,
+        "east": null,
+        "west": 5267
+      },
+      "roomId": 5277,
+      "_name": "Middletown Connector",
+      "_gridCol": 43,
+      "_gridRow": 62
+    },
+    {
+      "type": "sector",
+      "sector": "silesia",
+      "icon": 39,
+      "exits": {
+        "north": 6268,
+        "south": null,
+        "east": null,
+        "west": null
+      },
+      "roomId": 3,
+      "_name": "Silesia Sector",
+      "_area": "Sector Overview",
+      "_gridCol": 65,
+      "_gridRow": 62,
+      "description": "Despite official attempts to maintain Silesia as a showpiece of Lyran culture, it suffers the same problems as the rest of the city. The beautiful private estates of the Sector are as frequently financed by the very crime that devastates its poorer areas. The fixed arenas in Silesia use temperate terrain.",
+      "_sourceBitmap": "Solaris - Bitmap\\Silesia\\main.bmp"
+    },
+    {
+      "type": "bar",
+      "sector": "cathay",
+      "icon": 27,
+      "exits": {
+        "north": null,
+        "south": 5201,
+        "east": 5101,
+        "west": null
+      },
+      "roomId": 5001,
+      "_name": "Warrior's Hall",
+      "_area": "Chancellor's Quarter",
+      "_gridCol": 39,
+      "_gridRow": 63,
+      "description": "You are in Warrior's Hall. To the south you see Maximilian Ave. To the east you see a public data terminal.",
+      "_sourceBitmap": "Solaris - Bitmap\\Cathay\\Chancellor's Quarter\\1.bmp"
+    },
+    {
+      "type": "terminal",
+      "sector": "cathay",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": null,
+        "west": 5001
+      },
+      "roomId": 5101,
+      "_name": "Public Data Terminal",
+      "_area": "Chancellor's Quarter",
+      "_gridCol": 40,
+      "_gridRow": 63
+    },
+    {
+      "type": "tram",
+      "sector": "cathay",
+      "icon": 0,
+      "exits": {
+        "north": 5266,
+        "south": null,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5405,
+      "_name": "Chancellor's Quarter Tram Station",
+      "_area": "Chancellor's Quarter",
+      "_gridCol": 41,
+      "_gridRow": 63,
+      "_inferred": true
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 52,
+      "exits": {
+        "north": 5267,
+        "south": 5269,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5268,
+      "_name": "Maximilian Ave",
+      "_area": "Chancellor's Quarter",
+      "_gridCol": 42,
+      "_gridRow": 63
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 51,
+      "exits": {
+        "north": 5001,
+        "south": null,
+        "east": 5279,
+        "west": null
+      },
+      "roomId": 5201,
+      "_name": "Maximilian Ave",
+      "_area": "Chancellor's Quarter",
+      "_gridCol": 39,
+      "_gridRow": 64
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "_area": "Chancellor's Quarter",
+      "icon": 52,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 5280,
+        "west": 5201
+      },
+      "roomId": 5279,
+      "_name": "Maximilian Ave",
+      "_gridCol": 40,
+      "_gridRow": 64
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "_area": "Chancellor's Quarter",
+      "icon": 53,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 5269,
+        "west": 5279
+      },
+      "roomId": 5280,
+      "_name": "Maximilian Ave",
+      "_gridCol": 41,
+      "_gridRow": 64
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 57,
+      "exits": {
+        "north": 5268,
+        "south": 5281,
+        "east": null,
+        "west": 5280
+      },
+      "roomId": 5269,
+      "_name": "Maximilian Ave",
+      "_area": "Chancellor's Quarter",
+      "_gridCol": 42,
+      "_gridRow": 64
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "_area": "Cathay Roads",
+      "icon": 57,
+      "exits": {
+        "north": null,
+        "south": 5,
+        "east": 5270,
+        "west": null
+      },
+      "roomId": 5282,
+      "_name": "Cathay Sector Road",
+      "_gridCol": 40,
+      "_gridRow": 65
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "icon": 56,
+      "exits": {
+        "north": null,
+        "south": null,
+        "east": 5281,
+        "west": 5282
+      },
+      "roomId": 5270,
+      "_name": "Cathay Sector Road",
+      "_area": "Cathay Roads",
+      "_gridCol": 41,
+      "_gridRow": 65
+    },
+    {
+      "type": "street",
+      "sector": "cathay",
+      "_area": "Cathay Roads",
+      "icon": 56,
+      "exits": {
+        "north": 5269,
+        "south": null,
+        "east": null,
+        "west": 5270
+      },
+      "roomId": 5281,
+      "_name": "Cathay Sector Road",
+      "_gridCol": 42,
+      "_gridRow": 65
+    },
+    {
+      "type": "sector",
+      "sector": "cathay",
+      "icon": 36,
+      "exits": {
+        "north": 5282,
+        "south": null,
+        "east": null,
+        "west": null
+      },
+      "roomId": 5,
+      "_name": "Cathay Sector",
+      "_area": "Sector Overview",
+      "_gridCol": 40,
+      "_gridRow": 66,
+      "description": "Cathay displays the sharpest contrasts between the classes. A large body of what are essentially working-class serfs maintain the luxurious splendor of the small upper class. Crime and gang activity is rampant, despite the ruthless efficiency of Cathay Security. The fixed arenas in Cathay use temperate and tropical terrain.",
+      "_sourceBitmap": "Solaris - Bitmap\\Cathay\\main.bmp"
+    },
+    {
+      "roomId": 2004,
+      "_name": "ComStar Headquarters",
+      "description": "The place for game staff to meet and help new players. The place to find answers to all of your questions. ComStar Headquarters has a little something for everyone. ComStar members come here to relax. MechWarriors come here to hang out with the coolest group on Solaris.",
+      "type": "bar",
+      "sector": "international",
+      "_area": "Training Area",
+      "icon": 2,
+      "exits": {
+        "north": null,
+        "south": 2003,
+        "west": null,
+        "east": 2005
+      },
+      "_gridCol": 19,
+      "_gridRow": 68,
+      "_screen": 7,
+      "_sourceBitmap": "Solaris - Bitmap\\International Zone\\7.bmp",
+      "clientMapDescription": true
+    },
+    {
+      "roomId": 2005,
+      "_name": "Public Data Terminal",
+      "description": "A public data terminal in ComStar Headquarters.",
+      "type": "terminal",
+      "sector": "international",
+      "_area": "Training Area",
+      "icon": 21,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": 2004,
+        "east": null
+      },
+      "_gridCol": 20,
+      "_gridRow": 68,
+      "_sourceBitmap": "Solaris - Bitmap\\International Zone\\7.bmp"
+    },
+    {
+      "roomId": 146,
+      "_name": "Solaris Starport Arrivals Area",
+      "description": "Click on the stone arch icon to the east for a tutorial if you are new to Solaris City and need help. Click on the tram icon to the south if you know your way around and you're ready to go find a fight.  Remember, players with [MPBT] in front of their names are the game staff.  They will help to teach you the game. Other players that want to train you or that want you to join their group may not have the best intentions.",
+      "type": "hub",
+      "sector": "international",
+      "_area": "Training Area",
+      "icon": 1,
+      "exits": {
+        "north": null,
+        "south": 9010,
+        "west": null,
+        "east": 2000
+      },
+      "_gridCol": 15,
+      "_gridRow": 69,
+      "_screen": 2,
+      "_sourceBitmap": "Solaris - Bitmap\\International Zone\\2.bmp",
+      "clientMapDescription": true
+    },
+    {
+      "roomId": 2000,
+      "_name": "Solaris Tutorial",
+      "description": "Using this tutorial, you will move from one location to another and learn about the game. Each location explains a different feature. At the end of the tutorial you can leave this sector to go find a battle. +++ The five icons in the lower left corner of the screen represent locations. The center icon shows your current location. The other four icons show locations nearby to the north, south, east and west. +++ Click on the street icon to the east to continue.",
+      "type": "path",
+      "sector": "international",
+      "_area": "Training Area",
+      "icon": 52,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": 146,
+        "east": 2001
+      },
+      "_gridCol": 16,
+      "_gridRow": 69,
+      "_screen": 3,
+      "_sourceBitmap": "Solaris - Bitmap\\International Zone\\3.bmp",
+      "clientMapDescription": true
+    },
+    {
+      "roomId": 2001,
+      "_name": "West Training Street",
+      "description": "You are standing in a street location. Players use the streets to move from one location to another within a sector. You can chat with other players where you are in any location by entering text in the chat buffer just above the help button. Click on the street to the east to continue.",
+      "type": "street",
+      "sector": "international",
+      "_area": "Training Area",
+      "icon": 23,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": 2000,
+        "east": 2002
+      },
+      "_gridCol": 17,
+      "_gridRow": 69,
+      "_screen": 4,
+      "_sourceBitmap": "Solaris - Bitmap\\International Zone\\4.bmp",
+      "clientMapDescription": true
+    },
+    {
+      "roomId": 2002,
+      "_name": "East Training Street",
+      "description": "Click on the center street icon, your current location, for a list of all players at this location. From there, click on \"All\" to see a list of all players; you can see a player's score or send a message by clicking on that player in the list. Click on the street to the east to continue.",
+      "type": "street",
+      "sector": "international",
+      "_area": "Training Area",
+      "icon": 24,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": 2001,
+        "east": 2003
+      },
+      "_gridCol": 18,
+      "_gridRow": 69,
+      "_screen": 5,
+      "_sourceBitmap": "Solaris - Bitmap\\International Zone\\5.bmp",
+      "clientMapDescription": true
+    },
+    {
+      "roomId": 2003,
+      "_name": "Training Street",
+      "description": "Click on the Bar icon to the north to enter the ComStar Headquarters bar. Click on the Davion Arena icon to the south to enter the training arena. After looking at these areas, return here to continue the tutorial. Then, click on the street icon to the east to learn about traveling between sectors.",
+      "type": "street",
+      "sector": "international",
+      "_area": "Training Area",
+      "icon": 25,
+      "exits": {
+        "north": 2004,
+        "south": 2006,
+        "west": 2002,
+        "east": 2009
+      },
+      "_gridCol": 19,
+      "_gridRow": 69,
+      "_screen": 6,
+      "_sourceBitmap": "Solaris - Bitmap\\International Zone\\6.bmp",
+      "clientMapDescription": true
+    },
+    {
+      "roomId": 2009,
+      "_name": "Tram Station",
+      "description": "Click on the Tram icon to the east for a subway map of Solaris City. The map shows sectors in white and districts in color. From the map, click on a district name and then on \"Travel\" to travel to that district. (If you do this, you will exit this tutorial; take the tram back to the \"Solaris Starport\" district to return to the tutorial.) +++ The Jungle, The Factory and Steiner Stadium have easier street layouts, and are recommended for new warriors.",
+      "type": "tram",
+      "sector": "international",
+      "_area": "Training Area",
+      "icon": 46,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": 2003,
+        "east": 9000
+      },
+      "_gridCol": 20,
+      "_gridRow": 69,
+      "_screen": 11,
+      "_sourceBitmap": "Solaris - Bitmap\\International Zone\\11.bmp",
+      "clientMapDescription": true
+    },
+    {
+      "roomId": 9000,
+      "_name": "Solaris Transit Map",
+      "description": "A subway map of Solaris City, reached from the training-area tram station.",
+      "type": "tram",
+      "sector": "international",
+      "_area": "Training Area",
+      "icon": 0,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": 2009,
+        "east": null
+      },
+      "_gridCol": 21,
+      "_gridRow": 69,
+      "_sourceBitmap": "Solaris - Bitmap\\International Zone\\11.bmp"
+    },
+    {
+      "roomId": 9010,
+      "_name": "Starport Mass Transit",
+      "description": "Direct mass-transit access from the Solaris Starport arrivals area.",
+      "type": "tram",
+      "sector": "international",
+      "_area": "Training Area",
+      "icon": 0,
+      "exits": {
+        "north": 146,
+        "south": null,
+        "west": null,
+        "east": null
+      },
+      "_gridCol": 15,
+      "_gridRow": 70,
+      "_sourceBitmap": "Solaris - Bitmap\\International Zone\\2.bmp"
+    },
+    {
+      "roomId": 2006,
+      "_name": "Davion Training Arena: Reception Area",
+      "description": "This is the outer room of a Mech dueling arena. Each district on Solaris has five arenas; find them by traveling to a district, then walking around its streets. In each district, arenas 1 and 2 are sanctioned scoring arenas. +++ Click on the metal doors icon to the east to enter the Ready Room.",
+      "type": "arena",
+      "sector": "international",
+      "_area": "Training Area",
+      "icon": 32,
+      "exits": {
+        "north": 2003,
+        "south": null,
+        "west": null,
+        "east": 2007
+      },
+      "_gridCol": 19,
+      "_gridRow": 70,
+      "_screen": 8,
+      "_sourceBitmap": "Solaris - Bitmap\\International Zone\\8.bmp",
+      "clientMapDescription": true
+    },
+    {
+      "roomId": 2007,
+      "_name": "Davion Training Arena: Ready Room",
+      "description": "This is a simulation of a working Ready Room. An actual Ready Room has additional buttons to choose your Mech and Side; a button to see the current Status of all participants; and a description of the arena's climate. You would click on the mech icon to the east when ready to drop into battle. If alone, you will face droid opponents; if other players are present, you will battle them when all are ready. +++ Click east to continue.",
+      "type": "ready_room",
+      "sector": "international",
+      "_area": "Training Area",
+      "icon": 44,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": 2006,
+        "east": 2008
+      },
+      "_gridCol": 20,
+      "_gridRow": 70,
+      "_screen": 9,
+      "_sourceBitmap": "Solaris - Bitmap\\International Zone\\9.bmp",
+      "clientMapDescription": true
+    },
+    {
+      "roomId": 2008,
+      "_name": "Dropping Into Battle",
+      "description": "When everyone has clicked on the drop icon to show they're ready, a DropShip will take you to the battlefield. Once all Mechs are in place, the battle begins. When in your Mech, press and hold F1 for a list of all keyboard commands. +++ You can't drop into a real combat here; you must take the tram to another district on Solaris. Return to the street outside the arena, then head east for instructions for the tram.",
+      "type": "drop_room",
+      "sector": "international",
+      "_area": "Training Area",
+      "icon": 11,
+      "exits": {
+        "north": null,
+        "south": null,
+        "west": 2007,
+        "east": null
+      },
+      "_gridCol": 21,
+      "_gridRow": 70,
+      "_screen": 10,
+      "_sourceBitmap": "Solaris - Bitmap\\International Zone\\10.bmp",
+      "clientMapDescription": true
     }
   ],
-  "_schema": {
-    "type": "bar | arena | hub | terminal | bank | street | sector | path | tram",
-    "description": "Optional lower scene-header text, mirrored from SOLARIS.MAP for stock rooms.",
-    "clientMapDescription": "Optional boolean. When true, the client should use the room's description in the map/scene header context for stock rooms."
+  "_meta": {
+    "gridSize": 80,
+    "mapImage": "assets/maps/solaris_background.png",
+    "notes": [
+      "Black Hills first pass generated from Solaris bitmap area and room screens; bar exits match numbered bitmap descriptions.",
+      "Black Hills refinement: added area tram stations, Davion ready/drop rooms, pedestrian interchange west of the Cryptic Skeptic, Sortek icon update, and varied road icons.",
+      "Kobe first pass generated from Solaris bitmap area and room screens; bar exits match numbered bitmap descriptions, with area tram stations and Ishiyama ready/drop rooms added.",
+      "Arena support rooms normalized: ready_room uses icon 44 and drop_room uses icon 11, matching the International training arena.",
+      "Cathay first pass generated from Solaris bitmap area and room screens; bar exits match numbered bitmap descriptions, with area tram stations and Jungle ready/drop rooms added.",
+      "Cathay spatial fix: inserted intermediate road cells so all Cathay exits are grid-adjacent.",
+      "Cathay refinement: added an east-west path from Alley off Maximilian Ave to the north side of Middletown.",
+      "Silesia first pass generated from Solaris bitmap area and room screens; bar exits match numbered bitmap descriptions, with area tram stations and Steiner ready/drop rooms added.",
+      "Montenegro first pass generated from Solaris bitmap area and room screens; bar exits match numbered bitmap descriptions, with area tram stations and Factory ready/drop rooms added."
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Adds a validated Solaris world-map reconstruction workflow. The branch updates the Solaris map data, expands the grid editor to handle the reconstructed sectors/areas and new room types, and blocks invalid map saves with red room highlights so topology mistakes are caught before JSON is downloaded.

## Related Issue

Closes #155

## Type of Change

- [ ] Bug fix
- [x] Feature / enhancement
- [x] Research finding / protocol update
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Chore (dependencies, CI, config)

## Implementation Notes

- Replaces `world-map.json` with the reconstructed Solaris map data using explicit exits and saved grid positions.
- Extends `tools/map-editor-grid.html` for larger maps, area editing, additional room types, road icon options, and save-time topology validation.
- The editor now refuses saves when rooms cannot reach a tram, gameplay areas lack a tram, arena ready/drop chains are invalid, sectors are internally disconnected, or sectors directly connect to each other.
- Invalid rooms are highlighted in red after a failed save attempt.
- Adds server-side `RoomType` support for `ready_room`, `drop_room`, and `headquarters`, plus compatible scene-anchor fallback behavior for those room types.

## Testing

- `npm run build`
- Parsed the embedded editor script with Node via `new Function(...)`.
- Ran the editor validation block against `world-map.json`: `0` validation issues.
- Not live-client tested in this pass.

## Checklist

- [x] Branch is based on `master`
- [ ] Commit messages follow `type: description` convention (current commit is `updates for world map`)
- [x] TypeScript builds cleanly (`npm run build`)
- [x] No debug `console.log` left in production code paths
- [x] `RESEARCH.md` updated if this reflects a new RE finding (N/A)
- [x] `symbols.json` updated if new canonical names were introduced (N/A)
- [x] This PR is ready for review (not a draft)
