### PR TITLE
docs: update v1.29 symbols catalog

### DIFF
--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -1327,6 +1327,15 @@ The table rows for known v1.29 world and combat command names now match the clie
 function catalog. Remaining unnamed rows and older narrative sections should still be
 reconciled in bounded feature slices rather than by mechanically overwriting old prose.
 
+The repo-visible symbol dictionary was synced from the same client research
+catalogs on 2026-05-05. `symbols.json` now carries a dedicated
+`MPBTWIN.EXE v1.29` section with all 1,290 saved `retail_function_catalog.gd`
+rows represented as 1,285 unique names, preserves the five duplicate-name
+address rows in `also_at`, imports command/helper summaries where available,
+and records subsystem membership from `retail_subsystem_catalog.gd` for 1,114
+functions. Treat that section as the machine-readable companion to the v1.29
+catalog notes here.
+
 Cmd10–13 follow-up from the subsystem catalog: the v1.29 cached named-entry cluster is
 not just a text/status side channel. `Cmd10` seeds or reseeds the shared cached-entry
 table, while `Cmd11` / `Cmd12` are incremental updates that resolve existing slots

--- a/symbols.json
+++ b/symbols.json
@@ -140,5 +140,11243 @@
       "g_welcomeStrMMC_v123":          { "binary": "DAT_0047d240", "role": "Literal ESC?MMC Copyright Kesmai Corp. 1991" },
       "g_welcomeStrMMW_v123":          { "binary": "DAT_0047d264", "role": "Literal ESC?MMW Copyright Kesmai Corp. 1991" }
     }
+  },
+  "MPBTWIN.EXE v1.29": {
+    "_comment": "Generated from C:/MPBT/mpbt-client/scripts/research retail_* catalogs and cross-checked against RESEARCH.md notes. Addresses are retail v1.29 image offsets in mpbtwin.exe.",
+    "source_rows": 1290,
+    "unique_names": 1285,
+    "duplicate_name_rows": 5,
+    "subsystem_tagged_functions": 1114,
+    "functions": {
+      "World_OpenTextSelectionModalWindow_v129": {
+        "binary": "FUN_00401000",
+        "role": "Tears down the current world root UI and opens the shared modal shell used by numbered text-selection pages.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-modal-pages"
+        ]
+      },
+      "World_OpenNumberedTextSelectionDialog_v129": {
+        "binary": "FUN_00401060",
+        "role": "Builds the numbered text-selection dialog from the shared choice-string table.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-modal-pages"
+        ]
+      },
+      "World_NumberedTextSelectionDialog_HandleInput_v129": {
+        "binary": "FUN_004011b0",
+        "role": "Handles numeric hotkeys for the older numbered text-selection dialog.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-modal-pages"
+        ]
+      },
+      "Shell_CreateQueuedInboundLineBuffer_v129": {
+        "binary": "FUN_00401200",
+        "role": "Allocates an owned retail shell-line buffer and copies one inbound text line into it.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_FreeQueuedInboundLineBuffer_v129": {
+        "binary": "FUN_00401260",
+        "role": "Frees an owned retail shell-line buffer descriptor and its copied text payload.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_StackCleanupReturnStub_v129": {
+        "binary": "FUN_00401a00",
+        "role": "Orphaned shell-region stack-cleanup epilogue stub that only pops `ebx`, drops `0x54` stack bytes, and returns.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "caseD_7f1": {
+        "binary": "FUN_00401a63",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "caseD_206": {
+        "binary": "FUN_00401e96",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 38,
+        "source": "retail_function_catalog.gd"
+      },
+      "Shell_SendCloseCommandsToVisibleThreadWindows_v129": {
+        "binary": "FUN_00401fa0",
+        "role": "Broadcasts the retail auxiliary-window close commands to each visible non-main window on the current UI thread.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_SendCloseCommandsToVisibleThreadWindow_v129": {
+        "binary": "FUN_00401fc0",
+        "role": "Sends the retail close command pair to one visible non-main auxiliary window on the shell UI thread.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_HandleSocketWindowCreationFailure_v129": {
+        "binary": "FUN_00402010",
+        "role": "Logs the fatal frontend socket-window creation failure and tears down the main shell window.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_RunFrontendMain_v129": {
+        "binary": "FUN_00402080",
+        "role": "Main retail frontend entry path that initializes the client windowing/network stack, runs the shell message loop, and shuts down on exit.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_CreateMainWindow_v129": {
+        "binary": "FUN_004028f0",
+        "role": "Registers the retail MPBattleTech window class and creates the hidden main shell window.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_BuildExecutableDirectoryPath_v129": {
+        "binary": "FUN_004029e0",
+        "role": "Builds the retail executable directory path from the current module filename.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_ServiceNetworkStateLoop_v129": {
+        "binary": "FUN_00402ab0",
+        "role": "Polls queued shell/network frames, dispatches them through the shell state handlers, and advances the active frontend state tick.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_FlushOutboundCommandBuffer_v129": {
+        "binary": "FUN_00402bb0",
+        "role": "Finalizes and sends the current outbound shell command buffer when it contains a complete command frame.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch",
+          "frame-protocol-codec"
+        ],
+        "also_at": [
+          {
+            "binary": "FUN_00402bf0",
+            "xrefs": 72
+          }
+        ]
+      },
+      "Shell_ValidateAndDispatchEscCommandBuffer_v129": {
+        "binary": "FUN_00402c00",
+        "role": "Finalizes the current ESC-delimited shell command buffer, verifies it, and dispatches the validated command stream.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch",
+          "frame-protocol-codec"
+        ]
+      },
+      "Shell_AppendEscDelimitedStreamChunk_v129": {
+        "binary": "FUN_00402c50",
+        "role": "Appends raw shell stream bytes into the active line buffer, flushing the current line whenever an escape delimiter arrives.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_ResetHeartbeatState_v129": {
+        "binary": "FUN_00402cc0",
+        "role": "Resets the retail shell heartbeat bookkeeping during frontend state transitions.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_ResetFrontendTransientState_v129": {
+        "binary": "FUN_00402ce0",
+        "role": "Resets transient shell/frontend protocol, marquee, and input state before entering a fresh frontend scene.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_GetCentisecondTickCount_v129": {
+        "binary": "FUN_00402d50",
+        "role": "Returns the retail monotonic tick count in centiseconds.",
+        "xrefs": 62,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-tactical-overlays"
+        ]
+      },
+      "Shell_EnterDropScene_v129": {
+        "binary": "FUN_00402d60",
+        "role": "Clears the active shell/world UI and enters the retail DROP scene card flow from SCENES.DAT.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-visual-bootstrap",
+          "shell-picture-bootstrap",
+          "shell-state-dispatch"
+        ]
+      },
+      "Combat_FreeVisualResourcesAndLocationMap_v129": {
+        "binary": "FUN_00402e10",
+        "role": "Releases the currently loaded combat visual resource tables and cached world location map before combat visuals are rebuilt.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-visual-bootstrap"
+        ]
+      },
+      "Shell_RunWorldStateTick_v129": {
+        "binary": "FUN_00402e20",
+        "role": "Runs the retail shell state-3 world/frontend tick after banner handling finishes.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_RunCombatStateTick_v129": {
+        "binary": "FUN_00402e60",
+        "role": "Runs the retail shell state-4 combat tick by polling input and stepping the combat main loop.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound",
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_HandlePostVersionBannerLine_v129": {
+        "binary": "FUN_00402e80",
+        "role": "Handles inbound shell/banner lines after the frontend has already entered the active post-version state machine.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_HandlePreVersionBannerLine_v129": {
+        "binary": "FUN_00402fa0",
+        "role": "Handles inbound shell/banner lines during the retail pre-version negotiation phase.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "World_Cmd35_RequestClientExit_v129": {
+        "binary": "FUN_004031a0",
+        "role": "Requests immediate client shutdown from the world command stream.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "Shell_ClearNumLockToggleState_v129": {
+        "binary": "FUN_004031d0",
+        "role": "Consumes the retail Num Lock toggle edge so world/combat keyboard handling does not inherit a stale toggle bit.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_ReportBterrorEvent_v129": {
+        "binary": "FUN_00403210",
+        "role": "Writes one formatted event to `bterror.log`, optionally surfaces it immediately, and can latch the shared retail error flags.",
+        "xrefs": 141,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_ClassifyBannerLine_v129": {
+        "binary": "FUN_004032f0",
+        "role": "Classifies an incoming retail shell line as one of the known introductory copyright/banner lines.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_InitializeFrontendResourcesAndAudio_v129": {
+        "binary": "FUN_00403350",
+        "role": "Performs the one-shot retail frontend bootstrap for palettes, fonts, picture archives, and audio startup.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-instance-lifecycle",
+          "shell-picture-bootstrap",
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_ShutdownFrontendResourcesAndAudio_v129": {
+        "binary": "FUN_00403470",
+        "role": "Tears down the retail frontend shell resources, fonts, idle timer, and audio layer on exit.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_OpenTimedArchiveSlideshow_v129": {
+        "binary": "FUN_004034c0",
+        "role": "Begins a timed fullscreen archive slideshow session from a tagged archive name and a delay/tag script string.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-picture-bootstrap"
+        ]
+      },
+      "Shell_CloseTimedArchiveSlideshow_v129": {
+        "binary": "FUN_004035a0",
+        "role": "Stops the active timed archive slideshow, restores the frontend display, and clears the slideshow session globals.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-picture-bootstrap"
+        ]
+      },
+      "Shell_TickTimedArchiveSlideshow_v129": {
+        "binary": "FUN_00403620",
+        "role": "Advances one timed archive slideshow step, loads the next bitmap tag, presents it, and rearms the slideshow timer.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-picture-bootstrap"
+        ]
+      },
+      "Shell_InitializeFrontendAudio_v129": {
+        "binary": "FUN_004038b0",
+        "role": "Initializes the retail frontend sound driver, volumes, and LASR sound support flags from the saved shell audio configuration bits.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_ShutdownFrontendAudio_v129": {
+        "binary": "FUN_00403a30",
+        "role": "Shuts down the retail frontend sound driver and clears the associated sound-state flags.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_OpenNoGameCpuCheckDialog_v129": {
+        "binary": "FUN_00403a50",
+        "role": "Opens the frontend NoGameCPUCheck override dialog when the current CPU fails the retail game-speed threshold.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_NoGameCpuCheckDialogProc_v129": {
+        "binary": "FUN_00403ac0",
+        "role": "Dialog procedure for the retail NoGameCPUCheck override prompt.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Mech_SeedRecordCipherFromFilenameSuffix_v129": {
+        "binary": "FUN_00403cd0",
+        "role": "Seeds the retail mech-record XOR stream from the last four characters of the mechdata filename stem.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "mech-runtime-init"
+        ]
+      },
+      "Mech_XorRecordBufferWithCipherStream_v129": {
+        "binary": "FUN_00403d50",
+        "role": "XOR-decodes a mechdata record buffer byte-by-byte using the rolling filename-seeded retail cipher stream.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "mech-runtime-init"
+        ]
+      },
+      "Mech_NextRecordCipherWord_v129": {
+        "binary": "FUN_00403d80",
+        "role": "Advances the retail mech-record XOR generator and returns the next stream word derived from the filename-suffix seed.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "mech-runtime-init"
+        ]
+      },
+      "Combat_ResetPresentationStateSeedGuard_v129": {
+        "binary": "FUN_00403db0",
+        "role": "Clears the one-shot guard that allows the retail presentation-state XOR seed to be refreshed.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-visual-bootstrap"
+        ]
+      },
+      "Combat_CapturePresentationStateSeedTick_v129": {
+        "binary": "FUN_00403dc0",
+        "role": "Captures the current tick count as the retail presentation-state XOR seed when the guard is open.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-visual-bootstrap"
+        ]
+      },
+      "Combat_AllocateActorPresentationStateTable_v129": {
+        "binary": "FUN_00403de0",
+        "role": "Allocates the retail eight-slot actor presentation state table and refreshes its companion heap-noise buffer.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-visual-bootstrap"
+        ]
+      },
+      "Combat_FreeActorPresentationStateTable_v129": {
+        "binary": "FUN_00403e30",
+        "role": "Frees the active retail actor presentation state table and clears its allocation flag.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-visual-bootstrap"
+        ]
+      },
+      "Combat_DecodePresentationStateGlobals_v129": {
+        "binary": "FUN_00403e60",
+        "role": "XOR-decodes the shared retail combat presentation globals with the previously captured presentation seed.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-visual-bootstrap"
+        ]
+      },
+      "Combat_InitializeActorPresentationStateTable_v129": {
+        "binary": "FUN_00403fb0",
+        "role": "Zeroes and seeds the retail actor presentation state table, then reapplies XOR encoding to the shared presentation globals.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-visual-bootstrap"
+        ]
+      },
+      "Combat_SendSpeechOutText_v129": {
+        "binary": "FUN_00404370",
+        "role": "Sends one combat speech-out text payload through the retail outbound shell buffer.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_DecodeTerrainProjectionOutlinePoints_v129": {
+        "binary": "FUN_00404390",
+        "role": "Decodes the capped local-actor terrain projection outline point list used by the retail tactical projection overlay.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_Cmd72_InitLocalActor_v129": {
+        "binary": "FUN_00404420",
+        "role": "Initializes the local combat scene / self actor.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-instance-lifecycle",
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_DecodeLocalActorMechState_v129": {
+        "binary": "FUN_004049f0",
+        "role": "Decodes the cmd72 local-actor mech state block, including the backing mech record, component state tables, and trailing label string.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "mech-runtime-init"
+        ]
+      },
+      "Combat_Cmd63_ResultSceneInit_v129": {
+        "binary": "FUN_00404bc0",
+        "role": "Initializes the combat result scene / post-match surface.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-asset-loading",
+          "combat-terrain-scenery",
+          "combat-environment-backdrop",
+          "shell-picture-bootstrap",
+          "shell-state-dispatch"
+        ]
+      },
+      "Combat_Cmd74_DisplayStatusMessage_v129": {
+        "binary": "FUN_00404d40",
+        "role": "Displays combat status / HUD message text.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd"
+      },
+      "Combat_IsEjectConfirmPending_v129": {
+        "binary": "FUN_00404dc0",
+        "role": "Returns whether the retail local eject flow is waiting for its confirming hotkey press.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_ClearPendingEjectConfirm_v129": {
+        "binary": "FUN_00404dd0",
+        "role": "Cancels a pending local eject confirmation and redraws the retail eject-status HUD strip.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_AdvanceEjectConfirmState_v129": {
+        "binary": "FUN_00404df0",
+        "role": "Advances the retail two-step local eject confirmation state and starts the warning/audio phase on the second press.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_HandlePresentationHotkey_v129": {
+        "binary": "FUN_00404e70",
+        "role": "Handles combat-scene presentation hotkeys, including detail toggles, voice-panel mode changes, and other in-scene UI shortcuts.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-bank-fire",
+          "combat-presentation-hud",
+          "combat-presentation-controls"
+        ]
+      },
+      "Combat_ResetPresentationStateAndLoadVisualOptions_v129": {
+        "binary": "FUN_004051d0",
+        "role": "Resets the retail combat presentation state and loads the saved visual-detail / overlay option bits into the active runtime flags.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-visual-bootstrap"
+        ]
+      },
+      "Combat_SetActiveTerrainPaletteTable_v129": {
+        "binary": "FUN_004053a0",
+        "role": "Installs the active terrain palette table for the combat scene, copying it into the runtime palette buffer and marking every entry dirty.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-visual-bootstrap"
+        ]
+      },
+      "Combat_InitializeBattlefieldVisualState_v129": {
+        "binary": "FUN_004053e0",
+        "role": "Initializes the battlefield-facing visual runtime after combat resources are loaded, including terrain palette state, scenery, backdrop layers, and projectile effect slots.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-heat-hud",
+          "combat-visual-bootstrap"
+        ]
+      },
+      "Combat_ApplyActiveTerrainPaletteForDuration_v129": {
+        "binary": "FUN_00405540",
+        "role": "Applies the active combat terrain palette working copy immediately and arms a short restore deadline.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_DrawOverlayTextLine_v129": {
+        "binary": "FUN_00405570",
+        "role": "Draws one clipped text line onto the main combat overlay surface.",
+        "xrefs": 52,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission",
+          "combat-tactical-overlays"
+        ]
+      },
+      "Combat_RenderActorWorldMarkers_v129": {
+        "binary": "FUN_00405600",
+        "role": "Draws the retail world-screen actor marker overlays for the local actor and every active remote mech.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-tactical-overlays"
+        ]
+      },
+      "Combat_RenderTacticalRadarPanel_v129": {
+        "binary": "FUN_00405a30",
+        "role": "Draws the fixed-size retail tactical radar panel, including terrain projection, contact blips, range readout, and facing cues.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-presentation-hud",
+          "combat-tactical-overlays"
+        ]
+      },
+      "Combat_BuildTacticalRadarContactMarker_v129": {
+        "binary": "FUN_00406170",
+        "role": "Builds the small normalized contact-marker polygon used by the retail tactical radar panel.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-tactical-overlays"
+        ]
+      },
+      "Combat_DrawHeadingTapeHud_v129": {
+        "binary": "FUN_004061f0",
+        "role": "Draws the stacked retail heading-tape HUD for the local chassis and upper-body headings.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-tactical-overlays"
+        ]
+      },
+      "Combat_MainLoop_v129": {
+        "binary": "FUN_00406530",
+        "role": "Top-level retail combat loop / scene tick anchor.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control",
+          "combat-voice-transmission",
+          "combat-visual-bootstrap",
+          "combat-tactical-overlays",
+          "combat-transform-math",
+          "combat-terrain-contact",
+          "combat-actor-preview"
+        ]
+      },
+      "Combat_SendEjectCommandAfterCue_v129": {
+        "binary": "FUN_00406fb0",
+        "role": "Flushes the retail local eject opcode once the armed warning cue finishes playing.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_DrawFrameRateOverlay_v129": {
+        "binary": "FUN_00406ff0",
+        "role": "Updates the rolling retail framerate sample and draws the FPS overlay string on the combat frame.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-tactical-overlays"
+        ]
+      },
+      "Combat_DrawCombatHelpOverlay_v129": {
+        "binary": "FUN_00407080",
+        "role": "Draws the retail combat help overlay bitmap onto the main combat frame when the help latch is active.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-tactical-overlays"
+        ]
+      },
+      "Combat_HasAnyWeaponSlotEnabledByBankFilter_v129": {
+        "binary": "FUN_004070a0",
+        "role": "Returns whether the current retail weapon-bank filter leaves any local weapon slot enabled.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-bank-fire"
+        ]
+      },
+      "Combat_IsWeaponSlotEnabledByBankFilter_v129": {
+        "binary": "FUN_00407100",
+        "role": "Returns whether one local weapon slot is enabled by the active retail weapon-bank filter state.",
+        "xrefs": 7,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-slot-hud"
+        ]
+      },
+      "Combat_DoesWeaponSlotBankFilterStateChange_v129": {
+        "binary": "FUN_00407200",
+        "role": "Returns whether one local weapon slot would change enabled/highlight state under the pending retail bank filter.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-bank-fire"
+        ]
+      },
+      "Combat_SetWeaponBankFilterState_v129": {
+        "binary": "FUN_00407290",
+        "role": "Applies one retail weapon-bank filter selection and updates the slot highlight rectangles whose filter eligibility changed.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-bank-fire"
+        ]
+      },
+      "Combat_ToggleStickyViewMode_v129": {
+        "binary": "FUN_00407400",
+        "role": "Toggles the retail sticky-view mode latch used by the local aim and weapon-filter controls.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_ProcessWeaponBankFilterInput_v129": {
+        "binary": "FUN_00407420",
+        "role": "Processes the local directional weapon-bank filter inputs and updates the derived retail filter selection state.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_UpdateUpperBodyAimCueAudio_v129": {
+        "binary": "FUN_00407600",
+        "role": "Updates the local upper-body aim cue audio from the torso-yaw, pitch, and recenter activity timers.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_ProcessMouseUpperBodyAimInput_v129": {
+        "binary": "FUN_004076c0",
+        "role": "Reads mouse displacement and feeds the local torso-yaw and upper-body pitch accumulators.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_SelectNextTrackedActor_v129": {
+        "binary": "FUN_00407780",
+        "role": "Cycles the tracked-actor selection to the next eligible retail contact for the current presentation mode.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-tactical-overlays"
+        ]
+      },
+      "Combat_UpdateCombatStartCountdownHud_v129": {
+        "binary": "FUN_00407870",
+        "role": "Updates the retail combat-start countdown HUD readout and releases the local actor when the countdown expires.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_DrawTrackedActorScreenBracket_v129": {
+        "binary": "FUN_00407920",
+        "role": "Draws the retail screen-space bracket around the currently tracked actor and, when enabled, its adjacent info label.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-tactical-overlays"
+        ]
+      },
+      "Combat_DrawTrackedActorInfoLabel_v129": {
+        "binary": "FUN_00407c20",
+        "role": "Draws the tracked actor's three-line retail info label beside a world marker or screen bracket.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-tactical-overlays"
+        ]
+      },
+      "Combat_DrawWeaponAimCursor_v129": {
+        "binary": "FUN_00407cc0",
+        "role": "Updates the live combat aim-cursor screen position and draws the retail cursor bitmap when the current weapon filter leaves a local slot enabled.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-tactical-overlays"
+        ]
+      },
+      "Combat_FreeVoiceAndEffectPresentationResources_v129": {
+        "binary": "FUN_00407d60",
+        "role": "Frees the retail voice HUD surface and active-effect presentation pools during combat/result teardown.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_TickRemoteActorPresentationState_v129": {
+        "binary": "FUN_00407d80",
+        "role": "Advances one remote actor's presentation state and rebuilds the render matrices used by the combat overlay passes.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-tactical-overlays"
+        ]
+      },
+      "Combat_ComputeVelocityMagnitude3_v129": {
+        "binary": "FUN_00407fc0",
+        "role": "Returns the magnitude of a 3-axis retail velocity vector.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-contact"
+        ]
+      },
+      "Combat_ProcessLocalMechContact_v129": {
+        "binary": "FUN_00407ff0",
+        "role": "Processes local mech contact / ground interaction.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control",
+          "combat-terrain-contact"
+        ]
+      },
+      "Combat_ResolveLandingOrGroundContact_v129": {
+        "binary": "FUN_00408220",
+        "role": "Resolves landing or general ground-contact state.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control",
+          "combat-terrain-contact"
+        ]
+      },
+      "Combat_IntegrateActorMotion_v129": {
+        "binary": "FUN_00408700",
+        "role": "Integrates motion state into actor position / velocity fields.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_UpdateActorPreviewSectionStatusColors_v129": {
+        "binary": "FUN_00408810",
+        "role": "Updates the combat actor preview model's per-section status colors from the current armor and internal structure values.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-actor-preview"
+        ]
+      },
+      "Combat_SendLocalWeaponEffectUpdate_v129": {
+        "binary": "FUN_004089b0",
+        "role": "Packages one local weapon-fire/effect update from the computed fire solution and forwards it to the retail outbound combat stream.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_DrawOffscreenActorEdgeMarkers_v129": {
+        "binary": "FUN_00408a00",
+        "role": "Draws the retail off-screen actor edge markers around the combat frame for active remote contacts.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-tactical-overlays"
+        ]
+      },
+      "Combat_DrawOffscreenActorEdgeMarker_v129": {
+        "binary": "FUN_00408b70",
+        "role": "Draws one small directional off-screen actor marker glyph on the combat frame edge.",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-tactical-overlays"
+        ]
+      },
+      "Combat_DrawTacticalRadarRangeRings_v129": {
+        "binary": "FUN_00408e20",
+        "role": "Draws the concentric tactical-radar range rings for the current retail radar range step.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-tactical-overlays"
+        ]
+      },
+      "Combat_FillRectWithRandomInterferenceRuns_v129": {
+        "binary": "FUN_00408f50",
+        "role": "Paints randomized opaque span runs into a combat panel rect to create the retail interference/static effect.",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-actor-preview"
+        ]
+      },
+      "Combat_ShowTimedStatusMessage_v129": {
+        "binary": "FUN_00409060",
+        "role": "Latches one timed combat status message into the shared HUD buffer and mirrors it into the capture log when logging is active.",
+        "xrefs": 18,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control",
+          "combat-voice-transmission",
+          "combat-presentation-controls"
+        ]
+      },
+      "Combat_MapActorColorCodeToPaletteIndex_v129": {
+        "binary": "FUN_004090d0",
+        "role": "Maps a retail actor color code to the fixed palette index used by combat markers, radar blips, and status text.",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-tactical-overlays"
+        ]
+      },
+      "Combat_SendCmd19Action_v129": {
+        "binary": "FUN_00409120",
+        "role": "Queues outbound combat cmd19 and flushes it immediately.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-visual-bootstrap"
+        ]
+      },
+      "Combat_ResetLocalMotionAndRefreshAnimation_v129": {
+        "binary": "FUN_00409140",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "Combat_GetActorPanelInterferenceLevel_v129": {
+        "binary": "FUN_004091a0",
+        "role": "Returns the current actor-panel interference level from the encoded local-actor combat state.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-actor-preview"
+        ]
+      },
+      "Combat_ArmDeferredCollapseWhileAirborne_v129": {
+        "binary": "FUN_004091c0",
+        "role": "Arms deferred collapse while the actor is still airborne.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-fall"
+        ]
+      },
+      "Combat_InitializeVisualResourcesAndHudState_v129": {
+        "binary": "FUN_00409290",
+        "role": "Initializes the retail combat visual resources, fonts, and baseline HUD state before the main loop enters steady-state rendering.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-visual-bootstrap",
+          "combat-terrain-scenery"
+        ]
+      },
+      "System_ClickAolPaletteOkButton_v129": {
+        "binary": "FUN_00409380",
+        "role": "Child-window callback that finds the AOL palette dialog's `OK` button and simulates the double-click needed to dismiss it.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_StartAolPaletteWatcherTimer_v129": {
+        "binary": "FUN_00409450",
+        "role": "Starts the retail AOL palette watcher timer when an AOL Frame25 host window is present.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_StopAolPaletteWatcherTimer_v129": {
+        "binary": "FUN_00409510",
+        "role": "Cancels the retail AOL palette watcher timer on the active shell host window.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_TickAolPaletteWatcher_v129": {
+        "binary": "FUN_00409530",
+        "role": "Ticks the retail AOL palette watcher, polling the palette window and dispatching the OK-button callback when needed.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Combat_InitializeIdentityByteLookupTable_v129": {
+        "binary": "FUN_004095a0",
+        "role": "Resets the shared combat byte lookup table to the identity mapping `0..255`.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_InterpolateClippedPolygonVertexAttributes_v129": {
+        "binary": "FUN_004095c0",
+        "role": "Interpolates the payload fields for one newly clipped polygon vertex after the clip-plane intersection coordinates are solved.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-environment-backdrop"
+        ]
+      },
+      "Combat_ComputeClipPlaneIntersectionCoords_v129": {
+        "binary": "FUN_00409720",
+        "role": "Solves the two varying coordinates where a polygon edge intersects one homogeneous combat view-volume clip plane.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-environment-backdrop"
+        ]
+      },
+      "Combat_ClipPolygonToViewVolume_v129": {
+        "binary": "FUN_00409790",
+        "role": "Clips a homogeneous polygon vertex list against the retail combat view volume and emits the surviving scratch vertex list.",
+        "xrefs": 8,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-environment-backdrop"
+        ]
+      },
+      "Combat_ProjectWorldPointToScreenVertex_v129": {
+        "binary": "FUN_00409be0",
+        "role": "Projects one transformed combat world point into the shared six-word screen-vertex record used by overlays and effect renderers.",
+        "xrefs": 9,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-tactical-overlays",
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_ProjectClippedPolygonToTexturedRenderVertices_v129": {
+        "binary": "FUN_00409c50",
+        "role": "Projects a clipped polygon into the linked textured-render vertex buffer used by the retail textured polygon rasterizer.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-environment-backdrop",
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_ProjectClippedPolygonToScreen_v129": {
+        "binary": "FUN_00409e40",
+        "role": "Projects one already clipped polygon vertex list into integer screen coordinates and tracks its screen-space bounds.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-environment-backdrop"
+        ]
+      },
+      "Combat_ClipLineSegmentToViewVolume_v129": {
+        "binary": "FUN_00409f40",
+        "role": "Clips a two-point line segment against the retail combat view volume and writes the surviving endpoints back in place.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_ExpandIndexedPolygonVertexList_v129": {
+        "binary": "FUN_0040a000",
+        "role": "Expands a retail indexed polygon face record into the six-word-per-vertex scratch list consumed by the clip/project helpers.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-environment-backdrop"
+        ]
+      },
+      "Combat_ComputeVisibleAttachmentViewVariantIndex_v129": {
+        "binary": "FUN_0040a050",
+        "role": "Computes the visible attachment view-variant index from the current transformed attachment basis.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_RenderLitClippedPolygon_v129": {
+        "binary": "FUN_0040a1f0",
+        "role": "Clips, lights, projects, and rasterizes one uniformly shaded polygon through the retail flat-polygon path.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_RenderTexturedPolygonGroup_v129": {
+        "binary": "FUN_0040a270",
+        "role": "Expands, clips, projects, and rasterizes one textured polygon group from a retail mesh record.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_RenderFlatShadedPolygonGroup_v129": {
+        "binary": "FUN_0040a310",
+        "role": "Expands, clips, projects, and rasterizes one flat-shaded polygon group from a retail mesh record.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_RenderAttachmentMeshListAndTrackCursorHit_v129": {
+        "binary": "FUN_0040a3d0",
+        "role": "Renders one attachment's active mesh list and updates the retail cursor-hit globals when the attachment is selected.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_RenderTerrainSceneryObjectRecord_v129": {
+        "binary": "FUN_0040a850",
+        "role": "Transforms and renders one cached terrain-scenery object record through the retail polygon-group render path.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-tactical-overlays"
+        ]
+      },
+      "Combat_ComputeClampedLightDotShadeOffset_v129": {
+        "binary": "FUN_0040a8d0",
+        "role": "Computes a clamped lighting shade offset from the dot product of two fixed-point render vectors.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_SetEnvironmentLightDirectionAngles_v129": {
+        "binary": "FUN_0040a9a0",
+        "role": "Stores the shared combat light-direction angles and rebuilds the derived lighting vector used by the retail shading helpers.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-environment-backdrop"
+        ]
+      },
+      "Combat_RefreshJoystickCapabilitiesAndAxisConfig_v129": {
+        "binary": "FUN_0040ab00",
+        "role": "Probes the retail joystick device, refreshes cached capability/calibration state, and clears unsupported axis-mode assignments.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_PollJoystickButtonsAndHatBindings_v129": {
+        "binary": "FUN_0040b460",
+        "role": "Polls the configured combat joystick buttons and POV hat, dispatching newly pressed bindings into either presentation hotkeys or the bound action handler.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_ProcessMouseUpperBodyAimZones_v129": {
+        "binary": "FUN_0040b5f0",
+        "role": "Maps configured mouse control zones into torso-yaw and upper-body pitch deltas when direct aim input is idle.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_ProcessMouseChassisTurnInput_v129": {
+        "binary": "FUN_0040b790",
+        "role": "Reads the configured mouse turn zone and applies the result into the chassis-facing accumulator when keyboard turn input is idle.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_ComputeMouseTurnAxisPercent_v129": {
+        "binary": "FUN_0040b820",
+        "role": "Converts the configured mouse turn zone into a signed -100..100 turn-axis percentage.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_ProcessMouseThrottleZoneInput_v129": {
+        "binary": "FUN_0040b8b0",
+        "role": "Processes the retail mouse throttle zone and updates the local throttle target while the actor is grounded and not jump-active.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_ToggleInvertedMouseThrottle_v129": {
+        "binary": "FUN_0040ba20",
+        "role": "Toggles the retail inverted-mouse-throttle latch used by the mouse throttle zone.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_PollJoystickAxisState_v129": {
+        "binary": "FUN_0040ba90",
+        "role": "Refreshes the cached retail joystick axis state when the current device and capability flags permit it.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_GetMouseControlZoneConfig_v129": {
+        "binary": "FUN_0040bb10",
+        "role": "Returns the retail mouse-control zone descriptor for turn, aim, and related control surfaces.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_HasConfiguredJoystickAxisModes_v129": {
+        "binary": "FUN_0040bd50",
+        "role": "Returns whether any of the retail joystick axis-control channels currently has an active mode assignment.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_PlayWeaponTypeFireCue_v129": {
+        "binary": "FUN_0040bdb0",
+        "role": "Plays the retail fire audio cue associated with a weapon type.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-slot-hud"
+        ]
+      },
+      "Combat_UpdateLocalThrottleFeedbackAudio_v129": {
+        "binary": "FUN_0040bed0",
+        "role": "Updates the local throttle feedback audio, including transient cue playback and the continuous engine/throttle loop pitch.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_PlayImpactCue_v129": {
+        "binary": "FUN_0040bfe0",
+        "role": "Selects and plays the retail impact cue based on damage/effect severity and distance.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control",
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_PlayCollapseImpactCue_v129": {
+        "binary": "FUN_0040c100",
+        "role": "Plays the collapse/landing impact cue used when a mech falls into the recoverable down state.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Shell_ControlFrontendSlideshowAudioCue_v129": {
+        "binary": "FUN_0040c160",
+        "role": "Starts, stops, or fades the shared frontend slideshow audio cue used by the title/credits sequence and slideshow mode 2.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-picture-bootstrap"
+        ]
+      },
+      "World_RestoreStackedShellFocusTarget_v129": {
+        "binary": "FUN_0040c200",
+        "role": "Restores stacked-shell focus to the correct owner or fallback window before pointer-driven selection handling runs.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_ReactivateStackedShellOwnerWindow_v129": {
+        "binary": "FUN_0040c240",
+        "role": "Reactivates the stacked world-shell owner window when the stacked-shell focus flag is armed.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_ToggleStackedShellSelectionHighlight_v129": {
+        "binary": "FUN_0040c260",
+        "role": "Toggles the palette-swapped highlight rectangle for one stacked-shell selection row.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_ToggleStackedShellSelectionRowHighlight_v129": {
+        "binary": "FUN_0040c2b0",
+        "role": "Swaps the palette-highlight state for one indexed row in the active stacked world-shell dialog.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_HandleStackedShellSelectionPointer_v129": {
+        "binary": "FUN_0040c330",
+        "role": "Pointer handler for stacked world-shell selection dialogs backed by text-decoration rows.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_OpenStackedStatsDialog_v129": {
+        "binary": "FUN_0040c440",
+        "role": "Builds the shared stacked world-shell stats dialog family for the older early-world summary/detail pages.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_OpenStackedDetailedStatsDialog_v129": {
+        "binary": "FUN_0040d5d0",
+        "role": "Builds the six-row stacked world-shell detailed stats dialog used by one of the older summary-page modes.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_HandleStackedStatsDialogInput_v129": {
+        "binary": "FUN_0040dff0",
+        "role": "Keyboard input handler for the interactive stacked world-shell stats dialogs.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_HandleStackedShellActionHotkey_v129": {
+        "binary": "FUN_0040e860",
+        "role": "Maps confirm/cancel hotkeys on stacked world-shell action dialogs into the retail Cmd1D control-frame actions.",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_HandleStackedStatsDialogConfirmInput_v129": {
+        "binary": "FUN_0040e8b0",
+        "role": "Handles the simple confirm/cancel keyboard path for the non-editable stacked stats dialog variants.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_HandleStackedStatsDialogResponse_v129": {
+        "binary": "FUN_0040e910",
+        "role": "Consumes the response frame for the older stacked stats dialog family and opens the resulting notice or modal text window.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_OpenStackedDualSelectionDialog_v129": {
+        "binary": "FUN_0040eb70",
+        "role": "Builds a compact stacked world-shell dialog with two selectable named/value rows.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_HasNoActiveStackedShellWindow_v129": {
+        "binary": "FUN_0040f4b0",
+        "role": "Returns whether the shared stacked world-shell active flag is currently clear.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "World_ClearStackedShellActiveFlag_v129": {
+        "binary": "FUN_0040f4d0",
+        "role": "Clears the shared stacked world-shell active flag without touching the current window stack directly.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Combat_IsActorRecoverableSupportIntact_v129": {
+        "binary": "FUN_0040f4e0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 15,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_FindNextFireableWeaponSlot_v129": {
+        "binary": "FUN_0040f530",
+        "role": "Finds the next local weapon slot that is presently eligible to fire.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-slot-hud"
+        ]
+      },
+      "Combat_IsWeaponSlotFireable_v129": {
+        "binary": "FUN_0040f650",
+        "role": "Returns whether one local weapon slot is presently eligible to fire.",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-slot-hud"
+        ]
+      },
+      "Combat_IsTargetWithinWeaponMaxRange_v129": {
+        "binary": "FUN_0040f700",
+        "role": "Returns whether the current target lies within the retail maximum range for a weapon type.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-slot-hud"
+        ]
+      },
+      "Combat_ApplyWeaponRowDamageCode_v129": {
+        "binary": "FUN_0040f740",
+        "role": "Applies a higher retail damage code to one weapon-detail row and refreshes the matching local weapon-slot HUD state.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-slot-hud"
+        ]
+      },
+      "Combat_ApplyDetailRowDamageCode_v129": {
+        "binary": "FUN_0040f7d0",
+        "role": "Applies a higher retail damage code to one non-weapon mech-detail row and triggers the coupled local HUD/state fallout.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "Combat_DepleteAmmoPoolDetailEntry_v129": {
+        "binary": "FUN_0040fb50",
+        "role": "Zeros one retail ammo-pool detail entry and refreshes all local weapon slots that share that ammo pool's weapon type.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-slot-hud"
+        ]
+      },
+      "Combat_RemapWeaponSlotsToAmmoPoolIndex_v129": {
+        "binary": "FUN_0040fc70",
+        "role": "Reassigns all local weapon slots of one weapon type to the matching shared-ammo pool index.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-slot-hud"
+        ]
+      },
+      "Combat_WeaponTypeUsesAmmoPool_v129": {
+        "binary": "FUN_0040fd90",
+        "role": "Returns whether the supplied retail weapon type consumes shared ammo-pool entries.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-slot-hud"
+        ]
+      },
+      "Combat_ActivateWeaponSlotForFire_v129": {
+        "binary": "FUN_0040fdb0",
+        "role": "Commits one local weapon slot into its retail fire/cooldown state and refreshes the dependent HUD cells.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-slot-hud"
+        ]
+      },
+      "Combat_UpdateLocalHeatAccumulator_v129": {
+        "binary": "FUN_00410090",
+        "role": "Ticks the local heat accumulator from movement, throttle, and jump activity.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control",
+          "combat-heat-hud"
+        ]
+      },
+      "System_RoundFloatToNearestInt_v129": {
+        "binary": "FUN_00410310",
+        "role": "Rounds a float to the nearest integer using the retail `__ftol` helper plus a fractional-threshold check.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-jump-fuel-hud"
+        ]
+      },
+      "Combat_UpdateJumpFuelReserve_v129": {
+        "binary": "FUN_00410340",
+        "role": "Recharges or drains the local jump-fuel reserve and updates the jump-ready HUD indicator.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control",
+          "combat-jump-fuel-hud"
+        ]
+      },
+      "Combat_ComputeActorForwardSpeedComponent_v129": {
+        "binary": "FUN_00410650",
+        "role": "Computes the signed forward-speed component by projecting actor velocity onto the current facing heading.",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_ApplyLocalMovementForces_v129": {
+        "binary": "FUN_004106e0",
+        "role": "Builds the local movement-force vector from throttle, jump state, and transient impulses, then integrates it into actor velocity.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_UpdateWeaponRangeIndicators_v129": {
+        "binary": "FUN_00410a40",
+        "role": "Updates the per-weapon range-bracket HUD indicators against the current target distance.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_ClearExpiredWeaponSlotIndicators_v129": {
+        "binary": "FUN_00410b70",
+        "role": "Clears timed-out per-weapon HUD indicators after their transient slot timers expire.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control",
+          "combat-weapon-slot-hud"
+        ]
+      },
+      "Combat_DampenLocalMotionState_v129": {
+        "binary": "FUN_00410cd0",
+        "role": "Applies per-tick damping to local velocity, turn state, and airborne drift after the control forces are integrated.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_TickLocalActorControlLoop_v129": {
+        "binary": "FUN_00410f60",
+        "role": "Ticks the local actor control loop around movement/jump handling.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_UpdateHeatShutdownState_v129": {
+        "binary": "FUN_004110b0",
+        "role": "Maps local heat thresholds into shutdown posture/state changes and refreshes the movement HUD/animation side effects.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control",
+          "combat-heat-hud"
+        ]
+      },
+      "Combat_RecomputeWalkRunSpeedCaps_v129": {
+        "binary": "FUN_00411170",
+        "role": "Recomputes the actor's current walk and run speed caps from the damaged movement rating and any caller-supplied penalty.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Mech_MapDetailRowToInternalStructureSection_v129": {
+        "binary": "FUN_00411280",
+        "role": "Maps the 11 mech-detail armor/status rows onto the eight retail internal-structure section indices.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "mech-runtime-init",
+          "world-mech-management-pages"
+        ]
+      },
+      "Combat_WeaponTypeUsesCachedEffectModel_v129": {
+        "binary": "FUN_00411310",
+        "role": "Returns whether a retail weapon type should use the cached 3D effect-model path instead of the sprite/beam fallback.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_ComputeActorDistance_v129": {
+        "binary": "FUN_00411340",
+        "role": "Computes the retail 3D distance between two combat actors from their world coordinates.",
+        "xrefs": 7,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Shell_OpenOptionsPropertySheet_v129": {
+        "binary": "FUN_004113c0",
+        "role": "Opens the shared retail options property sheet used by the frontend and world-shell option buttons.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_TickOptionsPropertySheetAudio_v129": {
+        "binary": "FUN_00411570",
+        "role": "Timer callback that keeps the retail audio service layer advancing while the shared options property sheet is open.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_InitializePropertySheetPage_v129": {
+        "binary": "FUN_00411580",
+        "role": "Fills one retail property-sheet page descriptor before the shared options sheet is shown.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_OptionsPropertySheetInitCallback_v129": {
+        "binary": "FUN_004115c0",
+        "role": "Initialization callback for the retail options property sheet window.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_AudioOptionsPageProc_v129": {
+        "binary": "FUN_004122d0",
+        "role": "Dialog proc for the retail options tab that owns audio sliders, speech/LASR preview controls, mixer launch, and live capability-status text.",
+        "xrefs": 7,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Combat_FindJoystickCapabilityIndexByComboSelection_v129": {
+        "binary": "FUN_00413540",
+        "role": "Maps one joystick-options combo-box selection back to the underlying seven-slot capability index.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Shell_JoystickOptionsPageProc_v129": {
+        "binary": "FUN_00413560",
+        "role": "Dialog proc for the retail options tab that exposes joystick axis-mode selectors, sensitivity sliders, binding dialogs, and control-panel refresh.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control",
+          "shell-state-dispatch"
+        ]
+      },
+      "Combat_OpenJoystickControlPanelApplet_v129": {
+        "binary": "FUN_004142e0",
+        "role": "Launches the Windows joystick control-panel applet and starts the helper thread that hooks the spawned CPL window.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_FindJoystickControlPanelWindowEnumProc_v129": {
+        "binary": "FUN_00414390",
+        "role": "EnumWindows callback that finds the spawned joystick control-panel window owned by the retail frontend.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_HookJoystickControlPanelWindowThread_v129": {
+        "binary": "FUN_004143d0",
+        "role": "Helper thread that waits for the spawned joystick control-panel window, installs the retail hook pointer, and normalizes its extended style.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_BuildJoystickCapabilityFlagTable_v129": {
+        "binary": "FUN_004145c0",
+        "role": "Builds the small joystick capability flag table consumed by the retail options/property-sheet UI.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_FormatJoystickStatusSummary_v129": {
+        "binary": "FUN_00414660",
+        "role": "Builds the localized retail joystick status string for the combat-controls/options UI and returns the availability state code.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_OpenJoystickConfigDialog_v129": {
+        "binary": "FUN_00414750",
+        "role": "Opens the modal retail joystick-configuration dialog from the shell frontend.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_SetJoystickCapabilitySummaryControlText_v129": {
+        "binary": "FUN_00414770",
+        "role": "Builds the localized joystick capability summary string and writes it directly into one retail options dialog control.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "System_ResolveSpeechCpuCheckMode_v129": {
+        "binary": "FUN_00414ed0",
+        "role": "Resolves the retail speech CPU-check mode during frontend initialization.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_SpeechCpuCheckDialogProc_v129": {
+        "binary": "FUN_00415020",
+        "role": "Dialog procedure for the retail NoSpeechCPUCheck override prompt.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "ResourceArchive_CloseTaggedArchive_v129": {
+        "binary": "FUN_00415390",
+        "role": "Closes a retail tagged archive descriptor, releases its directory buffer, and frees the archive wrapper.",
+        "xrefs": 8,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-picture-bootstrap"
+        ]
+      },
+      "ResourceArchive_OpenTaggedArchive_v129": {
+        "binary": "FUN_004153d0",
+        "role": "Opens a retail tagged archive file and reads its fixed-size entry directory into memory.",
+        "xrefs": 8,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-visual-bootstrap",
+          "shell-picture-bootstrap",
+          "frame-text-rendering"
+        ]
+      },
+      "ResourceArchive_SeekTaggedEntry_v129": {
+        "binary": "FUN_00415560",
+        "role": "Locates a four-character tagged entry inside an opened retail archive and seeks the archive file to that payload.",
+        "xrefs": 100,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-visual-bootstrap",
+          "shell-picture-bootstrap",
+          "frame-text-rendering"
+        ]
+      },
+      "Mech_GetVariantCodeById_v129": {
+        "binary": "FUN_00415600",
+        "role": "Returns the localized mech variant code string for one mech id, such as `HBK-4G`.",
+        "xrefs": 9,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "mech-runtime-init",
+          "world-mech-management-pages"
+        ]
+      },
+      "Mech_GetChassisDisplayNameById_v129": {
+        "binary": "FUN_00415630",
+        "role": "Returns the localized mech chassis/family display name for one chassis id, such as `HUNCHBACK`.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "mech-runtime-init",
+          "world-mech-management-pages"
+        ]
+      },
+      "Mech_GetWeaponTypeLabelById_v129": {
+        "binary": "FUN_00415660",
+        "role": "Returns the localized retail weapon-type label for one weapon id, choosing either the long detail wording or the compact status-column wording.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-mech-management-pages"
+        ]
+      },
+      "Mech_ClassifyPagedListStatusById_v129": {
+        "binary": "FUN_004156c0",
+        "role": "Maps one mech id onto the shared four-way status/group byte used by the retail paged mech-list windows.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-mech-management-pages"
+        ]
+      },
+      "Mech_AllocateAndLoadRecordById_v129": {
+        "binary": "FUN_004156f0",
+        "role": "Allocates a retail mech-record buffer and fills it with the decoded mechdata entry for one mech id.",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "mech-runtime-init",
+          "world-mech-management-pages"
+        ]
+      },
+      "Mech_InitRuntimeStateFromRecord_v129": {
+        "binary": "FUN_004157a0",
+        "role": "Initializes actor runtime state from the mech record.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "mech-runtime-init"
+        ]
+      },
+      "Mech_InitComponentStatusFromRecord_v129": {
+        "binary": "FUN_00415a60",
+        "role": "Initializes per-component runtime status from the mech record.",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "mech-runtime-init"
+        ]
+      },
+      "Mech_GetInternalStructureMaxByTonnageAndSection_v129": {
+        "binary": "FUN_00415bd0",
+        "role": "Returns the retail maximum internal-structure value for one mech tonnage bucket and section index.",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "mech-runtime-init",
+          "world-mech-management-pages"
+        ]
+      },
+      "Mech_LoadRecordIntoBufferById_v129": {
+        "binary": "FUN_00415c90",
+        "role": "Loads, decrypts, and normalizes one retail mechdata record into a caller-supplied buffer.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "mech-runtime-init",
+          "world-mech-management-pages"
+        ]
+      },
+      "Combat_ClearCmbOrCmpHudToggleByHotkeyThunk_v129": {
+        "binary": "FUN_00415ff8",
+        "role": "Tiny retail tail wrapper that forwards into Combat_ClearCmbOrCmpHudToggleByHotkey_v129.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-presentation-hud"
+        ]
+      },
+      "Combat_SetCmbOrCmpHudToggleByHotkeyThunk_v129": {
+        "binary": "FUN_00416001",
+        "role": "Tiny retail tail wrapper that forwards into Combat_SetCmbOrCmpHudToggleByHotkey_v129.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-presentation-hud"
+        ]
+      },
+      "Combat_DrawWeaponSlotHudOptionCell_v129": {
+        "binary": "FUN_004160d0",
+        "role": "Draws one retail weapon-slot option cell bitmap for the requested slot row and option column.",
+        "xrefs": 20,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-slot-hud"
+        ]
+      },
+      "Combat_UpdateLocalThrottleTarget_v129": {
+        "binary": "FUN_00416230",
+        "role": "Updates the local throttle target used by movement control.",
+        "xrefs": 17,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_ProcessChassisTurnInput_v129": {
+        "binary": "FUN_00416380",
+        "role": "Processes the local chassis-turn input axis and applies it into the chassis-facing accumulator.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_ProcessUpperBodyAimInput_v129": {
+        "binary": "FUN_00416460",
+        "role": "Processes the local upper-body aim input axes, including keyboard deltas, mouse recentering, and zone-based fallback control.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_JumpJetInputTick_v129": {
+        "binary": "FUN_00416570",
+        "role": "Processes jump-jet input and checks the live jump-jet count gate.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_SetJumpFuelReadyIndicator_v129": {
+        "binary": "FUN_004168e0",
+        "role": "Toggles the jump-fuel ready indicator artwork between the active and inactive palette ramps.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-jump-fuel-hud"
+        ]
+      },
+      "Combat_UpdateJumpFuelGauge_v129": {
+        "binary": "FUN_004169d0",
+        "role": "Updates the vertical jump-fuel gauge fill and warning color from the current local reserve value.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-jump-fuel-hud"
+        ]
+      },
+      "Combat_HandleLocalControlHotkey_v129": {
+        "binary": "FUN_00416b20",
+        "role": "Dispatches the retail combat local-control hotkeys for weapon slots, fire controls, movement shortcuts, and voice-panel subcontrols.",
+        "xrefs": 8,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_ClearCmbOrCmpHudToggleByHotkey_v129": {
+        "binary": "FUN_00417860",
+        "role": "Routes the normalized presentation hotkey for `CMB` or `CMP` back into the default toggle state.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-presentation-hud"
+        ]
+      },
+      "Combat_SetCmbOrCmpHudToggleByHotkey_v129": {
+        "binary": "FUN_00417890",
+        "role": "Routes the normalized presentation hotkey for `CMB` or `CMP` into the alternate toggle state.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-presentation-hud"
+        ]
+      },
+      "Combat_SetHudTimeoutSlotExpiry_v129": {
+        "binary": "FUN_004178c0",
+        "role": "Arms one of the small combat HUD timeout slots for the current tick plus a caller-supplied duration.",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-presentation-hud"
+        ]
+      },
+      "Combat_ProcessExpiredHudTimeoutSlots_v129": {
+        "binary": "FUN_004178f0",
+        "role": "Polls the six lightweight combat HUD timeout slots and fires the follow-up indicator updates whose expiry time has passed.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-presentation-hud"
+        ]
+      },
+      "Combat_FireWeaponBank_v129": {
+        "binary": "FUN_00417950",
+        "role": "Executes the armed weapons in one local weapon bank against the current target and spawns the matching retail impact/effect side effects.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-bank-fire"
+        ]
+      },
+      "Combat_SpawnImpactEffectAtAttachmentOrCoord_v129": {
+        "binary": "FUN_00417b90",
+        "role": "Spawns the retail impact effect at a target attachment when available, or falls back to explicit world coordinates.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-bank-fire",
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_InitializeCombatHudAndControlState_v129": {
+        "binary": "FUN_00417cd0",
+        "role": "Installs the retail combat HUD/control callbacks and seeds the initial in-scene HUD state after the battlefield visuals are ready.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_DrawActorStatusPanel_v129": {
+        "binary": "FUN_00417f80",
+        "role": "Draws the retail actor status side panel for the local mech or the currently selected target.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_SelectWeaponSlotHudEntry_v129": {
+        "binary": "FUN_00418800",
+        "role": "Moves the active local weapon-slot HUD selection to the requested slot and flips the retail highlight colors.",
+        "xrefs": 8,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-slot-hud"
+        ]
+      },
+      "Combat_RedrawWeaponSlotHudWeaponTypeIcons_v129": {
+        "binary": "FUN_004188c0",
+        "role": "Redraws the retail weapon-type icon strip down the local weapon-slot HUD rows.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-slot-hud"
+        ]
+      },
+      "Combat_RedrawWeaponSlotHudGrid_v129": {
+        "binary": "FUN_004189a0",
+        "role": "Redraws the static local weapon-slot HUD grid and refreshes every slot's availability state.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-slot-hud"
+        ]
+      },
+      "Combat_SumWeaponTypeAmmoAndSlotCount_v129": {
+        "binary": "FUN_00418b20",
+        "role": "Sums the remaining ammo/value pool and matching slot count for one retail weapon type across the local mech loadout.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-slot-hud"
+        ]
+      },
+      "Combat_UpdateWeaponSlotHudAvailability_v129": {
+        "binary": "FUN_00418b90",
+        "role": "Refreshes one weapon-slot HUD cell set to reflect the current shared-ammo and fireability state.",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-slot-hud"
+        ]
+      },
+      "Combat_InitializeWeaponSlotHud_v129": {
+        "binary": "FUN_00418cb0",
+        "role": "Builds the local weapon-slot HUD grid, binds its hotkeys, and seeds the initial per-slot cell state.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-slot-hud"
+        ]
+      },
+      "Combat_UpdateVoiceTransmissionStatusStrip_v129": {
+        "binary": "FUN_00418e50",
+        "role": "Updates the compact combat voice-transmission status strip bitmaps and talkback meter.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_UpdateRadarRangeHudIndicator_v129": {
+        "binary": "FUN_00419030",
+        "role": "Advances the retail tactical-radar range selection and redraws the matching `RDR1`-`RDR5` HUD indicator.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-presentation-hud"
+        ]
+      },
+      "Combat_UpdateHudZoomIndicators_v129": {
+        "binary": "FUN_00419270",
+        "role": "Updates the paired retail `ZOM*` / `ZMB*` HUD zoom indicators and the shared HUD zoom-state byte.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-presentation-hud"
+        ]
+      },
+      "Combat_UpdateEjectStatusHudIndicator_v129": {
+        "binary": "FUN_00419440",
+        "role": "Redraws the retail `EJE1`-`EJE5` HUD strip for the current local eject-status state.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-presentation-hud"
+        ]
+      },
+      "Combat_UpdateCmbHudToggle_v129": {
+        "binary": "FUN_004195b0",
+        "role": "Updates the retail `CMB1`-`CMB4` HUD toggle strip and its paired presentation-mode bit.",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-presentation-hud"
+        ]
+      },
+      "Combat_UpdateChbHudToggle_v129": {
+        "binary": "FUN_00419710",
+        "role": "Updates the retail `CHB1`-`CHB4` HUD toggle strip from the current presentation toggle state.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-presentation-hud"
+        ]
+      },
+      "Combat_UpdateLogHudToggle_v129": {
+        "binary": "FUN_004197d0",
+        "role": "Updates the retail `LOG1` / `LOG2` HUD toggle, including the associated log-overlay state flip.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-presentation-hud"
+        ]
+      },
+      "Combat_RedrawWeaponBankHudReadouts_v129": {
+        "binary": "FUN_00419920",
+        "role": "Redraws the local weapon-bank readout rows on the combat HUD.",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-bank-fire"
+        ]
+      },
+      "Combat_UpdateHeatGaugeAndPaletteTint_v129": {
+        "binary": "FUN_00419ad0",
+        "role": "Redraws the local heat gauge and drives the staged combat palette tint from the current displayed heat level.",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-heat-hud",
+          "combat-weapon-bank-fire"
+        ]
+      },
+      "Combat_DrawLocalAirborneHudReadout_v129": {
+        "binary": "FUN_00419e30",
+        "role": "Draws the local airborne HUD readout from the actor altitude and vertical-response fields.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_UpdateLocalMovementHudAndAnimation_v129": {
+        "binary": "FUN_00419f50",
+        "role": "Updates the local movement HUD and ordinary stand/walk animation state.",
+        "xrefs": 15,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control",
+          "combat-weapon-bank-fire"
+        ]
+      },
+      "Frame_ReplacePaletteIndexInRect_v129": {
+        "binary": "FUN_0041a5e0",
+        "role": "Replaces one palette index with another throughout a frame-local rectangle without presenting it automatically.",
+        "xrefs": 17,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-jump-fuel-hud",
+          "frame-text-rendering"
+        ]
+      },
+      "Combat_RedrawEq4HudIndicator_v129": {
+        "binary": "FUN_0041a650",
+        "role": "Redraws the rightmost lower-row EQ4 HUD indicator from the local actor's cached indicator state.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-eq-hud"
+        ]
+      },
+      "Combat_RedrawEq1HudIndicator_v129": {
+        "binary": "FUN_0041a700",
+        "role": "Redraws the leftmost lower-row EQ1 HUD indicator from the local actor's cached indicator state.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-eq-hud"
+        ]
+      },
+      "Combat_RedrawEq3HudIndicator_v129": {
+        "binary": "FUN_0041a7b0",
+        "role": "Redraws the third lower-row EQ3 HUD indicator from the local actor's cached indicator state.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-eq-hud"
+        ]
+      },
+      "Combat_RedrawEq2HudIndicator_v129": {
+        "binary": "FUN_0041a870",
+        "role": "Redraws the second lower-row EQ2 HUD indicator from the local actor's cached indicator state.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-eq-hud"
+        ]
+      },
+      "Combat_DrawWeaponSlotRangeIndicator_v129": {
+        "binary": "FUN_0041a920",
+        "role": "Draws the local weapon-slot range-bracket indicator for one slot against the current target distance.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-slot-hud"
+        ]
+      },
+      "Combat_RenderImmediateWeaponFireOverlay_v129": {
+        "binary": "FUN_0041aba0",
+        "role": "Renders the small local immediate-fire overlay used by non-projectile, non-model weapon shots.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_TickLocalGroundMovementCadenceCue_v129": {
+        "binary": "FUN_0041adf0",
+        "role": "Ticks the alternating grounded movement cadence cue while the local mech has a nonzero throttle target.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_GetWeaponSlotMuzzleOrigin_v129": {
+        "binary": "FUN_0041ae60",
+        "role": "Resolves the world-space muzzle origin for one weapon slot from the actor's attachment tags.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_ComputeEffectAimAnglesToPoint_v129": {
+        "binary": "FUN_0041af90",
+        "role": "Computes the retail pitch/yaw effect angles that face from one world point toward another.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_ComputePointDistance_v129": {
+        "binary": "FUN_0041b080",
+        "role": "Returns the Euclidean distance between two combat world points with the retail overflow-safe 1/32 scaling step.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_BuildWeaponEffectSpawnGeometry_v129": {
+        "binary": "FUN_0041b0c0",
+        "role": "Builds the origin, target point, travel flags, and initial aim angles for one weapon-effect spawn.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_SpawnActiveWeaponEffect_v129": {
+        "binary": "FUN_0041b1e0",
+        "role": "Allocates a free active projectile/effect slot and seeds it from one weapon-effect spawn request.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_CanAppendDamageCodeValueToActiveEffect_v129": {
+        "binary": "FUN_0041b440",
+        "role": "Returns whether one live active effect slot can absorb another deferred damage code/value pair for the same target actor.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_AppendDamageCodeValueToActiveEffect_v129": {
+        "binary": "FUN_0041b490",
+        "role": "Appends one deferred damage code/value pair onto an active effect slot's pending impact list.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_GetLastSpawnedWeaponEffectSlotIndex_v129": {
+        "binary": "FUN_0041b4d0",
+        "role": "Returns the active effect-pool index most recently reserved by Combat_SpawnActiveWeaponEffect_v129.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_ResolveLocalWeaponFallbackImpactPoint_v129": {
+        "binary": "FUN_0041b4e0",
+        "role": "Resolves the local actor's fallback impact point when a weapon effect is fired without a locked target attachment.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_WeaponTypeUsesProjectileEffectPath_v129": {
+        "binary": "FUN_0041b750",
+        "role": "Returns whether a retail weapon type belongs to the projectile-style effect path set.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_WeaponTypeUsesBeamEffectPath_v129": {
+        "binary": "FUN_0041b780",
+        "role": "Returns whether a retail weapon type belongs to the beam-style effect path set.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_UpdateHeatPaletteTintStage_v129": {
+        "binary": "FUN_0041b7b0",
+        "role": "Evaluates the current heat-tint stage thresholds and applies the matching palette-tint amount when the local heat bar crosses into a new band.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-heat-hud"
+        ]
+      },
+      "Combat_ApplyHeatPaletteTint_v129": {
+        "binary": "FUN_0041b830",
+        "role": "Builds and applies the working combat heat-tint palette from the active terrain palette table.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-heat-hud"
+        ]
+      },
+      "Combat_AdjustPaletteChannelClamped_v129": {
+        "binary": "FUN_0041b8d0",
+        "role": "Adjusts one byte channel across a palette table with 0..255 saturation.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-heat-hud"
+        ]
+      },
+      "Combat_ResetHeatPaletteWorkingCopy_v129": {
+        "binary": "FUN_0041b950",
+        "role": "Resets the combat heat-tint working palette buffer from the active terrain palette table.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-heat-hud"
+        ]
+      },
+      "Combat_FireCurrentWeaponBank_v129": {
+        "binary": "FUN_0041b980",
+        "role": "Fires the currently selected local weapon bank and refreshes the dependent combat HUD panels.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-bank-fire"
+        ]
+      },
+      "Combat_UpdateCmpHudToggle_v129": {
+        "binary": "FUN_0041b9d0",
+        "role": "Updates the retail `CMP1`-`CMP4` HUD toggle strip and the paired presentation-mode side effects.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-presentation-hud"
+        ]
+      },
+      "Combat_ClearSpeechOutActorLabelSlots_v129": {
+        "binary": "FUN_0041bb20",
+        "role": "Clears the two retail speech-out actor label slots shown across the top edge of the combat HUD.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_DrawSpeechOutActorLabels_v129": {
+        "binary": "FUN_0041bb40",
+        "role": "Draws the active retail speech-out speaker labels across the top row of the combat HUD.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_SetSpeechOutActorLabelSlot_v129": {
+        "binary": "FUN_0041bc20",
+        "role": "Marks one speech-out actor label slot active for the actor currently mapped to a sound-source index.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_ClearSpeechOutActorLabelSlot_v129": {
+        "binary": "FUN_0041bc50",
+        "role": "Clears one active speech-out actor label slot on the combat HUD.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Shell_InitializeVersionString_v129": {
+        "binary": "FUN_0041bc70",
+        "role": "Formats the cached retail version banner string used by the shell title and credits overlays.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_GetVersionString_v129": {
+        "binary": "FUN_0041bcb0",
+        "role": "Returns the cached retail version banner string prepared during frontend startup.",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-picture-bootstrap"
+        ]
+      },
+      "Frame_MeasureGlyphRunWidth_v129": {
+        "binary": "FUN_0041bcc0",
+        "role": "Measures the rendered width of a printable glyph run in the selected retail font.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-actor-preview",
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_MeasureStringWidth_v129": {
+        "binary": "FUN_0041bd20",
+        "role": "Measures a retail string width using the active frame font, including tab-stop expansion.",
+        "xrefs": 13,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-actor-preview",
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_InvertTextDecorationPaletteByIndex_v129": {
+        "binary": "FUN_0041be00",
+        "role": "Inverts the palette indices inside one type-0 text-decoration rect, producing the retail pressed/flash visual for plain text controls.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_SetTextDecorationTextByIndex_v129": {
+        "binary": "FUN_0041be40",
+        "role": "Copies one string into a registered text-decoration entry and expands the decoration width to fit the measured label text.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_IsTextDecorationToggleStateSetByIndex_v129": {
+        "binary": "FUN_0041bec0",
+        "role": "Returns whether one toggle-style text-decoration/control entry is currently set.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering",
+          "world-selection-dialogs"
+        ]
+      },
+      "Frame_DrawFilledBoxOrBitmapDecoration_v129": {
+        "binary": "FUN_0041bf00",
+        "role": "Draws the simple filled-box decoration variant and the bitmap-backed decoration variant used by registered frame text decorations.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_SetTextDecorationToggleStateByIndex_v129": {
+        "binary": "FUN_0041c020",
+        "role": "Updates the checked or active state of one toggle-style text-decoration/control entry and redraws it in place.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering",
+          "world-selection-dialogs"
+        ]
+      },
+      "Frame_DrawLine_v129": {
+        "binary": "FUN_0041c070",
+        "role": "Draws one clipped line segment into the frame surface using the requested palette index.",
+        "xrefs": 18,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DrawLineAndPresent_v129": {
+        "binary": "FUN_0041c0c0",
+        "role": "Draws one clipped line segment into the frame surface and then presents the touched rectangle.",
+        "xrefs": 18,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DrawBeveledRectAndPresent_v129": {
+        "binary": "FUN_0041c170",
+        "role": "Draws a two-tone beveled rectangle border and presents each affected edge region immediately.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DrawBeveledRect_v129": {
+        "binary": "FUN_0041c320",
+        "role": "Draws a two-tone beveled rectangle border into the frame surface without presenting it immediately.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DrawBeveledBorderDecoration_v129": {
+        "binary": "FUN_0041c4d0",
+        "role": "Draws the beveled border decoration variant used by registered frame text decorations.",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_EnableTextDecorationByIndex_v129": {
+        "binary": "FUN_0041c530",
+        "role": "Marks one registered text-decoration/control entry as enabled for hit-testing and interaction.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DisableTextDecorationByIndex_v129": {
+        "binary": "FUN_0041c560",
+        "role": "Marks one registered text-decoration/control entry as disabled so pointer hit-testing skips it.",
+        "xrefs": 13,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_FlashHotkeyControl_v129": {
+        "binary": "FUN_0041c590",
+        "role": "Briefly flashes the retail control bound to a normalized hotkey, showing its pressed state before restoring the normal artwork.",
+        "xrefs": 12,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DefaultTextDecorationPointerHandler_v129": {
+        "binary": "FUN_0041c820",
+        "role": "Shared default mouse handler for retail frames that use registered text-decoration controls.",
+        "xrefs": 12,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_FindEnabledTextDecorationAtPoint_v129": {
+        "binary": "FUN_0041cb20",
+        "role": "Returns the first enabled registered text-decoration/control entry whose rectangle contains the supplied frame-local point.",
+        "xrefs": 13,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DrawTextDecorationByIndex_v129": {
+        "binary": "FUN_0041cb70",
+        "role": "Draws one registered text decoration/control entry by index.",
+        "xrefs": 8,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_RegisterTextDecoration_v129": {
+        "binary": "FUN_0041cd40",
+        "role": "Appends one typed decoration/control entry to a retail frame and initializes the stored rectangle, id, and payload fields.",
+        "xrefs": 130,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_SetTextDecorationBitmapPairByIndex_v129": {
+        "binary": "FUN_0041d0f0",
+        "role": "Stores the two bitmap resources used by one registered text-decoration/control entry and redraws that entry.",
+        "xrefs": 50,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_SetTextDecorationBevelPalettePairByIndex_v129": {
+        "binary": "FUN_0041d130",
+        "role": "Stores the two bevel palette indices used by one registered border-style text decoration.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_FindTopWindowAtPoint_v129": {
+        "binary": "FUN_0041d160",
+        "role": "Returns the topmost retail frame/window whose screen rectangle contains the supplied display coordinates.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DispatchMouseEventToWindowStack_v129": {
+        "binary": "FUN_0041d1b0",
+        "role": "Hit-tests the retail window stack at a mouse position and dispatches the resulting mouse event into the selected frame/control callback.",
+        "xrefs": 7,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DispatchTextDecorationActionById_v129": {
+        "binary": "FUN_0041d3f0",
+        "role": "Dispatches a released text-decoration/control id into the frame's primary or alternate action callback.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_UpdateTextCursorHighlight_v129": {
+        "binary": "FUN_0041d470",
+        "role": "Computes and toggles the current text cursor highlight rectangle for an editable frame text surface.",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DispatchNormalizedKeyToActiveWindow_v129": {
+        "binary": "FUN_0041d5b0",
+        "role": "Dispatches a normalized key to the active retail window callback, flashing any bound hotkey control first.",
+        "xrefs": 7,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_CreateRootWindow_v129": {
+        "binary": "FUN_0041dd60",
+        "role": "Clears the retail window-stack globals and creates the fullscreen root frame used as the compose/display anchor.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_RedrawRegisteredTextDecorations_v129": {
+        "binary": "FUN_0041de30",
+        "role": "Redraws all registered text decorations/controls that are currently enabled on the frame.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_ResetTextLayoutState_v129": {
+        "binary": "FUN_0041de70",
+        "role": "Resets the frame text cursor/layout state for the full text area and clears the backing surface when the frame flags request it.",
+        "xrefs": 7,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_ResetTextLayoutStateWithInsets_v129": {
+        "binary": "FUN_0041df00",
+        "role": "Resets the frame text cursor/layout state against an inset drawing rectangle and applies the requested layout mode.",
+        "xrefs": 11,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_AllocateEditableTextBuffer_v129": {
+        "binary": "FUN_0041df80",
+        "role": "Allocates the backing editable text buffer for a retail frame and stores its maximum character capacity.",
+        "xrefs": 7,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_AllocateSelectionValueTable_v129": {
+        "binary": "FUN_0041e030",
+        "role": "Allocates the per-entry integer value table used by retail selection dialogs and related frame menus.",
+        "xrefs": 7,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_SetActiveFont_v129": {
+        "binary": "FUN_0041e0e0",
+        "role": "Stores the active bitmap-font descriptor on a retail frame and refreshes the font-derived row metrics that travel with it.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering",
+          "world-travel-browser"
+        ]
+      },
+      "Frame_CreateWindow_v129": {
+        "binary": "FUN_0041e100",
+        "role": "Allocates and initializes a retail frame/window with backing storage, callbacks, and optional inset text layout.",
+        "xrefs": 14,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-picture-bootstrap",
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_ConfigureTextGridMetrics_v129": {
+        "binary": "FUN_0041e450",
+        "role": "Configures the active line height and derived text-grid metrics for a retail frame/window.",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_SetTextCursorPixelPos_v129": {
+        "binary": "FUN_0041e4a0",
+        "role": "Moves the retail frame text cursor to a clamped pixel position and updates the derived column and row state.",
+        "xrefs": 14,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_ClearCurrentTextLine_v129": {
+        "binary": "FUN_0041e500",
+        "role": "Clears the current retail text line, resets the cursor x-position, and drops the latched line metadata.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_WriteCharAtCursor_v129": {
+        "binary": "FUN_0041e560",
+        "role": "Writes one character at the frame's current text cursor using the active line and column state.",
+        "xrefs": 7,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_WriteCharAtCursorAndPresent_v129": {
+        "binary": "FUN_0041e580",
+        "role": "Writes one character at the current retail text cursor, presents the touched region immediately, and falls back to a full redraw on wrap and newline paths.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_ScrollTextViewportUpIfAtBottom_v129": {
+        "binary": "FUN_0041e6d0",
+        "role": "Scrolls the frame text viewport up by one line when the active text row hits the bottom edge and scrolling is enabled.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_WriteCharAtLineColumn_v129": {
+        "binary": "FUN_0041e740",
+        "role": "Writes one character at an explicit frame text line/column position and advances the logical cursor with wrapping rules.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DrawFormattedText_v129": {
+        "binary": "FUN_0041e860",
+        "role": "Parses and draws the retail inline-formatted text stream, including tabs, centered runs, embedded bitmaps, and inline widgets.",
+        "xrefs": 62,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DrawCenteredStringInWidth_v129": {
+        "binary": "FUN_0041ed40",
+        "role": "Measures a retail string and draws it horizontally centered within a caller-supplied width at the current text row.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_SeedEditableTextBuffer_v129": {
+        "binary": "FUN_0041eda0",
+        "role": "Draws an initial formatted string into a retail edit field and copies that same text into the frame's editable buffer state.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_FindWindowStackIndex_v129": {
+        "binary": "FUN_0041ee00",
+        "role": "Returns the current z-order index of a retail frame/window in the global window stack, or -1 when absent.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_BlitRelativeRect_v129": {
+        "binary": "FUN_0041ee30",
+        "role": "Normalizes a frame-local rectangle, offsets it by the owning panel origin, and blits that region through the retail surface-present path.",
+        "xrefs": 16,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-actor-preview",
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_RedrawWindowStackFrom_v129": {
+        "binary": "FUN_0041eed0",
+        "role": "Recomposites visible retail windows starting at a given frame and presents the affected screen region.",
+        "xrefs": 51,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-picture-bootstrap",
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DrawBitmapResourceAt_v129": {
+        "binary": "FUN_0041f070",
+        "role": "Draws a bitmap resource into the frame surface at the requested top-left position.",
+        "xrefs": 100,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-eq-hud",
+          "combat-presentation-hud",
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DrawBitmapResourceTransparentAt_v129": {
+        "binary": "FUN_0041f0d0",
+        "role": "Draws a bitmap resource into the frame surface while skipping pixels that match a transparent key value.",
+        "xrefs": 11,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-presentation-hud",
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DrawStringAt_v129": {
+        "binary": "FUN_0041f130",
+        "role": "Draws a retail string at a frame-local pixel position using a temporary text color and an optional font override.",
+        "xrefs": 110,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DrawBeveledFillBar_v129": {
+        "binary": "FUN_0041f1b0",
+        "role": "Draws a beveled bar widget with an optional filled span and an optional center marker line.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DrawFilledCircleSector_v129": {
+        "binary": "FUN_0041f280",
+        "role": "Draws a filled circular sector into the frame surface using a scratch mask buffer and the requested palette index.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_ResetWindowStack_v129": {
+        "binary": "FUN_0041f900",
+        "role": "Destroys every live retail frame/window in the stack and recreates the root frame unless full shutdown is active.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DestroyWindow_v129": {
+        "binary": "FUN_0041f990",
+        "role": "Destroys a retail frame/window, recursively releasing child frames, backing storage, and active-window state.",
+        "xrefs": 22,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-picture-bootstrap",
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_FindTopFullscreenWindowInStack_v129": {
+        "binary": "FUN_0041fb10",
+        "role": "Returns the topmost retail frame/window in the live stack whose fullscreen flag is set.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_ResetRootWindowTextLayout_v129": {
+        "binary": "FUN_0041fb40",
+        "role": "Clears the root frame's registered text-decoration state and restores its default text layout.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_ActivateWindow_v129": {
+        "binary": "FUN_0041fb90",
+        "role": "Moves a retail frame/window to the top of the z-order stack, marks it active, and redraws the affected display region.",
+        "xrefs": 10,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_LayoutAndDrawWrappedFormattedText_v129": {
+        "binary": "FUN_0041fc70",
+        "role": "Wraps a formatted retail text string, accounts for inline asset markers, and either measures or draws the resulting lines.",
+        "xrefs": 16,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_ActivateTopWindowExcept_v129": {
+        "binary": "FUN_004200f0",
+        "role": "Chooses the highest-priority retail frame/window other than one excluded target and activates that replacement window.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_SwapPaletteIndicesInRect_v129": {
+        "binary": "FUN_00420140",
+        "role": "Swaps two palette indices throughout a frame-local rectangle and optionally presents the modified region.",
+        "xrefs": 39,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-slot-hud",
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_InvertRectPixels_v129": {
+        "binary": "FUN_00420230",
+        "role": "Bit-inverts every pixel in a frame-local rectangle and optionally presents the touched region afterward.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DrawRectOutline_v129": {
+        "binary": "FUN_00420300",
+        "role": "Draws a one-pixel rectangle outline by emitting the four edge line segments.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_NormalizeRect_v129": {
+        "binary": "FUN_00420380",
+        "role": "Normalizes an in-place retail rectangle so left<=right and top<=bottom.",
+        "xrefs": 17,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Combat_RegisterLasrSequenceCallback_v129": {
+        "binary": "FUN_004203b0",
+        "role": "Thin wrapper around the Miles sequence-callback registration used by the retail LASR sound state machine.",
+        "xrefs": 28,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_ResetLasrSoundState_v129": {
+        "binary": "FUN_00421f60",
+        "role": "Resets the retail LASR sound state machine, clears the current/target state ids, and releases active LASR handles.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_LoadLasrSequenceProfiles_v129": {
+        "binary": "FUN_00422040",
+        "role": "Loads the retail LASR profile table by splitting each profile's sequence list and loading every named MIDI sequence.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_SetLasrProfileVolume_v129": {
+        "binary": "FUN_00422220",
+        "role": "Sets the current volume value across every sequence in one LASR profile.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_AdjustLasrProfileTempo_v129": {
+        "binary": "FUN_00422280",
+        "role": "Adjusts the playback tempo across every sequence in one LASR profile.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_OpenLasrProfileSequences_v129": {
+        "binary": "FUN_004222e0",
+        "role": "Allocates and initializes playback handles for every sequence in one LASR profile.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_StopLasrProfileSequences_v129": {
+        "binary": "FUN_00422350",
+        "role": "Stops and releases every active sequence handle in one LASR profile.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_StepLasrProfileVolumeTowardTarget_v129": {
+        "binary": "FUN_004223a0",
+        "role": "Steps the active LASR profile volume one unit toward the pending target volume.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_FadeOutLasrProfileVolume_v129": {
+        "binary": "FUN_00422410",
+        "role": "Fades the current LASR profile down by one volume step until it reaches silence.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_StopLasrSound_v129": {
+        "binary": "FUN_00422440",
+        "role": "Stops the active LASR sound profile and resets the LASR state machine when LASR is armed.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_EnsureLasrSoundInitialized_v129": {
+        "binary": "FUN_00422470",
+        "role": "Initializes the LASR sound system on first use and resets the runtime LASR state when initialization succeeds.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_SetLasrSoundState_v129": {
+        "binary": "FUN_004224b0",
+        "role": "Maps an abstract LASR state id to the concrete retail sound profile and target volume bookkeeping.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_TickLasrSoundState_v129": {
+        "binary": "FUN_004228d0",
+        "role": "Advances the retail LASR sound state machine, including pending volume ramps and sound-handle swaps.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_GetLasrSoundState_v129": {
+        "binary": "FUN_00422ac0",
+        "role": "Returns the currently latched LASR state id when the LASR sound system is enabled.",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_EnsureLasrMidiOutputOpen_v129": {
+        "binary": "FUN_00422ae0",
+        "role": "Ensures the Miles MIDI output used by the LASR sound layer is open.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_LoadLasrSequenceData_v129": {
+        "binary": "FUN_00422b30",
+        "role": "Loads one LASR sequence data blob into a profile slot and seeds its default tempo/volume values.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_InitLasrSequenceHandle_v129": {
+        "binary": "FUN_00422b70",
+        "role": "Allocates and initializes one Miles playback handle for a LASR sequence slot.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_StartLasrSequence_v129": {
+        "binary": "FUN_00422be0",
+        "role": "Starts one LASR sequence handle and reapplies the slot's current tempo and volume.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_StopLasrSequence_v129": {
+        "binary": "FUN_00422c30",
+        "role": "Stops one active LASR sequence handle.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_EndLasrSequence_v129": {
+        "binary": "FUN_00422c60",
+        "role": "Ends one active LASR sequence handle immediately.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_ReleaseLasrSequenceHandle_v129": {
+        "binary": "FUN_00422c90",
+        "role": "Releases one LASR sequence handle and clears the slot's handle pointer.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_AdjustLasrSequenceTempo_v129": {
+        "binary": "FUN_00422cd0",
+        "role": "Adjusts one LASR sequence slot's cached tempo and applies it to the active handle.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_SetLasrSequenceVolume_v129": {
+        "binary": "FUN_00422d20",
+        "role": "Sets one LASR sequence slot's cached volume and applies it to the active handle.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_GetLasrSequenceStatus_v129": {
+        "binary": "FUN_00422d70",
+        "role": "Returns the Miles playback status for one LASR sequence slot.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "World_NoOpTravelCompassPageSetupHook_v129": {
+        "binary": "FUN_00422da0",
+        "role": "Compiled-out travel-compass page setup hook that retail leaves empty after the fixed frame art is drawn.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "Shell_SetArrowCursorMode_v129": {
+        "binary": "FUN_00422db0",
+        "role": "Restores the retail arrow cursor and clears the wait-cursor state bit.",
+        "xrefs": 11,
+        "source": "retail_function_catalog.gd"
+      },
+      "Shell_SetWaitCursorMode_v129": {
+        "binary": "FUN_00422de0",
+        "role": "Enters the retail wait-cursor mode and latches the corresponding shell state bit.",
+        "xrefs": 11,
+        "source": "retail_function_catalog.gd"
+      },
+      "Shell_PlayUiRejectCue_v129": {
+        "binary": "FUN_00422e10",
+        "role": "Plays the shared retail UI reject cue when interface sound effects are enabled.",
+        "xrefs": 48,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "World_ClearPagedMechListSelectionHighlight_v129": {
+        "binary": "FUN_00422e50",
+        "role": "Restores the unselected border and bitmap placement for one paged mech-list slot and presents the slot rectangle.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-paged-mech-list"
+        ]
+      },
+      "World_DrawPagedMechListSelectionHighlight_v129": {
+        "binary": "FUN_00422f20",
+        "role": "Draws the active highlight border for one paged mech-list slot and presents the updated slot rectangle.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-paged-mech-list"
+        ]
+      },
+      "World_UpdatePagedMechListSelectionHighlight_v129": {
+        "binary": "FUN_00422ff0",
+        "role": "Clears the previously highlighted paged mech-list slot and draws the new active highlight.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-paged-mech-list"
+        ]
+      },
+      "World_PagedMechList_HandlePointer_v129": {
+        "binary": "FUN_00423040",
+        "role": "Pointer handler for the shared paged mech-list window.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-paged-mech-list"
+        ]
+      },
+      "World_PagedMechList_ActivatePointerSelection_v129": {
+        "binary": "FUN_004232f0",
+        "role": "Activates the currently pointed visible mech-list row through the shared paged mech-list input path.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-paged-mech-list"
+        ]
+      },
+      "World_RedrawPagedMechListWindow_v129": {
+        "binary": "FUN_00423350",
+        "role": "Repaints the current page of four visible mech-list slots, centered captions, footer text, and paging controls.",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-paged-mech-list"
+        ]
+      },
+      "World_RedrawPagedMechListChoiceLabels_v129": {
+        "binary": "FUN_004237a0",
+        "role": "Redraws the per-slot secondary choice labels for the visible paged mech-list entries and presents the updated window.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-paged-mech-list"
+        ]
+      },
+      "World_DrawPagedMechListShellFrame_v129": {
+        "binary": "FUN_004238e0",
+        "role": "Draws the static shell bitmap frame used under the retail paged mech-list window.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-paged-mech-list"
+        ]
+      },
+      "World_OpenPagedMechListWindow_v129": {
+        "binary": "FUN_004239f0",
+        "role": "Creates the shared four-slot paged mech-list window used by the late-world cmd26/cmd27/cmd32 chooser family.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-paged-mech-list"
+        ]
+      },
+      "World_Cmd26_ParseMechList_v129": {
+        "binary": "FUN_00423df0",
+        "role": "Mech list parser that feeds the mech-selection flow.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-paged-mech-list",
+          "mech-runtime-init"
+        ]
+      },
+      "World_Cmd32_AlternateRankingList_v129": {
+        "binary": "FUN_00423fa0",
+        "role": "Alternate ranking-style list parser.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-paged-mech-list"
+        ]
+      },
+      "World_Cmd27_AlternateMechChooser_v129": {
+        "binary": "FUN_00424130",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-paged-mech-list"
+        ]
+      },
+      "World_SendPagedMechListControlFrame_v129": {
+        "binary": "FUN_00424300",
+        "role": "Sends the cmd1d control-frame actions used by the paged mech-list footer buttons and alternate-choice submit path.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-paged-mech-list"
+        ]
+      },
+      "World_PagedMechList_HandleInput_v129": {
+        "binary": "FUN_00424410",
+        "role": "Handles confirm, cancel, paging, selection movement, alternate-choice cycling, and examine input for the shared paged mech-list window.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-paged-mech-list"
+        ]
+      },
+      "World_GetMechDetailRowCount_v129": {
+        "binary": "FUN_00424860",
+        "role": "Returns the total number of detail rows available for the active mech detail record.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-mech-management-pages"
+        ]
+      },
+      "World_GetMechDetailRowSection_v129": {
+        "binary": "FUN_004248a0",
+        "role": "Classifies a retail mech-detail row index into its backing section and base offset.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-mech-management-pages"
+        ]
+      },
+      "World_SetMechDetailRowConditionValue_v129": {
+        "binary": "FUN_004249c0",
+        "role": "Stores one decoded retail condition value into the correct mech-detail row backing array.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-mech-management-pages"
+        ]
+      },
+      "World_MechStatusOptionPage_SubmitSelection_v129": {
+        "binary": "FUN_00424a50",
+        "role": "Submit handler for the mech-status option hub.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser",
+          "world-mech-management-pages"
+        ]
+      },
+      "World_MechStatusOptionPage_HandleActionHotkey_v129": {
+        "binary": "FUN_00424af0",
+        "role": "Hotkey/control helper for the mech-status option hub.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-mech-management-pages"
+        ]
+      },
+      "World_CloseMechStatusOptionPage_v129": {
+        "binary": "FUN_00424b60",
+        "role": "Closes the active mech-status option page window and restores the normal arrow cursor.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-mech-management-pages"
+        ]
+      },
+      "World_DrawMechManagementListSelectionHighlight_v129": {
+        "binary": "FUN_00424b90",
+        "role": "Applies the highlighted palette state for the currently selected wide mech-management row.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-mech-management-pages"
+        ]
+      },
+      "World_ClearMechManagementListSelectionHighlight_v129": {
+        "binary": "FUN_00424c00",
+        "role": "Restores the non-highlighted palette state for the previously selected wide mech-management row.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-mech-management-pages"
+        ]
+      },
+      "World_UpdateMechManagementListSelectionHighlight_v129": {
+        "binary": "FUN_00424c70",
+        "role": "Shared selection-highlight callback for the mech component-action and buy-extra-ammo list pages.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-mech-management-pages"
+        ]
+      },
+      "World_MechComponentActionPage_HandlePointer_v129": {
+        "binary": "FUN_00424cb0",
+        "role": "Pointer handler for the mech component-action page.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-mech-management-pages"
+        ]
+      },
+      "World_MechStatusOptionPage_GetWeaponRangeBandIndex_v129": {
+        "binary": "FUN_00424e60",
+        "role": "Buckets one mech-status weapon entry into the short, medium, or long range band used by the retail status page.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-mech-management-pages"
+        ]
+      },
+      "World_MechStatusOptionPage_ClassifyWeaponDamageTier_v129": {
+        "binary": "FUN_00424ec0",
+        "role": "Maps a mech-status weapon entry onto the four retail damage tiers used by the status page.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-mech-management-pages"
+        ]
+      },
+      "World_MechStatusOptionPage_GetWeaponDamageTierLabel_v129": {
+        "binary": "FUN_00424f70",
+        "role": "Returns the retail text label for one mech-status weapon damage tier bucket.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-mech-management-pages"
+        ]
+      },
+      "World_Cmd30_MechStatusOptionPage_v129": {
+        "binary": "FUN_00424fb0",
+        "role": "Mech status option page in the Solaris mech-management family.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "mech-runtime-init",
+          "world-mech-management-pages"
+        ]
+      },
+      "World_MechComponentActionPage_GetConditionPercentColor_v129": {
+        "binary": "FUN_00425b90",
+        "role": "Maps a component-action row condition percentage onto the retail text color used by the page.",
+        "xrefs": 14,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-mech-management-pages"
+        ]
+      },
+      "World_GetMechDetailRowConditionPercent_v129": {
+        "binary": "FUN_00425bd0",
+        "role": "Returns the normalized condition percentage for one mech-detail row on the component-action page.",
+        "xrefs": 14,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-mech-management-pages"
+        ]
+      },
+      "World_Cmd31_MechComponentActionPage_v129": {
+        "binary": "FUN_00425d60",
+        "role": "Mech component action page / maintenance submenu.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "mech-runtime-init",
+          "world-mech-management-pages"
+        ]
+      },
+      "World_MechComponentActionPage_HandleActionHotkey_v129": {
+        "binary": "FUN_00426ef0",
+        "role": "Hotkey action handler for the mech component-action page.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-mech-management-pages"
+        ]
+      },
+      "World_MechComponentActionPage_HandleKey_v129": {
+        "binary": "FUN_00426f90",
+        "role": "Keyboard handler for the mech component-action page.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-mech-management-pages"
+        ]
+      },
+      "World_GetMechDetailRowLabel_v129": {
+        "binary": "FUN_00427290",
+        "role": "Builds the display label string for one selected mech-detail row.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-mech-management-pages"
+        ]
+      },
+      "World_MechComponentActionPage_UpdateSelectionHeader_v129": {
+        "binary": "FUN_004274d0",
+        "role": "Refreshes the mech component-action page header/detail strip for the currently selected row.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-mech-management-pages"
+        ]
+      },
+      "World_BuyExtraAmmoList_HandlePointer_v129": {
+        "binary": "FUN_004275f0",
+        "role": "Pointer handler for the buy-extra-ammo selection list.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-mech-management-pages"
+        ]
+      },
+      "World_Cmd39_BuyExtraAmmoList_v129": {
+        "binary": "FUN_00427730",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-mech-management-pages"
+        ]
+      },
+      "World_BuyExtraAmmoList_HandleKey_v129": {
+        "binary": "FUN_00427a40",
+        "role": "Keyboard handler for the buy-extra-ammo selection list.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-mech-management-pages"
+        ]
+      },
+      "World_ClearPagedMechListAndComponentActionFlags_v129": {
+        "binary": "FUN_00427bc0",
+        "role": "Clears the active state bits shared by the paged mech-list window and the mech component-action page.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch",
+          "world-mech-management-pages"
+        ]
+      },
+      "Combat_MultiplyFixedMatrix4x4_v129": {
+        "binary": "FUN_00427bd0",
+        "role": "Multiplies two retail 4x4 fixed-point transform matrices into an output matrix.",
+        "xrefs": 8,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-transform-math"
+        ]
+      },
+      "Combat_CopyFixedMatrix4x4_v129": {
+        "binary": "FUN_00427f30",
+        "role": "Copies one retail 4x4 fixed-point transform matrix into another buffer.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-transform-math"
+        ]
+      },
+      "Combat_BuildInverseAffineMatrix4x4_v129": {
+        "binary": "FUN_00427f60",
+        "role": "Builds the retail inverse-affine 4x4 transform used to move points from world space into local combat space.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-transform-math"
+        ]
+      },
+      "Combat_SetFixedMatrix4x4Identity_v129": {
+        "binary": "FUN_00427fd0",
+        "role": "Initializes a retail 4x4 fixed-point matrix to the identity transform.",
+        "xrefs": 20,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-transform-math"
+        ]
+      },
+      "Combat_ApplyEulerRotationTripletToMatrix4x4_v129": {
+        "binary": "FUN_00428070",
+        "role": "Applies a three-angle Euler rotation triplet onto an existing retail 4x4 transform matrix.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-transform-math"
+        ]
+      },
+      "Combat_RotateMatrix4x4AroundX_v129": {
+        "binary": "FUN_00428370",
+        "role": "Rotates a retail 4x4 transform matrix around the X axis by one fixed-point angle.",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-transform-math"
+        ]
+      },
+      "Combat_RotateMatrix4x4AroundY_v129": {
+        "binary": "FUN_00428450",
+        "role": "Rotates a retail 4x4 transform matrix around the Y axis by one fixed-point angle.",
+        "xrefs": 7,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-transform-math"
+        ]
+      },
+      "Combat_RotateMatrix4x4AroundZ_v129": {
+        "binary": "FUN_00428530",
+        "role": "Rotates a retail 4x4 transform matrix around the Z axis by one fixed-point angle.",
+        "xrefs": 15,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-transform-math"
+        ]
+      },
+      "Combat_ScaleMatrix4x4Axes_v129": {
+        "binary": "FUN_00428610",
+        "role": "Applies per-axis fixed-point scale factors to the X, Y, and Z columns of a retail 4x4 transform matrix.",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-transform-math"
+        ]
+      },
+      "Combat_TranslateMatrix4x4Local_v129": {
+        "binary": "FUN_004286c0",
+        "role": "Applies a local-space translation onto a retail 4x4 transform matrix.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-transform-math"
+        ]
+      },
+      "Combat_RenderModelAttachments_v129": {
+        "binary": "FUN_00428770",
+        "role": "Transforms, depth-sorts, and renders a model's attachment list while updating the model's projected screen bounds.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-transform-math",
+          "combat-actor-preview",
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_BuildActorAnimationPose_v129": {
+        "binary": "FUN_00428990",
+        "role": "Builds the final animation pose for a combat actor.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-fall",
+          "combat-transform-math",
+          "combat-animation-pose-sampling",
+          "combat-actor-preview"
+        ]
+      },
+      "Combat_InterpolateAnimationTranslationTriplet_v129": {
+        "binary": "FUN_00428ab0",
+        "role": "Samples one animation state's translation track at the requested frame and writes the interpolated X/Y/Z triplet.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-pose-sampling"
+        ]
+      },
+      "Combat_InterpolateAnimationEulerAngles_v129": {
+        "binary": "FUN_00428bc0",
+        "role": "Samples one animation state's rotation track, resolves angle wraparound, and converts the result into the retail fixed-angle triplet.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-pose-sampling"
+        ]
+      },
+      "Combat_FindAnimationStateDefinitionById_v129": {
+        "binary": "FUN_00428d50",
+        "role": "Looks up an animation-state definition by id.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-fall",
+          "combat-animation-pose-sampling"
+        ]
+      },
+      "Combat_UpdateAnimationControllerProgress_v129": {
+        "binary": "FUN_00428d80",
+        "role": "Advances combat animation-controller progress.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-fall",
+          "combat-animation-pose-sampling"
+        ]
+      },
+      "Combat_BuildAnimationNodePoseRecursive_v129": {
+        "binary": "FUN_00428e10",
+        "role": "Recursively resolves animation-node pose state.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-fall",
+          "combat-transform-math",
+          "combat-animation-pose-sampling"
+        ]
+      },
+      "Combat_AllocateTransformAnimation_v129": {
+        "binary": "FUN_00428fb0",
+        "role": "Allocates the retail transform-animation state table and per-state translation/rotation track buffers.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-pose-sampling",
+          "combat-animation-instance-lifecycle"
+        ]
+      },
+      "Combat_SetActorAnimationState_v129": {
+        "binary": "FUN_004292d0",
+        "role": "Central combat actor animation-state setter.",
+        "xrefs": 12,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-fall"
+        ]
+      },
+      "Combat_AdvanceAnimationControllerState_v129": {
+        "binary": "FUN_00429810",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-fall"
+        ]
+      },
+      "World_Cmd52_RejectShortcutBinding_v129": {
+        "binary": "FUN_004298b0",
+        "role": "Rejects a pending shortcut binding, removes the optimistic local row, and reports the failure dialog.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_Cmd53_ConfirmShortcutBinding_v129": {
+        "binary": "FUN_00429970",
+        "role": "Confirms a pending shortcut binding and replaces the optimistic marker with the final Alt-key assignment.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_RegisterShortcutBinding_v129": {
+        "binary": "FUN_00429a40",
+        "role": "Registers a world shortcut / hotkey binding.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_RemoveShortcutBindingAtIndex_v129": {
+        "binary": "FUN_00429b10",
+        "role": "Removes one locally cached shortcut-binding row by table index and persists the updated shortcut list.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "Combat_ResetActorLookupState_v129": {
+        "binary": "FUN_00429b50",
+        "role": "Clears the shared actor-id lookup state and transient effect scratch globals used by retail combat sync.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-visual-bootstrap"
+        ]
+      },
+      "Combat_Cmd64_AddActor_v129": {
+        "binary": "FUN_00429bb0",
+        "role": "Creates or seeds a remote combatant slot with pilot/mech data.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-instance-lifecycle"
+        ]
+      },
+      "Combat_Cmd62_StartCombat_v129": {
+        "binary": "FUN_0042a010",
+        "role": "Begins the combat scene / combat session.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd"
+      },
+      "Combat_Cmd65_UpdateActorPosition_v129": {
+        "binary": "FUN_0042a050",
+        "role": "Primary remote actor position-sync handler.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd"
+      },
+      "Combat_SendLocalMotionUpdate_v129": {
+        "binary": "FUN_0042a4f0",
+        "role": "Packages the periodic retail local-motion update after the local actor pose has been integrated for the current combat tick.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_Cmd66_ActorDamageUpdate_v129": {
+        "binary": "FUN_0042a6a0",
+        "role": "Remote actor damage-state update.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_Cmd67_LocalDamageUpdate_v129": {
+        "binary": "FUN_0042a6e0",
+        "role": "Local actor damage-state update.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_ApplyDamagePairOrQueueEffect_v129": {
+        "binary": "FUN_0042a700",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_SpawnInternalStructureDestructionEffect_v129": {
+        "binary": "FUN_0042a890",
+        "role": "Spawns the retail destruction effect for a fully depleted internal-structure row.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "Combat_ApplyDamageCodeValue_v129": {
+        "binary": "FUN_0042a990",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_SendWeaponEffectUpdate_v129": {
+        "binary": "FUN_0042aae0",
+        "role": "Appends one outbound retail weapon/effect update frame with source-target bytes plus angle and XYZ payload.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_Cmd73_UpdateActorRateFields_v129": {
+        "binary": "FUN_0042aba0",
+        "role": "Stores scaled short control/aim/offset values into the combat actor table.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd"
+      },
+      "Combat_Cmd68_SpawnWeaponEffect_v129": {
+        "binary": "FUN_0042ac60",
+        "role": "Weapon/effect update that reads source-target ids plus angle and XYZ fields.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_Cmd69_ImpactEffectAtCoord_v129": {
+        "binary": "FUN_0042ae50",
+        "role": "Projectile / sound / impact update with XYZ fields and local-distance checks.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_Cmd70_ActorAnimState_v129": {
+        "binary": "FUN_0042b000",
+        "role": "Combat state/animation control packet.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-fall"
+        ]
+      },
+      "Combat_SendLocalMechContactUpdate_v129": {
+        "binary": "FUN_0042b380",
+        "role": "Sends the retail local-mech contact update for the remote actor hit by the local collision response.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-contact"
+        ]
+      },
+      "Combat_Cmd71_ResetEffectState_v129": {
+        "binary": "FUN_0042b400",
+        "role": "Resets combat effect state after transient effect packets.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_SendCmd12Action_v129": {
+        "binary": "FUN_0042b440",
+        "role": "Outbound combat action sender for client cmd12 control frames.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd"
+      },
+      "Combat_NoOpMissedPacketLog_v129": {
+        "binary": "FUN_0042b460",
+        "role": "Compiled-out missed-packet logger sink used by a few combat packet handlers on retail fallback/error paths.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_Cmd61_SetVoiceTransmissionTuneToChannelId_v129": {
+        "binary": "FUN_0042b470",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_Cmd60_UpdateActorVoiceTransmissionState_v129": {
+        "binary": "FUN_0042b4e0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_Cmd59_ConfigureVoiceTransmission_v129": {
+        "binary": "FUN_0042b550",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_SendVoiceTransmissionActorState_v129": {
+        "binary": "FUN_0042b5c0",
+        "role": "Encodes and flushes the outbound combat voice-transmission actor-state command.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_SendVoiceTransmissionTuneToChannelId_v129": {
+        "binary": "FUN_0042b600",
+        "role": "Encodes and flushes the outbound combat voice-transmission tune/channel-selection command.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Frame_AllocateRasterMaskBuffer_v129": {
+        "binary": "FUN_0042b640",
+        "role": "Allocates a zeroed byte-mask raster plus the small width/height bookkeeping header used by the filled-sector renderer.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_FreeRasterMaskBuffer_v129": {
+        "binary": "FUN_0042b6b0",
+        "role": "Releases the scratch raster-mask buffer allocated for filled circle-sector rendering.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_FreeBitmapFontDescriptor_v129": {
+        "binary": "FUN_0042b6d0",
+        "role": "Releases one retail bitmap font descriptor and its loaded TFONT data blob.",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_GetGlyphAdvance_v129": {
+        "binary": "FUN_0042b720",
+        "role": "Returns the horizontal advance for one glyph in the selected retail font table.",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-actor-preview",
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_LoadBitmapFontDescriptor_v129": {
+        "binary": "FUN_0042b730",
+        "role": "Loads a retail TFONT data file into a font descriptor and precomputes the printable glyph advances.",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_InitializeBitmapFontDescriptorAdvances_v129": {
+        "binary": "FUN_0042b830",
+        "role": "Builds the cached printable glyph-advance table for a loaded retail bitmap font descriptor.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Shell_StartInactivityShutdownTimer_v129": {
+        "binary": "FUN_0042b870",
+        "role": "Starts the retail inactivity shutdown timer and records the current activity tick.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_StopInactivityShutdownTimer_v129": {
+        "binary": "FUN_0042b8b0",
+        "role": "Stops the retail inactivity shutdown timer when the frontend shell is being torn down.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_HandleInactivityShutdownTimer_v129": {
+        "binary": "FUN_0042b8d0",
+        "role": "Timer callback that warns about prolonged frontend inactivity and eventually forces the retail idle shutdown.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_OpenInactivityShutdownWarningDialog_v129": {
+        "binary": "FUN_0042b9a0",
+        "role": "Opens the small modeless warning dialog shown shortly before the retail inactivity shutdown fires.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_InactivityShutdownDialogProc_v129": {
+        "binary": "FUN_0042b9d0",
+        "role": "Dialog procedure for the retail inactivity shutdown warning prompt.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Combat_SetLocalControlActionPressedState_v129": {
+        "binary": "FUN_0042ba60",
+        "role": "Sets or clears the held-state bit for one continuous retail local-control action.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_LookupBoundKeyAction_v129": {
+        "binary": "FUN_0042bcc0",
+        "role": "Resolves a retail combat action id from the current keyboard-binding tables using an encoded key plus modifier mask.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_InitializeJoystickBindingLookupTables_v129": {
+        "binary": "FUN_0042bd20",
+        "role": "Loads or migrates the retail joystick keymap when needed, then rebuilds the runtime lookup tables used to resolve bound joystick actions.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_JoystickBindingDialogProc_v129": {
+        "binary": "FUN_0042bf60",
+        "role": "Handles the retail joystick binding-assignment dialog for buttons, POV directions, and axis channels.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_FormatJoystickBindingLabel_v129": {
+        "binary": "FUN_0042c7a0",
+        "role": "Formats a retail joystick binding code into the human-readable label shown by the joystick dialogs.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_HasDuplicateJoystickBindings_v129": {
+        "binary": "FUN_0042c8b0",
+        "role": "Returns whether the active retail joystick action-binding table contains any duplicate assignments.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_RebuildJoystickConflictList_v129": {
+        "binary": "FUN_0042c910",
+        "role": "Recomputes the retail joystick binding-conflict list and repopulates the dialog list box with the duplicate assignments.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_JoystickConfigDialogProc_v129": {
+        "binary": "FUN_0042ca40",
+        "role": "Handles the retail joystick-configuration dialog lifecycle, selection changes, assignment edits, and apply/reset actions.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_SaveJoystickKeymap_v129": {
+        "binary": "FUN_0042d120",
+        "role": "Writes the current retail joystick/keymap tables to `keymap.bin` and returns whether every table write succeeded.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_LoadJoystickKeymap_v129": {
+        "binary": "FUN_0042d1e0",
+        "role": "Loads the retail joystick/keymap tables from `keymap.bin`, falling back to the built-in defaults when the file is absent or malformed.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_ComputeActorBearingToActor_v129": {
+        "binary": "FUN_0042d610",
+        "role": "Computes the retail planar bearing from one actor to another in the engine's signed heading units.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-contact"
+        ]
+      },
+      "Combat_ComputeActorSubsystemEffectivenessTotals_v129": {
+        "binary": "FUN_0042d6d0",
+        "role": "Accumulates one actor's non-weapon subsystem effectiveness totals and returns both the baseline total and the missing amount.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_ComputeActorWeaponEffectivenessTotals_v129": {
+        "binary": "FUN_0042d740",
+        "role": "Accumulates one actor's weapon effectiveness totals and returns both the baseline value and the unavailable-weapon deficit.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_ComputeActorEffectivenessScore_v129": {
+        "binary": "FUN_0042d850",
+        "role": "Computes a normalized remaining combat-effectiveness score for one actor from armor, weapon, and component losses.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_CompareActorRelativeEffectiveness_v129": {
+        "binary": "FUN_0042d990",
+        "role": "Compares two actors by normalized remaining combat effectiveness and returns a scaled ratio.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_StepLasrRelativeEffectivenessState_v129": {
+        "binary": "FUN_0042da50",
+        "role": "Steps the LASR relative-advantage state one slot up or down from the previous effectiveness ratio.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_ResetLasrRelativeEffectivenessState_v129": {
+        "binary": "FUN_0042dab0",
+        "role": "Resets the stored LASR relative-effectiveness ratio and state latch to their drop-scene defaults.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_AreActorsWithinAnyWeaponRange_v129": {
+        "binary": "FUN_0042dad0",
+        "role": "Checks whether either actor currently sits within any configured weapon range band of the other.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Combat_AutoSelectLasrSoundState_v129": {
+        "binary": "FUN_0042dbe0",
+        "role": "Auto-selects the retail LASR sound state from the current target, nearest hostile, and range/visibility rules.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-lasr-sound"
+        ]
+      },
+      "Shell_FreeMessageCatalog_v129": {
+        "binary": "FUN_0042dd80",
+        "role": "Frees one loaded retail message-catalog slot and clears the active selection when that same slot was selected.",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_GetActiveMessageCatalogIndex_v129": {
+        "binary": "FUN_0042de10",
+        "role": "Returns the currently active retail message-catalog slot index, or `-1` when no catalog is selected.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_GetActiveMessageCatalogLine_v129": {
+        "binary": "FUN_0042de30",
+        "role": "Returns one 1-based line from the active retail message-catalog section, falling back to the explicit `\\",
+        "xrefs": 100,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_LoadMessageCatalog_v129": {
+        "binary": "FUN_0042de80",
+        "role": "Loads an `END`-delimited retail message catalog file into one frontend catalog slot and optionally selects an initial section.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_SelectMessageCatalog_v129": {
+        "binary": "FUN_0042e130",
+        "role": "Selects one loaded retail message-catalog slot as the active shell text source.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_SelectMessageCatalogSection_v129": {
+        "binary": "FUN_0042e170",
+        "role": "Selects one section inside a loaded retail message catalog and updates the active section pointer.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_ParseComstarIdCode_v129": {
+        "binary": "FUN_0042e1e0",
+        "role": "Parses a five-character retail ComStar ID code into the corresponding numeric ID, returning `-1` on invalid or out-of-range input.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "System_FormatComstarIdCode_v129": {
+        "binary": "FUN_0042e240",
+        "role": "Formats one retail numeric ComStar ID into its zero-padded five-character display code.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-modal-pages"
+        ]
+      },
+      "System_Base36StringToInt_v129": {
+        "binary": "FUN_0042e300",
+        "role": "Converts a short ASCII base36 string into an integer, logging invalid digits and overflow through the retail debug stream.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "System_IntToBase36String_v129": {
+        "binary": "FUN_0042e450",
+        "role": "Converts a non-negative integer into an upper-case base36 string stored in a shared static buffer.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-modal-pages"
+        ]
+      },
+      "System_ToggleCaptureLog_v129": {
+        "binary": "FUN_0042e530",
+        "role": "Toggles the shared retail capture log file and posts the corresponding begin/end status lines.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control",
+          "shell-state-dispatch"
+        ]
+      },
+      "System_WriteCaptureLogEntry_v129": {
+        "binary": "FUN_0042e620",
+        "role": "Appends one formatted entry to `btcap_log` while the shared retail capture bit is enabled.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_SendHeartbeat_v129": {
+        "binary": "FUN_0042e690",
+        "role": "Sends the retail shell heartbeat command appropriate for the active world or combat state.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Frame_DecodeStringArg_v129": {
+        "binary": "FUN_0042e720",
+        "role": "Decodes a retail string argument into a caller-owned buffer and returns its length.",
+        "xrefs": 22,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-protocol-codec"
+        ]
+      },
+      "Frame_DecodeType1StringArg_v129": {
+        "binary": "FUN_0042e780",
+        "role": "Decodes a retail type1-length string argument into a caller-owned buffer and returns its length.",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-protocol-codec"
+        ]
+      },
+      "Shell_HandleReceivedMessage_v129": {
+        "binary": "FUN_0042e7e0",
+        "role": "Handles a retail inbound message payload by routing it to the world shell console or the combat transmission history.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_EncodeRpsPreambleStateByte_v129": {
+        "binary": "FUN_0042e940",
+        "role": "Encodes one outbound Solaris RPS pre-dispatch state byte pair.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_HandleRpsPreambleStateByte_v129": {
+        "binary": "FUN_0042e960",
+        "role": "Processes the Solaris RPS pre-dispatch state byte that precedes ordinary inbound shell commands.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "World_Cmd05_SetArrowCursor_v129": {
+        "binary": "FUN_0042e9b0",
+        "role": "Dispatches the early-world command that restores the arrow cursor mode.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd"
+      },
+      "World_Cmd06_SetWaitCursor_v129": {
+        "binary": "FUN_0042e9c0",
+        "role": "Dispatches the early-world command that switches the frontend into wait-cursor mode.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd"
+      },
+      "World_Cmd09_OpenNumberedTextSelection_v129": {
+        "binary": "FUN_0042e9d0",
+        "role": "Decodes and opens the older numbered text-selection modal from a streamed string list.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-modal-pages"
+        ]
+      },
+      "World_Cmd10_ParseCachedNamedEntryList_v129": {
+        "binary": "FUN_0042ea30",
+        "role": "Parses the early-world cached named-entry list and emits a compact summary line into the live shell text surface.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-cached-entry-list"
+        ]
+      },
+      "World_FindCachedNamedEntrySlotById_v129": {
+        "binary": "FUN_0042ec60",
+        "role": "Finds the cached named-entry slot for a retail id inside the early-world entry table.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-cached-entry-list"
+        ]
+      },
+      "World_Cmd11_UpdateCachedNamedEntryText_v129": {
+        "binary": "FUN_0042ec90",
+        "role": "Updates the cached text for one named entry id and appends the corresponding shell log line.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-cached-entry-list"
+        ]
+      },
+      "World_Cmd12_UpdateCachedNamedEntryState_v129": {
+        "binary": "FUN_0042ed90",
+        "role": "Updates the per-entry state for one cached named entry and appends the matching shell status line.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-cached-entry-list"
+        ]
+      },
+      "World_Cmd13_StoreCachedNamedEntry_v129": {
+        "binary": "FUN_0042eff0",
+        "role": "Stores or updates one cached named entry record and appends the corresponding shell line when the text surface is live.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-cached-entry-list"
+        ]
+      },
+      "World_ScrollListShell_HandleInput_v129": {
+        "binary": "FUN_0042f140",
+        "role": "Keyboard handler for the retail Cmd45 scroll-list shell, including row movement, MORE paging, and submit behavior.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_ScrollListShell_HandleMouse_v129": {
+        "binary": "FUN_0042f360",
+        "role": "Pointer handler for the retail Cmd45 scroll-list shell, covering hover selection, click submit, and close-on-activate behavior.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_ScrollListShell_ToggleRowHighlight_v129": {
+        "binary": "FUN_0042f4d0",
+        "role": "Inverts the palette-highlight rectangle for one visible Cmd45 scroll-list row.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_ScrollListShell_UpdateSelectionHighlight_v129": {
+        "binary": "FUN_0042f530",
+        "role": "Selection-change callback for the retail Cmd45 scroll-list shell.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_Cmd58_SetScrollListId_v129": {
+        "binary": "FUN_0042f5a0",
+        "role": "Companion helper that latches the current scroll-list id for Cmd45.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_Cmd45_ScrollListShell_v129": {
+        "binary": "FUN_0042f5b0",
+        "role": "Decodes the retail Cmd45 scroll-list shell, populates its visible rows, and installs the shared keyboard, mouse, and selection callbacks.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_ClearScrollListShellActiveFlag_v129": {
+        "binary": "FUN_0042f910",
+        "role": "Clears the active-bit for the shared Cmd45 scroll-list shell window.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch",
+          "world-travel-browser"
+        ]
+      },
+      "Combat_SendVoiceTransmissionText_v129": {
+        "binary": "FUN_0042f920",
+        "role": "Sends one combat voice-transmission text payload through the retail outbound shell buffer.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Shell_SendOutboundCommand06ByteArg_v129": {
+        "binary": "FUN_0042f950",
+        "role": "Emits outbound retail shell command opcode `0x06` with one encoded byte argument and flushes the completed command frame.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "World_SendByteSelection_v129": {
+        "binary": "FUN_0042f970",
+        "role": "Sends the compact one-byte world selection response used by older popup/list handlers.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "World_SendMenuSelection_v129": {
+        "binary": "FUN_0042f990",
+        "role": "Ordinary world list-submit helper that assembles outbound Cmd7 menu selections.",
+        "xrefs": 21,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser",
+          "world-paged-mech-list"
+        ]
+      },
+      "World_SendTransientNoticeResponse_v129": {
+        "binary": "FUN_0042f9c0",
+        "role": "Sends the response frame for an interactive transient notice.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-transient-notice-queue"
+        ]
+      },
+      "World_SendLegacySelectionResponse_v129": {
+        "binary": "FUN_0042fa00",
+        "role": "Sends the old cmd10-family world selection response with a command id and type4 payload value.",
+        "xrefs": 10,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-modal-pages",
+          "world-selection-dialogs"
+        ]
+      },
+      "World_SendLegacyTextResponse_v129": {
+        "binary": "FUN_0042fa30",
+        "role": "Sends the old cmd08-family world text response with a command id and byte-counted string payload.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-modal-pages"
+        ]
+      },
+      "Shell_AppendBannerStateChangeControlFrame_v129": {
+        "binary": "FUN_0042fa60",
+        "role": "Appends the direct retail state-change control frame used by the pre/post-version banner transition handlers.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "World_SendNumberedTextSelectionResponse_v129": {
+        "binary": "FUN_0042fab0",
+        "role": "Sends the response frame for the older numbered text-selection dialog.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-modal-pages"
+        ]
+      },
+      "World_SendPagedMechListAlternateChoiceTable_v129": {
+        "binary": "FUN_0042fae0",
+        "role": "Sends the alternate-choice table selected from the retail paged mech-list window.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-paged-mech-list"
+        ]
+      },
+      "Shell_SendCmpDialogCommand_v129": {
+        "binary": "FUN_0042fb50",
+        "role": "Sends one immediate CMP dialog command opcode and an optional type1 text payload, then flushes it immediately.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "comstar-messaging"
+        ]
+      },
+      "Frame_DecodeType1Arg_v129": {
+        "binary": "FUN_0042fb80",
+        "role": "Decodes one retail type1 integer argument from the active packet cursor.",
+        "xrefs": 17,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-protocol-codec"
+        ]
+      },
+      "Frame_EncodeType1Arg_v129": {
+        "binary": "FUN_0042fb90",
+        "role": "Thin wrapper that encodes a retail type1 integer argument into the outbound command buffer.",
+        "xrefs": 8,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-protocol-codec"
+        ]
+      },
+      "World_Cmd59_FailStub_v129": {
+        "binary": "FUN_0042fba0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd"
+      },
+      "Shell_RespondToFrq_v129": {
+        "binary": "FUN_0042fbb0",
+        "role": "Responds to the retail FRQ request in combat state by sending the cached four-field response payload.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_UpdateCrc32_v129": {
+        "binary": "FUN_0042fcb0",
+        "role": "Updates a running CRC32 accumulator over one byte buffer using the retail non-reflected polynomial stepper.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Combat_SendLocalActorStateChecksum_v129": {
+        "binary": "FUN_0042fd10",
+        "role": "Builds and sends the retail local-actor checksum reply from the inbound challenge seed.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_ApplyChassisTurnInputRate_v129": {
+        "binary": "FUN_0042ff40",
+        "role": "Applies a signed chassis-turn input rate over elapsed time into the local turn accumulator.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_ApplyTorsoYawInputRate_v129": {
+        "binary": "FUN_0042ff80",
+        "role": "Applies a signed torso-yaw input rate over elapsed time into the clamped upper-body yaw accumulator.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_ApplyUpperBodyPitchInputRate_v129": {
+        "binary": "FUN_0042ffe0",
+        "role": "Applies a signed upper-body pitch input rate over elapsed time into the clamped pitch accumulator.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_RecenterUpperBodyAimOffsets_v129": {
+        "binary": "FUN_00430040",
+        "role": "Decays the live torso-yaw and upper-body pitch offsets back toward neutral when direct aim input is idle.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_AccumulateTorsoYawOffset_v129": {
+        "binary": "FUN_00430160",
+        "role": "Accumulates the local torso-yaw offset with retail +/-0x1ffe clamping.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_AccumulateUpperBodyPitchOffset_v129": {
+        "binary": "FUN_004301c0",
+        "role": "Accumulates the local upper-body pitch offset with retail +/-0x1ffe clamping.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Frame_DecodeArg_v129": {
+        "binary": "FUN_00430220",
+        "role": "Decodes a variable-width retail base-85 frame integer from the active packet cursor.",
+        "xrefs": 100,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-protocol-codec",
+          "world-travel-browser",
+          "comstar-messaging"
+        ]
+      },
+      "Frame_EncodeArg_v129": {
+        "binary": "FUN_004302f0",
+        "role": "Encodes a variable-width retail base-85 integer into the outbound command buffer.",
+        "xrefs": 16,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-protocol-codec"
+        ]
+      },
+      "Shell_DispatchValidatedCommandBuffer_v129": {
+        "binary": "FUN_00430400",
+        "role": "Walks a validated shell command payload and dispatches each opcode through the retail handler table.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch",
+          "frame-protocol-codec"
+        ]
+      },
+      "Shell_VerifyEscCommandChecksum_v129": {
+        "binary": "FUN_00430760",
+        "role": "Verifies the rolling checksum on a completed retail shell command buffer using the active shell/combat state seed.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch",
+          "frame-protocol-codec"
+        ]
+      },
+      "Frame_DecodeByteArg_v129": {
+        "binary": "FUN_004308e0",
+        "role": "Decodes one retail `!`-offset byte argument from the active packet cursor.",
+        "xrefs": 34,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-protocol-codec"
+        ]
+      },
+      "Shell_AppendOutboundCommandChecksumTrailer_v129": {
+        "binary": "FUN_004308f0",
+        "role": "Appends the retail checksum/trailer bytes that finalize one outbound shell command frame.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_AppendOutboundCommandOpcode_v129": {
+        "binary": "FUN_004309d0",
+        "role": "Appends one outbound retail shell command opcode into the transmit buffer using the `!`-offset wire encoding.",
+        "xrefs": 32,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch",
+          "frame-protocol-codec"
+        ]
+      },
+      "Frame_EncodeByteArg_v129": {
+        "binary": "FUN_004309f0",
+        "role": "Encodes one raw byte argument into the outbound retail command buffer using the `!`-offset wire format.",
+        "xrefs": 16,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-protocol-codec"
+        ]
+      },
+      "Shell_ResetOutboundCommandBuffer_v129": {
+        "binary": "FUN_00430a10",
+        "role": "Resets the outbound shell command buffer and seeds it with the retail ESC/`!` frame prefix.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch",
+          "frame-protocol-codec"
+        ]
+      },
+      "Frame_EncodeByteCountedStringArg_v129": {
+        "binary": "FUN_00430a40",
+        "role": "Encodes a retail byte-counted string argument into the outbound command buffer.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-protocol-codec"
+        ]
+      },
+      "Frame_EncodeType1StringArg_v129": {
+        "binary": "FUN_00430aa0",
+        "role": "Encodes a retail type1-length string argument into the outbound command buffer.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-protocol-codec"
+        ]
+      },
+      "Frame_DecodeStringSpanArg_v129": {
+        "binary": "FUN_00430b00",
+        "role": "Decodes a retail string argument as a pointer-plus-length span from the active packet cursor.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-protocol-codec"
+        ]
+      },
+      "Frame_DecodeType1StringSpanArg_v129": {
+        "binary": "FUN_00430ba0",
+        "role": "Decodes a retail type1-length string argument as a pointer-plus-length span from the active packet cursor.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-protocol-codec"
+        ]
+      },
+      "Shell_SelectInboundCommandTable_v129": {
+        "binary": "FUN_00430bf0",
+        "role": "Selects the active inbound retail command table and protocol label for the shell's RPS or COMBAT stream.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_IntegerSquareRoot_v129": {
+        "binary": "FUN_00430d00",
+        "role": "Computes the integer square root of a non-negative retail fixed/range accumulator.",
+        "xrefs": 15,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-jump-fuel-hud"
+        ]
+      },
+      "World_ComputeLocationBrowserSelectionDistance_v129": {
+        "binary": "FUN_00430d80",
+        "role": "Computes the scaled map distance from the current browser origin to the selected location entry.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_FormatLocationBrowserSelectionDistanceString_v129": {
+        "binary": "FUN_00430dd0",
+        "role": "Formats the currently selected room's distance string for the location-browser detail panel.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_FormatLocationBrowserDistanceScaleString_v129": {
+        "binary": "FUN_00430e80",
+        "role": "Formats the current location-browser distance scale string shown above the selection details.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_DrawLocationBrowserSelectionMarker_v129": {
+        "binary": "FUN_00430f70",
+        "role": "Draws the current location-browser selection marker in either the standard map or grouped-browser mode.",
+        "xrefs": 8,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_UpdateGroupedLocationBrowserSubmitControlState_v129": {
+        "binary": "FUN_00431060",
+        "role": "Updates the grouped location-browser submit control palette state when the current selection becomes submit-disabled or submit-enabled.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_CloseLocationBrowserWindows_v129": {
+        "binary": "FUN_00431100",
+        "role": "Closes the active location-browser map window pair and clears the browser-open world-shell flag.",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_DrawLocationBrowserWindow_v129": {
+        "binary": "FUN_00431130",
+        "role": "Draws the standard location-browser map window, marker overlay, and compact selection-detail shell.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_DrawGroupedLocationBrowserWindow_v129": {
+        "binary": "FUN_004315a0",
+        "role": "Draws the grouped location-browser map window and its tall aggregated selection-detail shell.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_RedrawLocationBrowserSelectionDetails_v129": {
+        "binary": "FUN_00431800",
+        "role": "Redraws the currently selected location-browser room details into the main map shell and auxiliary detail window.",
+        "xrefs": 10,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_LocationBrowser_HandleMouse_v129": {
+        "binary": "FUN_00431cb0",
+        "role": "Pointer handler for the shared location-browser map window.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_GroupedLocationBrowser_HandleMouse_v129": {
+        "binary": "FUN_00431f70",
+        "role": "Pointer handler for the grouped location-browser map window used by Cmd43.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_IsPointerInGroupedLocationBrowserMarkerBounds_v129": {
+        "binary": "FUN_004322b0",
+        "role": "Hit-tests one grouped location-browser marker rectangle against the current pointer position.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_FindNearestLocationBrowserRoomInDirection_v129": {
+        "binary": "FUN_004322f0",
+        "role": "Finds the nearest selectable location-browser room in the requested directional cone.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_BuildLocationBrowserWindow_v129": {
+        "binary": "FUN_00432450",
+        "role": "Builds the shared location-browser window used by the Solaris travel/browser commands.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_Cmd40_LocationBrowser_v129": {
+        "binary": "FUN_00432540",
+        "role": "Shared world location / scene browser builder.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_Cmd43_GroupedLocationBrowser_v129": {
+        "binary": "FUN_00432800",
+        "role": "Grouped Solaris location browser / travel-mode aggregator.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_LocationBrowser_HandleInput_v129": {
+        "binary": "FUN_00432a10",
+        "role": "Keyboard and hotkey handler for the shared location-browser map window.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_LocationBrowserDistrictList_UpdateSelectionHighlight_v129": {
+        "binary": "FUN_00432d10",
+        "role": "Clears or redraws the currently selected row highlight in the district-scoped location list window.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_LocationBrowserDistrictList_HandleMouse_v129": {
+        "binary": "FUN_00432db0",
+        "role": "Pointer handler for the district-scoped location list window opened from the browser and travel pages.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_Cmd49_MapConnectorOverlay_v129": {
+        "binary": "FUN_004332b0",
+        "role": "Draws a Solaris map connector/path line between two locations.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_Cmd61_MapConnectorOverlayWide_v129": {
+        "binary": "FUN_00433340",
+        "role": "Wide-range variant of the Solaris connector/path overlay family.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_OpenLocationBrowserDistrictListWindow_v129": {
+        "binary": "FUN_004333d0",
+        "role": "Opens the style-7 district-scoped location list window for the currently selected browser room.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_Cmd56_MapRoomMarkerOverlay_v129": {
+        "binary": "FUN_004336a0",
+        "role": "Draws a small highlight box over a room on the Solaris map.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_Cmd60_MapRoomMarkerOverlayWide_v129": {
+        "binary": "FUN_004337f0",
+        "role": "Wide-range variant of the Solaris room-marker overlay.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_Cmd44_SetLocationDistanceScale_v129": {
+        "binary": "FUN_00433940",
+        "role": "Location-browser distance scale / range-setting helper.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd"
+      },
+      "World_CloseLocationBrowserDistrictListWindow_v129": {
+        "binary": "FUN_00433960",
+        "role": "Closes the district-scoped location list window and, when needed, tears down the paired location-browser windows.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_DrawLocationBrowserRoomMarkers_v129": {
+        "binary": "FUN_00433990",
+        "role": "Draws the one-pixel room marker dashes for the standard location-browser map view.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_LoadLocationMapDataFile_v129": {
+        "binary": "FUN_004339f0",
+        "role": "Loads an IS_MAP or SOLARIS_MAP data file into the in-memory location table and bitmap payload.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_FreeLocationMapDataBlock_v129": {
+        "binary": "FUN_00433c40",
+        "role": "Frees one heap-owned location-map data block, including its room-table strings and decoded bitmap.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_FreeLocationMapData_v129": {
+        "binary": "FUN_00433ca0",
+        "role": "Releases the currently loaded location-map data block before a browser/map rebuild.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_EnsureLocationMapIndex_v129": {
+        "binary": "FUN_00433d00",
+        "role": "Ensures the active location-map data is loaded, then rebuilds the filtered per-district index used by the browser/map overlays.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_Cmd50_ClearLocationBrowserSelectionHighlight_v129": {
+        "binary": "FUN_00433ec0",
+        "role": "Calls the shared location-browser highlight callback in clear mode for the currently latched selection.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_Cmd51_DrawLocationBrowserSelectionHighlight_v129": {
+        "binary": "FUN_00433ee0",
+        "role": "Calls the shared location-browser highlight callback in redraw mode for the current selection.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "Shell_ClearFrontendDisplayAndApplyCurrentPalette_v129": {
+        "binary": "FUN_00433f00",
+        "role": "Clears the full frontend display to color 0 and reapplies the current frontend palette table.",
+        "xrefs": 9,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-picture-bootstrap"
+        ]
+      },
+      "Frame_CyclePaletteEntries_v129": {
+        "binary": "FUN_00433f30",
+        "role": "Rotates a contiguous palette range at a fixed tick interval and uploads the updated entries.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Combat_ResetImpactScreenShakeState_v129": {
+        "binary": "FUN_00434000",
+        "role": "Clears the active and queued impact-driven screen-shake banks used by combat rendering.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_QueueImpactScreenShake_v129": {
+        "binary": "FUN_00434020",
+        "role": "Queues one impact-driven screen shake using a damage-class magnitude and caller-supplied duration.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_PollScreenShakeMode_v129": {
+        "binary": "FUN_00434100",
+        "role": "Polls the combat shake banks and returns the currently active screen-shake mode when the next shake tick is due.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_BuildCameraShakeOffsets_v129": {
+        "binary": "FUN_004341b0",
+        "role": "Builds signed screen-shake offsets for the active combat shake mode.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_BuildImpactScreenShakeOffsets_v129": {
+        "binary": "FUN_00434200",
+        "role": "Builds signed X/Y offsets for the active impact-driven screen shake and rolls queued impact shakes forward as they expire.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_ResetWeaponFireScreenShakeState_v129": {
+        "binary": "FUN_00434350",
+        "role": "Clears the weapon-fire screen-shake bank used by combat rendering.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_QueueWeaponFireScreenShake_v129": {
+        "binary": "FUN_00434370",
+        "role": "Queues a fixed-duration weapon-fire screen shake based on the current weapon/effect id.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-weapon-bank-fire",
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_BuildWeaponFireScreenShakeOffsets_v129": {
+        "binary": "FUN_00434430",
+        "role": "Builds signed X/Y offsets for the active weapon-fire screen-shake bank.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_SelectActiveScreenShakeMode_v129": {
+        "binary": "FUN_00434510",
+        "role": "Selects which combat screen-shake bank should drive the current frame when multiple shake banks are armed.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "System_DetectDirectXCapabilityLevel_v129": {
+        "binary": "FUN_00434550",
+        "role": "Probes the OS plus DirectDraw and DirectInput runtime support and returns the retail DirectX capability level code used by frontend startup.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "MakeRandomModulo": {
+        "binary": "FUN_00434930",
+        "role": "Advances the shared retail LCG seed and returns a modulo-bounded pseudo-random value.",
+        "xrefs": 30,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_SetRandomSeed_v129": {
+        "binary": "FUN_00434970",
+        "role": "Stores a new seed value for the shared retail LCG used by MakeRandomModulo.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control",
+          "combat-terrain-scenery",
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_WriteClampedSpriteScaleTableRow_v129": {
+        "binary": "FUN_00434980",
+        "role": "Quantizes one generated sprite-scale table row to bytes, clamps it to the requested scale bound, and writes it to the open `.scl` file.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_GenerateSpriteScaleTableFile_v129": {
+        "binary": "FUN_00434a10",
+        "role": "Builds one sprite-scale table in memory and serializes it as `spr_%d.scl` when the cache file is missing.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_AllocateSpriteScaleTableBuffers_v129": {
+        "binary": "FUN_00434b40",
+        "role": "Allocates the triangular byte buffer and per-row pointer table for one sprite-scale table.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_LoadSpriteScaleTableFile_v129": {
+        "binary": "FUN_00434cb0",
+        "role": "Loads one cached sprite-scale table from an open `.scl` file into the packed runtime buffers.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_ClearSpriteScaleTableCache_v129": {
+        "binary": "FUN_00434d30",
+        "role": "Frees every cached sprite-scale table and resets the small in-memory `.scl` cache.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_GetOrCreateSpriteScaleTable_v129": {
+        "binary": "FUN_00434da0",
+        "role": "Returns the cached sprite-scale table for one scale id, loading `spr_%d.scl` or generating it on first use.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_InitializeEffectAnimationCaches_v129": {
+        "binary": "FUN_00434e60",
+        "role": "Allocates and zeroes the retail combat effect-animation caches before default effect assets are loaded.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_FreeEffectAnimationCaches_v129": {
+        "binary": "FUN_00435070",
+        "role": "Frees the three global combat effect-animation cache buffers and clears their pointers.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "System_CopyCString_v129": {
+        "binary": "FUN_004350d0",
+        "role": "Copies a null-terminated C string, including the trailing zero, from one retail buffer to another.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_FreeDefaultEffectAnimations_v129": {
+        "binary": "FUN_00435100",
+        "role": "Releases the cached default combat effect animations and clears the shared sprite-scale cache.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_LoadDefaultEffectAnimations_v129": {
+        "binary": "FUN_00435130",
+        "role": "Loads the default combat explosion, smoke, and acknowledgement-burst effect animations into the retail effect-animation slots.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_LoadEffectAnimationSlot_v129": {
+        "binary": "FUN_00435340",
+        "role": "Loads one `.anm` effect animation file into the requested retail effect-animation slot.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_FreeEffectAnimationSlot_v129": {
+        "binary": "FUN_00435560",
+        "role": "Frees the palette and pixel payload buffers owned by one retail effect-animation slot.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_SetEffectAnimationSlotScaleLinks_v129": {
+        "binary": "FUN_004355c0",
+        "role": "Sets the smaller/larger scale-neighbor links used when an effect animation slot needs to swap to a better size variant.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_AllocateEffectSpriteAnimationInstance_v129": {
+        "binary": "FUN_00435630",
+        "role": "Claims one live effect-sprite animation instance slot, seeds its timers, and returns the generation-tagged handle.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_RenderEffectSpriteAnimationInstance_v129": {
+        "binary": "FUN_00435750",
+        "role": "Validates, advances, scale-selects, and draws one live effect-sprite animation instance.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_BlitScaledEffectSpriteFrame_v129": {
+        "binary": "FUN_00435a20",
+        "role": "Blits one scaled effect-sprite frame into the combat backbuffer through the retail sprite-scale table.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_ResetActorAnimationCache_v129": {
+        "binary": "FUN_00435c00",
+        "role": "Clears the shared retail actor-animation cache table used to reuse loaded animation assets across actor instances.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-instance-lifecycle"
+        ]
+      },
+      "Combat_AllocateActorAnimationInstance_v129": {
+        "binary": "FUN_00435c20",
+        "role": "Allocates one retail actor animation instance, reusing cached animation object/state resources when available.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-instance-lifecycle",
+          "combat-animation-asset-loading"
+        ]
+      },
+      "Combat_FreeActorAnimationInstance_v129": {
+        "binary": "FUN_004360b0",
+        "role": "Releases one retail actor animation instance and decrements the shared animation-cache reference count.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-instance-lifecycle",
+          "combat-animation-asset-loading"
+        ]
+      },
+      "Combat_SelectActorAnimationStateRecord_v129": {
+        "binary": "FUN_00436180",
+        "role": "Selects one raw actor animation-state record by id and resets the preview controller counters without running the full transition path.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-actor-preview"
+        ]
+      },
+      "Combat_FindActorAnimationTrackByStateTag_v129": {
+        "binary": "FUN_004361f0",
+        "role": "Returns one actor-animation track record from a retail animation instance by state tag.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-instance-lifecycle"
+        ]
+      },
+      "Combat_SetAnimationNodeStatePoseDisabledByTag_v129": {
+        "binary": "FUN_00436240",
+        "role": "Sets or clears the per-node flag that suppresses state-pose interpolation for the tagged animation node.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-fall"
+        ]
+      },
+      "Combat_SetAnimationNodeRotationOffsetEnabledByTag_v129": {
+        "binary": "FUN_004362a0",
+        "role": "Sets or clears the per-node flag that applies the controller's additive rotation-offset triplet to the tagged animation node.",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-fall"
+        ]
+      },
+      "Combat_SetAttachmentSubtreeHiddenStateByTag_v129": {
+        "binary": "FUN_00436300",
+        "role": "Recursively sets or clears the hidden-state bit for one attachment tag and all of its child attachments.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_IsAttachmentTagHidden_v129": {
+        "binary": "FUN_004363a0",
+        "role": "Returns whether an actor's attachment tag is currently hidden in the retail attachment-state bitmask.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_SetActorPreviewSectionStatusColor_v129": {
+        "binary": "FUN_00436420",
+        "role": "Writes one color override into the tagged preview-model section entry used by the actor preview panel.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-actor-preview"
+        ]
+      },
+      "Combat_GetAttachmentTrailColorByTag_v129": {
+        "binary": "FUN_00436470",
+        "role": "Returns the retail trail-strip color associated with one attachment tag.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_GetAttachmentLocalOffsetByTag_v129": {
+        "binary": "FUN_004364c0",
+        "role": "Returns the local attachment offset for one attachment tag in model space.",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_GetAnimationNodeByStateTag_v129": {
+        "binary": "FUN_00436530",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-fall"
+        ]
+      },
+      "Combat_AnimCallback_ClearActorRecoveryBlock_v129": {
+        "binary": "FUN_00436570",
+        "role": "Animation callback that clears the actor recovery block.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-fall"
+        ]
+      },
+      "Combat_SetJumpJetAnimationState_v129": {
+        "binary": "FUN_00436580",
+        "role": "Switches an actor animation controller into the jump-jet / airborne start state.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-fall"
+        ]
+      },
+      "Combat_ClearAirborneFlagsAndSetIdleAnimation_v129": {
+        "binary": "FUN_004365a0",
+        "role": "Clears the retail airborne state bits on an actor record and returns its animation controller to idle.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-fall"
+        ]
+      },
+      "Combat_SetGroundedIdleAnimation_v129": {
+        "binary": "FUN_004365e0",
+        "role": "Marks the actor grounded in the runtime record and switches the animation controller to idle.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-fall"
+        ]
+      },
+      "Combat_SetGroundedMovementAnimation_v129": {
+        "binary": "FUN_00436610",
+        "role": "Marks the actor grounded in the runtime record and switches the animation controller into the ordinary movement loop.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-fall"
+        ]
+      },
+      "Combat_StartFallDownAnim_SetRecoveryBlock_v129": {
+        "binary": "FUN_00436640",
+        "role": "Starts the fall-down animation path and sets the recovery block.",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-fall"
+        ]
+      },
+      "Combat_SetActorAnimationState11_ThenIdle_v129": {
+        "binary": "FUN_00436680",
+        "role": "Starts retail animation state `11` and returns the actor to grounded idle when that intermediate transition completes.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-fall"
+        ]
+      },
+      "Combat_SetActorAnimationState12_ThenIdle_v129": {
+        "binary": "FUN_004366a0",
+        "role": "Starts retail animation state `12` and returns the actor to grounded idle when that intermediate transition completes.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-fall"
+        ]
+      },
+      "Combat_SetActorAnimationState14_ThenFallDown_v129": {
+        "binary": "FUN_004366c0",
+        "role": "Starts retail animation state `14` and chains into the fall-down/recovery-block path when that transition completes.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-fall"
+        ]
+      },
+      "Combat_SetActorAnimationState13_ThenFallDown_v129": {
+        "binary": "FUN_004366e0",
+        "role": "Starts retail animation state `13` and chains into the fall-down/recovery-block path when that transition completes.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-fall"
+        ]
+      },
+      "Combat_AllocateEffectModelEntries_v129": {
+        "binary": "FUN_00436700",
+        "role": "Allocates the fixed retail pool of transient effect-model entries.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_FreeEffectModelEntries_v129": {
+        "binary": "FUN_004367b0",
+        "role": "Frees the fixed retail pool of transient effect-model entries.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_ResetEffectModelEntries_v129": {
+        "binary": "FUN_004367d0",
+        "role": "Clears the active-state flags across the retail transient effect-model pool.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_SpawnAttachmentSubtreeEffectModelsByTag_v129": {
+        "binary": "FUN_00436800",
+        "role": "Recursively spawns detached effect-model entries for one attachment subtree rooted at the requested tag.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_CollectVisibleEffectModels_v129": {
+        "binary": "FUN_00436b60",
+        "role": "Queues the active type-8 model-effect entries that are still alive for the retail effect/render pass.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_RenderEffectModel_v129": {
+        "binary": "FUN_00436c60",
+        "role": "Draws a retail combat effect model resource with the current effect transform.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_UpdateEffectModelEntryMotion_v129": {
+        "binary": "FUN_00436ca0",
+        "role": "Advances one active transient effect-model entry's spin, velocity, and height with the retail damped-falloff rules.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Frame_LoadUnitBitmapByTag_v129": {
+        "binary": "FUN_00436f40",
+        "role": "Loads a unit bitmap by tag from the pre-opened HUNITS.DAT and UNITS.DAT retail archives.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-picture-bootstrap",
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_ResolveInlineBitmapTag_v129": {
+        "binary": "FUN_00436f90",
+        "role": "Resolves a retail inline bitmap token to either a preloaded shared bitmap or a newly loaded unit bitmap.",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-picture-bootstrap",
+          "frame-text-rendering"
+        ]
+      },
+      "Shell_ShowTitleAndCreditsSequence_v129": {
+        "binary": "FUN_00437040",
+        "role": "Shows the retail title and credits bitmap sequence from TITLE.DAT.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-picture-bootstrap",
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_LoadMwPictureArchivesAndTables_v129": {
+        "binary": "FUN_00437380",
+        "role": "Opens MW_MPICS.DAT, preloads the shared bitmap tables, and opens the unit bitmap archives used by retail inline/image surfaces.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-picture-bootstrap",
+          "frame-text-rendering"
+        ]
+      },
+      "Combat_FreeVisualResourceTables_v129": {
+        "binary": "FUN_00437590",
+        "role": "Closes the active combat tagged archives and frees the cached retail combat bitmap tables.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-visual-bootstrap"
+        ]
+      },
+      "Combat_LoadVisualResourceTables_v129": {
+        "binary": "FUN_00437600",
+        "role": "Opens COMBAT.DAT and bulk-loads the combat bitmap/resource tables required by the retail HUD and effect surfaces.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-visual-bootstrap"
+        ]
+      },
+      "Frame_FreeWorldShellBitmapTables_v129": {
+        "binary": "FUN_00438860",
+        "role": "Frees the cached MW_MPICS world-shell bitmap tables and clears their global slots.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-picture-bootstrap"
+        ]
+      },
+      "Frame_FreeWorldShellBitmapTableEntry_v129": {
+        "binary": "FUN_00438af0",
+        "role": "Frees one heap-allocated world-shell bitmap table entry and its owned bitmap payload.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_LoadWorldShellBitmapTables_v129": {
+        "binary": "FUN_00438b20",
+        "role": "Loads the fixed MW_MPICS world-shell bitmap tables into the retail global caches.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-picture-bootstrap",
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_FreeWorldShellDialogBitmapTables_v129": {
+        "binary": "FUN_00439340",
+        "role": "Frees the additional world-shell dialog/subpanel bitmap tables loaded from MW_MPICS and clears their globals.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "World_TickAnimatedShellBitmaps_v129": {
+        "binary": "FUN_004393f0",
+        "role": "Advances and redraws any timed animated shell bitmaps registered for the world-state tick.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Frame_GetCachedBitmapBuffer_v129": {
+        "binary": "FUN_004394e0",
+        "role": "Looks up or loads a cached bitmap buffer by resource name from the requested retail archive.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_LoadBitmapBufferFromArchive_v129": {
+        "binary": "FUN_00439610",
+        "role": "Loads a bitmap resource from an opened retail archive into a heap buffer descriptor.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_FreeLoadedBitmapBuffer_v129": {
+        "binary": "FUN_00439740",
+        "role": "Frees one loaded bitmap-buffer descriptor and the owned heap blocks it carries.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_FreeCachedBitmapBufferCache_v129": {
+        "binary": "FUN_00439780",
+        "role": "Frees the shared cached bitmap-buffer table populated by Frame_GetCachedBitmapBuffer_v129.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_ShowCenteredArchiveBitmap_v129": {
+        "binary": "FUN_004397d0",
+        "role": "Loads a bitmap from a named retail archive, centers it on the active frame, presents it, and releases the temporary bitmap.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-picture-bootstrap",
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_ClearActiveFrameAndPresent_v129": {
+        "binary": "FUN_004398d0",
+        "role": "Clears the active fullscreen frame to palette index 0 and immediately presents it to the display.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-picture-bootstrap",
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_ClearPaletteToBlack_v129": {
+        "binary": "FUN_00439930",
+        "role": "Sets every palette entry in the active frame palette table to black and uploads the full palette.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-picture-bootstrap",
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_ClearPaletteFadeTargetBuffer_v129": {
+        "binary": "FUN_00439970",
+        "role": "Zeroes the shared RGB palette-fade target buffer so the next retail fade interpolates toward black.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-picture-bootstrap"
+        ]
+      },
+      "Combat_ResetEnvironmentRuntimeState_v129": {
+        "binary": "FUN_00439990",
+        "role": "Releases the retail terrain/environment runtime pools, including placed scenery instances, active projectile-effect slots, and the cached terrain object records.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_CollectVisibleTerrainSceneryInstances_v129": {
+        "binary": "FUN_004399f0",
+        "role": "Transforms the active terrain-scenery instances into camera space and queues the ones that are plausibly visible for the retail effect/render pass.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_RenderEffectModelHitProxy_v129": {
+        "binary": "FUN_00439b00",
+        "role": "Renders the auxiliary effect-model hit proxy used by the retail cursor-selection pass and returns whether it was selected.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_RenderTerrainSceneryProjection_v129": {
+        "binary": "FUN_00439b80",
+        "role": "Projects and draws the active terrain-scenery field into either the main combat camera or the tactical radar view.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-tactical-overlays"
+        ]
+      },
+      "Combat_LoadCached3dObjectRecord_v129": {
+        "binary": "FUN_00439e30",
+        "role": "Returns one cached parsed 3d object record by id, loading it from the shared archive path on first use.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-asset-loading",
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_Free3dObjectRecordCache_v129": {
+        "binary": "FUN_00439f30",
+        "role": "Frees the cached 3d object record table and every parsed record it owns.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-asset-loading"
+        ]
+      },
+      "Combat_Free3dObjectRecord_v129": {
+        "binary": "FUN_00439f80",
+        "role": "Frees one parsed 3d object record and all of its nested arrays.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-asset-loading"
+        ]
+      },
+      "Combat_InitializeTerrainSceneryField_v129": {
+        "binary": "FUN_0043a020",
+        "role": "Builds the retail terrain-scenery field for the current combat map and clears the shared indexed-directory cache afterward.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_BuildTerrainSceneryField_v129": {
+        "binary": "FUN_0043a0a0",
+        "role": "Allocates the temporary placement inputs, loads the indexed terrain object table, and assembles the current combat map's terrain-scenery field.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_AllocateTerrainSceneryPlacementBands_v129": {
+        "binary": "FUN_0043a170",
+        "role": "Allocates and seeds the default terrain-scenery placement-band table for the active terrain type.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_FreeTerrainSceneryPlacementBands_v129": {
+        "binary": "FUN_0043a240",
+        "role": "Frees the temporary terrain-scenery placement-band table.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_BuildTerrainSceneryObjectGroups_v129": {
+        "binary": "FUN_0043a270",
+        "role": "Groups indexed terrain object records into scenery-class buckets based on their retail flag bits.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_AllocateTerrainSceneryObjectGroups_v129": {
+        "binary": "FUN_0043a320",
+        "role": "Allocates the four-bucket terrain-scenery object-group table used during placement.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_FreeTerrainSceneryObjectGroups_v129": {
+        "binary": "FUN_0043a3c0",
+        "role": "Frees the temporary terrain-scenery object-group table and any per-bucket id arrays it owns.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_PopulateTerrainSceneryField_v129": {
+        "binary": "FUN_0043a410",
+        "role": "Allocates the final terrain-scenery instance table, chooses random candidates from the grouped records, and seeds each instance's transform and scale.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_AllocateTerrainSceneryInstances_v129": {
+        "binary": "FUN_0043a690",
+        "role": "Allocates the shared terrain-scenery instance array at `DAT_0047f728`.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_PlaceTerrainSceneryInstanceWithoutOverlap_v129": {
+        "binary": "FUN_0043a700",
+        "role": "Chooses a random non-overlapping position and radius for one terrain-scenery instance.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_Compute3dObjectPlanarRadius_v129": {
+        "binary": "FUN_0043a900",
+        "role": "Computes the maximum planar radius of a parsed 3d object record from its vertex table.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_ComputeTerrainSceneryScaleForRadius_v129": {
+        "binary": "FUN_0043a940",
+        "role": "Converts a target scenery radius and raw object extent into the fixed-point uniform scale used by retail terrain object placement.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_SetTerrainAssetSet_v129": {
+        "binary": "FUN_0043a960",
+        "role": "Selects the active retail terrain asset set and formats the matching `terrain\\\\ter_%03d.*` filenames.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_LoadTerrainPaletteOverrides_v129": {
+        "binary": "FUN_0043a9c0",
+        "role": "Loads the selected terrain palette file and seeds missing RGB triples into the shared terrain-scenery color table.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_QueryTerrainScenerySupportAtCoord_v129": {
+        "binary": "FUN_0043aaa0",
+        "role": "Queries the active terrain-scenery field for a supporting face under a world-space coordinate and fills the retail ground-contact record.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-contact"
+        ]
+      },
+      "Combat_FindTerrainSceneryInstanceAtCoord_v129": {
+        "binary": "FUN_0043ad60",
+        "role": "Finds the active terrain-scenery instance whose placement radius contains the given world-space X/Y coordinate.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-contact"
+        ]
+      },
+      "Combat_ComputeTerrainSceneryFaceHeightAtCoord_v129": {
+        "binary": "FUN_0043ae30",
+        "role": "Evaluates the height of a terrain-scenery support face at the given world-space X/Y coordinate.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-contact"
+        ]
+      },
+      "Combat_FindContactMechAtCoord_v129": {
+        "binary": "FUN_0043af10",
+        "role": "Finds another active mech whose collision cylinder overlaps the supplied world-space contact point.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-contact"
+        ]
+      },
+      "Combat_InitializeActiveProjectileEffectSlots_v129": {
+        "binary": "FUN_0043afd0",
+        "role": "Allocates and zeroes the retail active projectile/effect slot pool used by the combat effect update loop.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_UpdateActiveProjectileEffects_v129": {
+        "binary": "FUN_0043b030",
+        "role": "Walks the active projectile/effect pool, advances each live entry, resolves completed impacts, and queues visible effects for rendering.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-transform-math",
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_RenderWeaponEffectModelOrFallback_v129": {
+        "binary": "FUN_0043b250",
+        "role": "Draws a retail weapon effect model when present, otherwise falls back to the weapon-specific sprite/quad renderer.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_UpdateProjectileEffectState_v129": {
+        "binary": "FUN_0043b2a0",
+        "role": "Advances one active projectile/effect toward its impact point, refreshing target-attachment coordinates until the effect lands.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-transform-math",
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_DecodeTerrainSceneryConfig_v129": {
+        "binary": "FUN_0043b650",
+        "role": "Decodes the local-actor terrain-scenery config payload, including scenery class masks and no-place blocker circles.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_FreeTerrainSceneryPlacementBlockerTable_v129": {
+        "binary": "FUN_0043b760",
+        "role": "Frees the decoded terrain-scenery placement blocker table and clears its shared pointer.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_NoOpImpactEffectHook_v129": {
+        "binary": "FUN_0043b780",
+        "role": "Compiled-out impact-effect hook that retail leaves empty after projectile and fallback impact visuals are armed.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_ResolveProjectileImpactDamage_v129": {
+        "binary": "FUN_0043b790",
+        "role": "Resolves a projectile/effect impact by playing the impact cue and applying any queued damage pairs to the target actor.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_RenderWeaponEffectFallbackSpriteOrBeam_v129": {
+        "binary": "FUN_0043b970",
+        "role": "Draws the retail fallback visual for weapon effects when no dedicated model resource is present.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_DrawTerrainProjectionOutline_v129": {
+        "binary": "FUN_0043bcf0",
+        "role": "Draws the closed outline for the already-projected terrain projection polygon on the target overlay surface.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-tactical-overlays"
+        ]
+      },
+      "Combat_IntersectSegmentWithTerrainSceneryFace_v129": {
+        "binary": "FUN_0043bfc0",
+        "role": "Intersects a world-space segment against the currently selected terrain-scenery face and returns the hit point when the segment crosses that polygon.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-contact"
+        ]
+      },
+      "Combat_NormalizeVector3InPlace_v129": {
+        "binary": "FUN_0043c340",
+        "role": "Normalizes a 3D vector in place and reports failure when the input vector is effectively zero-length.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-contact"
+        ]
+      },
+      "Combat_IntersectRayWithPlane_v129": {
+        "binary": "FUN_0043c3a0",
+        "role": "Intersects a ray with a plane equation and returns both the hit point and the parametric distance when the ray faces the plane.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-contact"
+        ]
+      },
+      "Combat_SpawnTerrainSceneryImpactTrailBursts_v129": {
+        "binary": "FUN_0043c4b0",
+        "role": "Spawns the paired retail trail-strip bursts used when an impact hits a qualifying terrain-scenery instance.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Frame_InitializeBitmapLookupTableCache_v129": {
+        "binary": "FUN_0043c530",
+        "role": "Initializes the shared retail bitmap lookup-table cache used by buffered bitmap loads.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_FreeBitmapLookupTableCache_v129": {
+        "binary": "FUN_0043c5d0",
+        "role": "Frees the shared retail bitmap lookup-table cache and clears both lookup-table banks.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_GetBitmapLookupTablePair_v129": {
+        "binary": "FUN_0043c620",
+        "role": "Returns the cached retail x-axis and y-axis lookup tables for a bitmap buffer descriptor, allocating them on demand.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_GetOrCreateBitmapLookupTable_v129": {
+        "binary": "FUN_0043c6c0",
+        "role": "Looks up or allocates one bitmap lookup table inside the shared retail lookup-table cache.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Combat_InitializeSkyBackdrop_v129": {
+        "binary": "FUN_0043c800",
+        "role": "Loads the `SKY0` bitmap and seeds the fixed transform used by the retail sky-backdrop pass.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-environment-backdrop"
+        ]
+      },
+      "Combat_InitializeAmbientGroundDetail_v129": {
+        "binary": "FUN_0043c840",
+        "role": "Initializes the retail ambient ground-detail runtime state, including random anchor points, GRD bitmaps, and the special cached support mesh.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-environment-backdrop"
+        ]
+      },
+      "Combat_FreeAmbientGroundDetailSeeds_v129": {
+        "binary": "FUN_0043c990",
+        "role": "Frees the randomized ambient ground-detail anchor table.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-environment-backdrop"
+        ]
+      },
+      "Combat_RenderAmbientGroundDetail_v129": {
+        "binary": "FUN_0043c9b0",
+        "role": "Renders the retail ambient ground-detail sprites at their randomized world anchors using the cached `GRD0` / `GRD1` bitmaps.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-environment-backdrop"
+        ]
+      },
+      "Combat_IsActorSegmentClearOfTerrainScenery_v129": {
+        "binary": "FUN_0043cca0",
+        "role": "Tests whether the 3D segment between two actor positions stays clear of solid terrain-scenery support geometry.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-contact"
+        ]
+      },
+      "Combat_ResetEffectSpriteEntries_v129": {
+        "binary": "FUN_0043cec0",
+        "role": "Clears the active-state flags across the retail transient effect-sprite pool.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_ResetEffectHitProxyModelEntries_v129": {
+        "binary": "FUN_0043cef0",
+        "role": "Clears the active-state flags across the retail type-6 effect hit-proxy model pool.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_CollectVisibleEffectSprites_v129": {
+        "binary": "FUN_0043cf20",
+        "role": "Queues the active timed sprite effects that are still alive for the retail effect/render pass.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_CollectVisibleEffectHitProxyModels_v129": {
+        "binary": "FUN_0043cf80",
+        "role": "Queues the active type-6 effect model entries that are rendered through the retail hit-proxy path.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_CollectVisibleSpriteTrailAndHitProxyEffects_v129": {
+        "binary": "FUN_0043d000",
+        "role": "Queues the non-model transient effect pools that retail renders after the visible model-effect pass.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_ResetActiveEffectRenderPools_v129": {
+        "binary": "FUN_0043d020",
+        "role": "Clears the live-entry flags across the retail combat effect render pools without freeing their storage.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_InitializeActiveEffectRenderPools_v129": {
+        "binary": "FUN_0043d040",
+        "role": "Allocates and clears the retail combat effect render pools used by the active-effects pass.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_FreeActiveEffectRenderPools_v129": {
+        "binary": "FUN_0043d1a0",
+        "role": "Releases the retail combat effect render pools during combat visual teardown.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_RenderEffectSprite_v129": {
+        "binary": "FUN_0043d1e0",
+        "role": "Projects and draws a screen-facing retail effect sprite with distance- and lifetime-scaled size.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_SpawnEffectSprite_v129": {
+        "binary": "FUN_0043d340",
+        "role": "Allocates one timed retail effect sprite entry at a world position.",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Shell_ResetQueuedInboundLineQueueState_v129": {
+        "binary": "FUN_0043d400",
+        "role": "Resets the retail queued inbound-line FIFO counters and pointers without freeing payloads.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_ClearQueuedInboundLineQueue_v129": {
+        "binary": "FUN_0043d420",
+        "role": "Drains the retail queued inbound-line FIFO, freeing each copied line buffer and then resetting queue state.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_EnqueueQueuedInboundLineBuffer_v129": {
+        "binary": "FUN_0043d450",
+        "role": "Appends one copied shell-line buffer to the tail of the retail queued inbound-line FIFO.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_DequeueQueuedInboundLineBuffer_v129": {
+        "binary": "FUN_0043d4a0",
+        "role": "Removes and returns the oldest copied shell-line buffer from the retail queued inbound-line FIFO.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_CreateQueuedInboundLineQueueNode_v129": {
+        "binary": "FUN_0043d4f0",
+        "role": "Allocates one retail FIFO node for a queued inbound-line buffer.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_FreeQueuedInboundLineQueueNode_v129": {
+        "binary": "FUN_0043d510",
+        "role": "Clears and frees one retail queued inbound-line FIFO node.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_VerifyManifestFiles_v129": {
+        "binary": "FUN_0043d530",
+        "role": "Validates that every file listed in `MANIFEST.TXT` exists before the frontend continues booting.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_SaveFrontendConfigToRegistry_v129": {
+        "binary": "FUN_0043d730",
+        "role": "Writes the retail frontend config blob and version marker to the Kesmai registry key.",
+        "xrefs": 19,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_LoadOrInitializeFrontendConfig_v129": {
+        "binary": "FUN_0043d870",
+        "role": "Loads the retail frontend config blob from the Kesmai registry key or seeds it with defaults on first run.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "World_TravelCompassPage_TestPointerHit_v129": {
+        "binary": "FUN_0043d970",
+        "role": "Runs the travel-compass page pointer hit-test only while that page is the active world root.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_SendTravelCompassMouseControlFrame_v129": {
+        "binary": "FUN_0043d9c0",
+        "role": "Translates one travel-compass mouse hit into the corresponding outbound Cmd1D control-frame action.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_TravelCompassPage_HandleMouse_v129": {
+        "binary": "FUN_0043da10",
+        "role": "Pointer handler for the early-world travel-compass page.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_SendCmd1dControlFrame_v129": {
+        "binary": "FUN_0043db30",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 31,
+        "source": "retail_function_catalog.gd"
+      },
+      "World_OpenStackedShellWindow_v129": {
+        "binary": "FUN_0043db80",
+        "role": "Pushes the current world child window onto the shell stack, then opens a new stacked shell window as the active child.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-modal-pages"
+        ]
+      },
+      "World_RedrawTravelCompassPageHighlights_v129": {
+        "binary": "FUN_0043dc20",
+        "role": "Repaints the travel-compass page slot highlights, borders, and unavailable-slot overlays.",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_RedrawTravelCompassPageArt_v129": {
+        "binary": "FUN_0043dd20",
+        "role": "Redraws the five picture panels and fixed shell art for the travel-compass page.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_DrawTravelCompassSlotHatchFill_v129": {
+        "binary": "FUN_0043dfc0",
+        "role": "Draws the alternating hatch fill used on one travel-compass slot rectangle.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_CloseStackedShellWindow_v129": {
+        "binary": "FUN_0043e040",
+        "role": "Closes the current stacked world-shell child window and restores the previous active shell window when one is saved.",
+        "xrefs": 33,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-modal-pages",
+          "world-selection-dialogs",
+          "world-transient-notice-queue"
+        ],
+        "also_at": [
+          {
+            "binary": "FUN_004468c0",
+            "xrefs": 4
+          }
+        ]
+      },
+      "World_Cmd07_MenuDialog_v129": {
+        "binary": "FUN_0043e0f0",
+        "role": "Server menu dialog renderer.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd"
+      },
+      "World_OpenStackedTransientNoticeWindow_v129": {
+        "binary": "FUN_0043e730",
+        "role": "Opens the stacked shell-child notice window used by queued type-2 transient notices.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-transient-notice-queue"
+        ]
+      },
+      "World_OpenStackedTextDialog_v129": {
+        "binary": "FUN_0043e840",
+        "role": "Builds the shared stacked world text dialog with one-button or two-button action layouts.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser",
+          "world-modal-pages"
+        ]
+      },
+      "World_Cmd20_ParseTextDialog_v129": {
+        "binary": "FUN_0043ebc0",
+        "role": "Decodes the late-world text-dialog payload and forwards it into the shared stacked text dialog builder.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-modal-pages"
+        ]
+      },
+      "World_OpenUnkeyedTripleStringListDialog_v129": {
+        "binary": "FUN_0043ec10",
+        "role": "Thin wrapper that opens the shared triple-string list dialog without the leading key/id column.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-selection-dialogs"
+        ]
+      },
+      "World_Cmd48_KeyedTripleStringList_v129": {
+        "binary": "FUN_0043ec20",
+        "role": "Wraps the shared triple-string list dialog builder with the keyed item-id column enabled.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-selection-dialogs"
+        ]
+      },
+      "World_OpenTripleStringListDialog_v129": {
+        "binary": "FUN_0043ec50",
+        "role": "Builds the late-world triple-string list dialog, optionally including the stored leading key column.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-selection-dialogs"
+        ]
+      },
+      "World_MenuDialog_HandleInput_v129": {
+        "binary": "FUN_0043efc0",
+        "role": "Keyboard input handler for the retail menu-dialog surface.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser",
+          "world-selection-dialogs"
+        ]
+      },
+      "World_MenuDialog_HandleMouse_v129": {
+        "binary": "FUN_0043f110",
+        "role": "Pointer/mouse handler for the retail menu-dialog surface.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser",
+          "world-selection-dialogs"
+        ]
+      },
+      "World_BitmaskSelectionList_HandleInput_v129": {
+        "binary": "FUN_0043f3c0",
+        "role": "Handles confirm/cancel input and per-row toggles for the late-world checkbox selection dialog.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-selection-dialogs"
+        ]
+      },
+      "World_Cmd42_BitmaskSelectionList_v129": {
+        "binary": "FUN_0043f4c0",
+        "role": "Decodes a numbered checkbox list and opens the shared late-world multi-select dialog.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-selection-dialogs"
+        ]
+      },
+      "World_OpenScrollListEntryActionDialog_v129": {
+        "binary": "FUN_0043f7c0",
+        "role": "Opens the special two-option follow-up dialog for one selected Cmd45 scroll-list entry.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_CachedNamedEntrySelectionDialog_ToggleSelectionHighlight_v129": {
+        "binary": "FUN_0043fac0",
+        "role": "Inverts one cached-entry selection-dialog highlight rectangle.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-cached-entry-list"
+        ]
+      },
+      "World_CachedNamedEntrySelectionDialog_UpdateSelectionHighlight_v129": {
+        "binary": "FUN_0043fb40",
+        "role": "Selection-change callback for the cached named-entry selection dialog.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-cached-entry-list"
+        ]
+      },
+      "World_OpenCachedNamedEntrySelectionDialog_v129": {
+        "binary": "FUN_0043fcb0",
+        "role": "Opens a world selection dialog over the cached named-entry table and wires the shared selection callback.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-cached-entry-list"
+        ]
+      },
+      "World_CachedNamedEntrySelectionDialog_HandleInput_v129": {
+        "binary": "FUN_00440300",
+        "role": "Handles navigation and submit actions for the cached named-entry selection dialog.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-cached-entry-list"
+        ]
+      },
+      "World_ByteSelectionMenu_HandleInput_v129": {
+        "binary": "FUN_00440590",
+        "role": "Handles the legacy world byte-selection menu and submits the chosen byte value.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "World_OpenModalTextWindow_v129": {
+        "binary": "FUN_00440610",
+        "role": "Opens the shared modal world text window with optional seeded input text.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-modal-pages"
+        ]
+      },
+      "World_Cmd08_MenuClose_v129": {
+        "binary": "FUN_00440780",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-modal-pages"
+        ]
+      },
+      "World_Cmd15_OpenNumericPrompt_v129": {
+        "binary": "FUN_004407e0",
+        "role": "Opens a range-checked numeric input prompt bound to a retail follow-up command id.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-modal-pages"
+        ]
+      },
+      "World_ModalTextWindow_HandleInput_v129": {
+        "binary": "FUN_00440880",
+        "role": "Shared input handler for the retail modal text window and its text-entry variants.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-modal-pages"
+        ]
+      },
+      "World_NumericPrompt_HandleInput_v129": {
+        "binary": "FUN_00440a70",
+        "role": "Handles Enter/Escape on the retail numeric prompt, validates the typed number, and sends the follow-up command.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-modal-pages"
+        ]
+      },
+      "Shell_ClearStatusMarqueeBuffer_v129": {
+        "binary": "FUN_00440b60",
+        "role": "Clears the active shell status marquee text buffer and resets its tracked length.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_AppendStatusMarqueeText_v129": {
+        "binary": "FUN_00440b70",
+        "role": "Appends one decoded text segment into the scrolling shell status marquee buffer.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_TickScrollingStatusMarquee_v129": {
+        "binary": "FUN_00440cc0",
+        "role": "Advances and redraws the scrolling shell status marquee when the world state is idle enough to show it.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "World_Cmd34_TravelCompassLabelStrip_v129": {
+        "binary": "FUN_00440e40",
+        "role": "Updates the upper label strip on the early-world travel-compass page from streamed text rows.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_ClearWorldUiChildren_v129": {
+        "binary": "FUN_00440f30",
+        "role": "Clears active world UI children before rebuilding a panel/browser surface.",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_Cmd46_ClearWorldUiChildren_v129": {
+        "binary": "FUN_00440f80",
+        "role": "Clears active world UI children before rebuilding a world sub-surface.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd"
+      },
+      "World_TeardownRootUiWindows_v129": {
+        "binary": "FUN_00440fb0",
+        "role": "Closes the active world root and auxiliary UI windows and clears the corresponding world-shell state bits.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "World_TravelCompassPage_HandleInput_v129": {
+        "binary": "FUN_00441090",
+        "role": "Keyboard and hotkey handler for the early-world travel-compass page.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_ActivateTravelCompassCmpButton_v129": {
+        "binary": "FUN_004412b0",
+        "role": "Plays the travel-compass CMP button flash/press animation and then opens the shared CMP action dialog.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser",
+          "comstar-messaging"
+        ]
+      },
+      "World_CreateShellWindowByStyle_v129": {
+        "binary": "FUN_004413b0",
+        "role": "Builds one of the shared framed world-shell window layouts by style id.",
+        "xrefs": 20,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-cached-entry-list",
+          "world-modal-pages",
+          "world-selection-dialogs",
+          "world-transient-notice-queue"
+        ]
+      },
+      "World_DrawTravelCompassPageFrameArt_v129": {
+        "binary": "FUN_00441810",
+        "role": "Draws the fixed shell-frame bitmap layers used by the early-world travel-compass page.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_Cmd04_TravelCompassPage_v129": {
+        "binary": "FUN_00441980",
+        "role": "Builds the early-world travel-compass page with one center slot, four surrounding travel slots, and fixed byte-selection actions.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_Cmd14_PersonnelRecord_v129": {
+        "binary": "FUN_00442620",
+        "role": "Renders the retail personnel-record modal page with ID, battle-count, and dossier text rows.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-modal-pages"
+        ]
+      },
+      "World_Cmd41_NameMechScoreMatrix_v129": {
+        "binary": "FUN_00442a00",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd"
+      },
+      "World_MessageView_HandleInput_v129": {
+        "binary": "FUN_00442e60",
+        "role": "Keyboard input handler for the read-message / reply-enabled ComStar message view.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "comstar-messaging"
+        ]
+      },
+      "World_FreeShellWindowAuxBuffers_v129": {
+        "binary": "FUN_00442fd0",
+        "role": "Frees the optional heap-backed auxiliary buffers attached to one shell window instance.",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser",
+          "comstar-messaging"
+        ]
+      },
+      "World_MessageView_DispatchNormalizedKey_v129": {
+        "binary": "FUN_00443080",
+        "role": "Normalizes Escape/Space shortcuts for the reply-enabled message view and forwards them into the active-window key dispatcher.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "comstar-messaging"
+        ]
+      },
+      "World_Cmd36_MessageView_v129": {
+        "binary": "FUN_004430b0",
+        "role": "Read-message / reply-enabled ComStar message view.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "comstar-messaging"
+        ]
+      },
+      "World_MessageView_ExtractReplyPrefixTags_v129": {
+        "binary": "FUN_00443430",
+        "role": "Extracts hidden reply-prefix tags from a received message body into the window's auxiliary buffer and strips them from the visible text.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "comstar-messaging"
+        ]
+      },
+      "World_HotkeySelectionMenu_HandleInput_v129": {
+        "binary": "FUN_00443650",
+        "role": "Input callback for the hotkey-driven world selection menu.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_SendHotkeySelectionMenuControlFrame_v129": {
+        "binary": "FUN_00443840",
+        "role": "Sends the cmd1d control frame for the active hotkey selection menu, mapping the `More` row to sentinel value `1000`.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_HotkeySelectionMenu_DispatchNormalizedKey_v129": {
+        "binary": "FUN_00443890",
+        "role": "Normalizes the hotkey selection menu's special Space shortcut and forwards it into the active window key dispatcher.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_Cmd57_HotkeySelectionMenu_v129": {
+        "binary": "FUN_004438b0",
+        "role": "Hotkey-driven selection menu in the late-world list family.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_Cmd37_OpenCompose_v129": {
+        "binary": "FUN_00443d10",
+        "role": "Server wrapper that opens the local ComStar compose window.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "comstar-messaging"
+        ]
+      },
+      "World_OpenComposeEditor_v129": {
+        "binary": "FUN_00443d80",
+        "role": "Opens the local editable ComStar compose editor for one or many target ids.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "comstar-messaging"
+        ]
+      },
+      "World_ResetComposeEditorState_v129": {
+        "binary": "FUN_00443fb0",
+        "role": "Allocates and resets the per-editor recipient/body state used by the ComStar message surfaces.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "comstar-messaging"
+        ]
+      },
+      "World_LoadTextFileIntoModalTextWindow_v129": {
+        "binary": "FUN_00444260",
+        "role": "Loads a local text file into the active modal world text window's editable buffer.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-modal-pages"
+        ]
+      },
+      "Frame_ClassifyEditableTextKeyAction_v129": {
+        "binary": "FUN_004445c0",
+        "role": "Maps one editable-text keypress to the retail editor action id used by the shared text-entry handler.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_AppendWrappedInputChar_v129": {
+        "binary": "FUN_00444730",
+        "role": "Appends one character to an editable wrapped text buffer, enforcing width limits and rerendering when the current line overflows.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_ConvertTrailingBitmapTokenToInlineTag_v129": {
+        "binary": "FUN_00444920",
+        "role": "Converts the trailing five-character bitmap token in the editable buffer into a validated inline bitmap marker.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DrawInlineAssetRuns_v129": {
+        "binary": "FUN_00444a30",
+        "role": "Processes and draws the inline asset markers embedded in a wrapped retail text block.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DrawWrappedTextBlock_v129": {
+        "binary": "FUN_00444c80",
+        "role": "Lays out a string into wrapped frame lines, honoring explicit breaks and inline asset markers, then draws the resulting text block.",
+        "xrefs": 8,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DrawWrappedLine_v129": {
+        "binary": "FUN_00444ee0",
+        "role": "Draws one pre-wrapped line into the current frame text surface by streaming characters through the active cursor writer.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_BackspaceWrappedInputChar_v129": {
+        "binary": "FUN_00444f30",
+        "role": "Removes the last character from an editable wrapped text buffer and refreshes the affected line or rerenders the wrapped block when needed.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_InsertHardLineBreakMarker_v129": {
+        "binary": "FUN_00445240",
+        "role": "Inserts the retail hard line-break marker into the editable wrapped text buffer and refreshes the cursor state.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_MoveWrappedTextCursorRight_v129": {
+        "binary": "FUN_00445330",
+        "role": "Advances the editable-text cursor one wrapped-text position to the right.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_MoveWrappedTextCursorLeft_v129": {
+        "binary": "FUN_00445480",
+        "role": "Moves the editable-text cursor one wrapped-text position to the left.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_MoveWrappedTextCursorUp_v129": {
+        "binary": "FUN_004455c0",
+        "role": "Moves the editable-text cursor up one wrapped line while preserving the preferred horizontal offset.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_MoveWrappedTextCursorDown_v129": {
+        "binary": "FUN_004456d0",
+        "role": "Moves the editable-text cursor down one wrapped line while preserving the preferred horizontal offset.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "World_ComposeEditor_SubmitMessage_v129": {
+        "binary": "FUN_004458c0",
+        "role": "Prepends any hidden reply-prefix tags, encodes the recipient/body payload, and submits the active ComStar compose editor message.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "comstar-messaging"
+        ]
+      },
+      "Frame_InsertSelectedUnitBitmapTagIntoEditableText_v129": {
+        "binary": "FUN_004459d0",
+        "role": "Inserts the currently selected retail unit bitmap token into the editable wrapped text buffer.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_InsertCurrentHouseBitmapTagIntoEditableText_v129": {
+        "binary": "FUN_00445a10",
+        "role": "Inserts the current retail house crest bitmap token into the editable wrapped text buffer.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_InsertInlineBitmapTagIntoEditableText_v129": {
+        "binary": "FUN_00445a50",
+        "role": "Inserts one inline bitmap marker into an editable wrapped text buffer, rerenders the field, and refreshes the cursor metrics.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_CopyCString_v129": {
+        "binary": "FUN_00445d40",
+        "role": "Copies one null-terminated C string into another frame-text buffer, preserving the trailing zero byte.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_InsertCStringAtOffset_v129": {
+        "binary": "FUN_00445d70",
+        "role": "Inserts one null-terminated string into another retail text buffer at the requested byte offset.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DeleteCStringRangeInPlace_v129": {
+        "binary": "FUN_00445dc0",
+        "role": "Deletes one byte range from an in-place retail text buffer by sliding the trailing text over the removed span.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_ReplaceCStringInTextBuffer_v129": {
+        "binary": "FUN_00445df0",
+        "role": "Replaces every occurrence of one substring inside a retail text buffer, honoring the caller's maximum buffer size.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_InsertSoftWrapsIntoTextBuffer_v129": {
+        "binary": "FUN_00445ee0",
+        "role": "Walks a retail text buffer token by token and inserts soft line breaks when the accumulated pixel width exceeds the requested wrap width.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_MeasureNextWrappedTokenWidth_v129": {
+        "binary": "FUN_00445f50",
+        "role": "Measures the pixel width and byte span of the next whitespace-delimited token in a retail wrapped text buffer.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_CountWrappedTextLines_v129": {
+        "binary": "FUN_00446000",
+        "role": "Normalizes one retail text string and returns how many wrapped lines it will occupy inside the current frame width.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "World_Cmd38_NoOp_v129": {
+        "binary": "FUN_004467a0",
+        "role": "Inert world command slot 38 that retail leaves as a zero-return stub.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd"
+      },
+      "World_LoadLocationLabelBitmap_v129": {
+        "binary": "FUN_004467b0",
+        "role": "Rebuilds the current location-browser label bitmap from the active label code.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_Cmd47_SetLocationLabelCode_v129": {
+        "binary": "FUN_00446840",
+        "role": "Updates the location-browser label code and refreshes its bitmap when the code changes.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_Cmd54_SetCurrentUnitCode_v129": {
+        "binary": "FUN_00446870",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd"
+      },
+      "World_Cmd55_SetCurrentHouseCode_v129": {
+        "binary": "FUN_00446890",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd"
+      },
+      "World_Cmd33_NoOp_v129": {
+        "binary": "FUN_004468b0",
+        "role": "Inert world command slot 33 that retail leaves as a zero-return stub.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_SendTravelCompassSlotSelection_v129": {
+        "binary": "FUN_004468d0",
+        "role": "Sends the travel-compass selection for one of the four surrounding page slots.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_ClearWorldUiChildrenActiveFlag_v129": {
+        "binary": "FUN_004469e0",
+        "role": "Clears the shared world-child active flag without destroying the tracked child-window table.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch",
+          "world-travel-browser"
+        ]
+      },
+      "World_ResetLocationLabelBitmapCache_v129": {
+        "binary": "FUN_004469f0",
+        "role": "Clears the cached location-label bitmap pointer and invalidates the last latched label code.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "Frame_IsPrintableEditableTextChar_v129": {
+        "binary": "FUN_00446a10",
+        "role": "Returns whether one key code is a printable ASCII character accepted by the retail editable-text handler.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_GetCurrentWrappedLineText_v129": {
+        "binary": "FUN_00446a30",
+        "role": "Returns the pointer to the current wrapped-line text buffer in the frame's wrap metadata.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "World_IsTravelCompassCurrentLabelPictureId_v129": {
+        "binary": "FUN_00446a50",
+        "role": "Returns whether a travel-compass picture id is the singleton current-label placeholder.",
+        "xrefs": 10,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "World_IsTravelCompassDistrictLabelPictureId_v129": {
+        "binary": "FUN_00446a60",
+        "role": "Returns whether a travel-compass picture id falls in the district-label placeholder range.",
+        "xrefs": 10,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "Shell_OpenCmpActionDialog_v129": {
+        "binary": "FUN_00446a80",
+        "role": "Opens the shared CMP action dialog used by both combat HUD and travel-compass entry points.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "comstar-messaging"
+        ]
+      },
+      "Shell_CmpActionDialogProc_v129": {
+        "binary": "FUN_00446ab0",
+        "role": "Dialog procedure for the shared CMP action chooser.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "comstar-messaging"
+        ]
+      },
+      "Shell_OpenCmpInfoDialog_v129": {
+        "binary": "FUN_00446c20",
+        "role": "Opens the one-button follow-up informational dialog used by the shared CMP action flow.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "comstar-messaging"
+        ]
+      },
+      "Shell_CmpInfoDialogProc_v129": {
+        "binary": "FUN_00446c50",
+        "role": "Dialog procedure for the one-button CMP informational modal.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "comstar-messaging"
+        ]
+      },
+      "Shell_OpenCmpMessageEntryDialog_v129": {
+        "binary": "FUN_00446d40",
+        "role": "Opens the free-text CMP message-entry dialog.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "comstar-messaging"
+        ]
+      },
+      "Shell_CmpMessageEntryDialogProc_v129": {
+        "binary": "FUN_00446d70",
+        "role": "Dialog procedure for the typed CMP message-entry modal.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "comstar-messaging"
+        ]
+      },
+      "System_InitializeDirectDrawDisplay_v129": {
+        "binary": "FUN_00446fc0",
+        "role": "Initializes the retail DirectDraw display path, including the palette state and the primary frontend rendering surfaces.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_ShutdownDirectDrawDisplay_v129": {
+        "binary": "FUN_00447570",
+        "role": "Releases the retail DirectDraw display path, including the primary surfaces, clipper chain, and root DirectDraw object.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_WaitForVerticalBlank_v129": {
+        "binary": "FUN_004475f0",
+        "role": "Blocks until the active DirectDraw display reaches the next vertical blank interval.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Frame_FillDisplayRect_v129": {
+        "binary": "FUN_00447600",
+        "role": "Color-fills a rectangle on the active display surface with a palette index.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-picture-bootstrap",
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_BlitDirectDrawSurfaceToDisplay_v129": {
+        "binary": "FUN_00447680",
+        "role": "Blits a raw DirectDraw surface rectangle to the active display surface, choosing the retail fast or clipped path as needed.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "Frame_PresentFrameRect_v129": {
+        "binary": "FUN_00447760",
+        "role": "Presents a rectangle from a frame surface to the display at the requested screen coordinates.",
+        "xrefs": 72,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-jump-fuel-hud",
+          "combat-eq-hud",
+          "combat-presentation-hud",
+          "shell-picture-bootstrap",
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_GetPaletteEntryRgb_v129": {
+        "binary": "FUN_00447930",
+        "role": "Reads one palette entry's RGB triplet from the frame palette table into a caller-provided buffer.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_SetPaletteEntryRgb_v129": {
+        "binary": "FUN_00447970",
+        "role": "Writes one RGB triplet back into the frame palette table in the retail shifted storage format.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_UpdatePaletteRange_v129": {
+        "binary": "FUN_004479b0",
+        "role": "Uploads a contiguous palette range from the frame palette table to the active palette object.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_UpdateFullPalette_v129": {
+        "binary": "FUN_00447a10",
+        "role": "Uploads the full 256-entry frame palette table to the active palette object.",
+        "xrefs": 19,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-picture-bootstrap",
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_CaptureDisplayPaletteState_v129": {
+        "binary": "FUN_00447a20",
+        "role": "Captures the current display palette state before shell dialogs or modal prompts disturb it.",
+        "xrefs": 11,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Frame_CreateDirectDrawSurface_v129": {
+        "binary": "FUN_00447a90",
+        "role": "Creates one DirectDraw surface for a frame-owned backing store and reports any retail DirectDraw failure through the shared bterror path.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_RestoreActiveDisplaySurface_v129": {
+        "binary": "FUN_00447bf0",
+        "role": "Restores the active DirectDraw display surface after a lost-surface event and reports any failure through the shared bterror path.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-picture-bootstrap"
+        ]
+      },
+      "System_GetDirectDrawErrorString_v129": {
+        "binary": "FUN_00447c80",
+        "role": "Maps a DirectDraw/HRESULT failure code to the localized retail error string shown in BTERR reports.",
+        "xrefs": 12,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_ShowModalMessageBox_v129": {
+        "binary": "FUN_00448620",
+        "role": "Shows a frontend modal message box while preserving the retail palette snapshot rules used by shell dialogs.",
+        "xrefs": 11,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_OpenStatusTextDialog_v129": {
+        "binary": "FUN_00448660",
+        "role": "Opens the small modeless shell status-text dialog and writes one caller-supplied line into it.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_CloseStatusTextDialog_v129": {
+        "binary": "FUN_004486e0",
+        "role": "Closes the active modeless shell status-text dialog when one is open.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_StatusTextDialogProc_v129": {
+        "binary": "FUN_00448700",
+        "role": "Minimal dialog procedure for the modeless shell status-text dialog.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_ConfirmClientExit_v129": {
+        "binary": "FUN_00448720",
+        "role": "Shows the retail exit confirmation prompt and posts the shell shutdown command when the player accepts.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "World_OpenByteSelectionMenuHelp_v129": {
+        "binary": "FUN_004487b0",
+        "role": "Opens the retail `wnd_menu` help topic for byte-selection menus.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-travel-browser"
+        ]
+      },
+      "Shell_RestoreMainWindowIfAuxiliaryClosed_v129": {
+        "binary": "FUN_004488c0",
+        "role": "Restores the main shell window when the tracked auxiliary world window is no longer valid.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Frame_RestoreSavedCursor_v129": {
+        "binary": "FUN_00448900",
+        "role": "Restores the saved retail cursor handle as the active Windows cursor.",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_HideCursor_v129": {
+        "binary": "FUN_00448920",
+        "role": "Clears the current retail cursor and hides the Windows cursor.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_SetCursorScreenPos_v129": {
+        "binary": "FUN_00448940",
+        "role": "Moves the Windows cursor to an absolute screen-space position.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_SetSavedCursorByMode_v129": {
+        "binary": "FUN_00448960",
+        "role": "Loads one stock cursor shape into the saved retail cursor slot and applies it when the cursor is visible.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_InitializeSavedArrowCursor_v129": {
+        "binary": "FUN_004489b0",
+        "role": "Initializes the retail saved/current cursor handles to the stock arrow cursor.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "System_GetFileLengthByPath_v129": {
+        "binary": "FUN_004489d0",
+        "role": "Opens one file path in binary mode, returns its byte length, and closes it immediately.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_LoadFileIntoBuffer_v129": {
+        "binary": "FUN_00448a10",
+        "role": "Loads an entire file into a caller-supplied buffer or allocates a new one sized to the file.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Shell_NoOpPreVersionBannerLineHook_v129": {
+        "binary": "FUN_00448ac0",
+        "role": "Compiled-out pre-version banner-line hook that retail leaves empty before the negotiated state-change frame is sent.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Frame_NoOpSingleByteNormalizedKeyHook_v129": {
+        "binary": "FUN_00448ad0",
+        "role": "Compiled-out single-byte normalized-key hook that retail still calls from the raw pre-dispatch wrapper before handing control to the active window.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Shell_WaitForKeypressOrTimeout_v129": {
+        "binary": "FUN_00448ae0",
+        "role": "Pumps the Windows message queue until the deadline expires or the user presses a key.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-picture-bootstrap"
+        ]
+      },
+      "System_InitializeSoftwareRasterizerSpanCode_v129": {
+        "binary": "FUN_00448b40",
+        "role": "Unlocks and seeds the retail software-rasterizer span code used by the combat polygon fill routines.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_IsProcessorTypeAtLeast_v129": {
+        "binary": "FUN_00448bb0",
+        "role": "Returns whether the current Windows processor type meets the supplied retail threshold.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_VerifyExecutableChecksumFromDisk_v129": {
+        "binary": "FUN_00448bd0",
+        "role": "Opens the running retail executable from disk, skips the embedded checksum block, and verifies the remaining bytes against the stored checksum word.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_UpdateExecutableChecksumSegment_v129": {
+        "binary": "FUN_00448dd0",
+        "role": "Updates the executable self-check accumulator over one caller-selected byte segment.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_InitializeExecutableChecksumTable_v129": {
+        "binary": "FUN_00448e10",
+        "role": "Builds the 256-entry reflected checksum table used by the retail executable self-check.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_VerifyExecutableChecksum_v129": {
+        "binary": "FUN_00448e50",
+        "role": "Verifies the retail executable checksum before the frontend continues through startup.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Combat_InitializeSharedRenderProjectionContexts_v129": {
+        "binary": "FUN_00448e70",
+        "role": "Initializes the shared combat render/projection context blocks used by the backdrop, terrain projection, tactical radar, and active-effects passes.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-visual-bootstrap"
+        ]
+      },
+      "Combat_RenderActorPreviewPanel_v129": {
+        "binary": "FUN_00449070",
+        "role": "Renders a labeled combat actor preview panel by posing the actor model, drawing it with the preview camera, and centering a truncated caption.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-transform-math",
+          "combat-actor-preview"
+        ]
+      },
+      "Combat_RenderSkyAndGroundBackdrop_v129": {
+        "binary": "FUN_00449400",
+        "role": "Draws the retail `SKY0` backdrop, the main ground plane quads, and any enabled ambient ground-detail sprites behind the active combat effects.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-environment-backdrop"
+        ]
+      },
+      "Combat_RenderEffectModelAndCheckCursorHit_v129": {
+        "binary": "FUN_004499d0",
+        "role": "Renders an effect model, updates its screen-space extents, and reports whether the current cursor hit-test selected it.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-transform-math",
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_ComputeVectorMagnitude3_v129": {
+        "binary": "FUN_00449bc0",
+        "role": "Returns the Euclidean magnitude of a supplied 3-axis combat-space delta vector.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_BuildActiveEffectsCameraTransform_v129": {
+        "binary": "FUN_00449bf0",
+        "role": "Builds the local active-effects camera transform, applying screen shake and the current local actor pose before the render pass runs.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_RenderActiveEffectsPass_v129": {
+        "binary": "FUN_00449d90",
+        "role": "Runs the retail combat effect render pass: updates active effects, depth-sorts the visible ones, and dispatches type-specific draw helpers.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-environment-backdrop",
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_CollectVisibleActorRenderEntries_v129": {
+        "binary": "FUN_0044a280",
+        "role": "Advances active actor presentation state, rebuilds actor poses, and queues visible actor records for the retail effect/render pass.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_CacheActorRenderDistance_v129": {
+        "binary": "FUN_0044a3f0",
+        "role": "Caches the current camera distance on one actor record for the retail effect/render pass.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Frame_EncodeMaskedSpanRuns_v129": {
+        "binary": "FUN_0044a410",
+        "role": "Encodes a bitmap-sized mask surface into the packed `(mask_word, run_length)` stream consumed by Frame_CompositeMaskedSpanRuns_v129.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-visual-bootstrap",
+          "combat-actor-preview"
+        ]
+      },
+      "Frame_CompositeMaskedSpanRuns_v129": {
+        "binary": "FUN_0044a4e0",
+        "role": "Composites a run-length list of masked pixel spans into a destination frame buffer.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-actor-preview"
+        ]
+      },
+      "Combat_RebuildVoiceTransmissionRosterOrder_v129": {
+        "binary": "FUN_0044a5e0",
+        "role": "Rebuilds the retail roster-display order used by the voice-transmission roster HUD.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_InitializeVoiceTransmissionHudControls_v129": {
+        "binary": "FUN_0044a640",
+        "role": "Initializes the retail combat voice-transmission HUD controls and default panel state.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_FreeVoiceTransmissionHudControls_v129": {
+        "binary": "FUN_0044a8c0",
+        "role": "Releases the retail combat voice-transmission HUD control surface and clears the panel flags.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_ScrollVoiceTransmissionHudHistory_v129": {
+        "binary": "FUN_0044a900",
+        "role": "Scrolls the retail combat voice-transmission history view and redraws the voice HUD.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_PresentCollapsedVoiceTransmissionHudPanel_v129": {
+        "binary": "FUN_0044a970",
+        "role": "Presents the cached collapsed retail voice-transmission HUD panel region.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_ResetVoiceTransmissionHudToggleAnimation_v129": {
+        "binary": "FUN_0044a9c0",
+        "role": "Resets the staged voice-transmission HUD toggle animation back to its baseline state.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_TickVoiceTransmissionHudToggleAnimation_v129": {
+        "binary": "FUN_0044a9e0",
+        "role": "Ticks the retail expand/collapse animation for the combat voice-transmission HUD.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_IsVoiceTransmissionHudToggleAnimationActive_v129": {
+        "binary": "FUN_0044aae0",
+        "role": "Returns whether the voice-transmission HUD toggle animation is still in flight.",
+        "xrefs": 15,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_SetVoiceTransmissionHudControlsEnabled_v129": {
+        "binary": "FUN_0044ab00",
+        "role": "Enables or disables the registered retail voice-transmission HUD controls for the current panel mode.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_RefreshOpenVoiceTransmissionHud_v129": {
+        "binary": "FUN_0044abe0",
+        "role": "Refreshes the currently open retail voice-transmission HUD variant and re-enables its controls.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_RedrawVoiceTransmissionHudTransitionFrame_v129": {
+        "binary": "FUN_0044ac00",
+        "role": "Redraws one staged transition frame for the retail voice-transmission HUD open/close animation.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_RedrawVoiceTransmissionCmpStatusIcon_v129": {
+        "binary": "FUN_0044ae30",
+        "role": "Redraws the small CMP-status icon embedded in the retail voice-transmission HUD.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_RedrawVoiceTransmissionHud_v129": {
+        "binary": "FUN_0044aec0",
+        "role": "Dispatches the combat voice-transmission HUD redraw to the active retail layout variant.",
+        "xrefs": 7,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_RedrawVoiceTransmissionHudBlank_v129": {
+        "binary": "FUN_0044af00",
+        "role": "Redraws the blank/base combat voice-transmission HUD panel.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_RedrawVoiceTransmissionHudHistory_v129": {
+        "binary": "FUN_0044af80",
+        "role": "Redraws the history-style combat voice-transmission HUD variant with recent transmission rows.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_DrawVoiceTransmissionHudLabel_v129": {
+        "binary": "FUN_0044b120",
+        "role": "Draws one clipped label row inside the combat voice-transmission HUD using the active HUD font colors.",
+        "xrefs": 14,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_HandleVoiceTransmissionInput_v129": {
+        "binary": "FUN_0044b1a0",
+        "role": "Handles the active combat voice-transmission text-entry mode, including typing, submit, and local history echo.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission",
+          "combat-presentation-controls"
+        ]
+      },
+      "Combat_DrawVoiceTransmissionStatusHud_v129": {
+        "binary": "FUN_0044b3d0",
+        "role": "Draws the live combat voice-transmission status HUD, including the selected talker/target label.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_AllocateVoiceTransmissionHistoryBuffer_v129": {
+        "binary": "FUN_0044b540",
+        "role": "Allocates and initializes the retail combat voice-transmission history ring buffer.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_FreeVoiceTransmissionHistoryBuffer_v129": {
+        "binary": "FUN_0044b620",
+        "role": "Frees the retail combat voice-transmission history buffer during teardown.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_AppendVoiceTransmissionHistoryEntry_v129": {
+        "binary": "FUN_0044b640",
+        "role": "Appends one status or transmission line into the combat voice-history ring buffer and refreshes the HUD when needed.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_SelectActiveVoiceTransmissionStatusMessage_v129": {
+        "binary": "FUN_0044b7b0",
+        "role": "Selects the currently visible retail voice/status message and advances the compact status-strip queue.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_RedrawVoiceTransmissionHudRoster_v129": {
+        "binary": "FUN_0044b8c0",
+        "role": "Redraws the roster-style combat voice-transmission HUD variant with channel/participant status rows.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_SelectVoiceTransmissionTune_v129": {
+        "binary": "FUN_0044bcb0",
+        "role": "Handles one local combat voice-transmission tune selection from the retail voice panel.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_ToggleVoiceTransmissionActorState_v129": {
+        "binary": "FUN_0044bdd0",
+        "role": "Toggles one actor's combat voice-transmission enabled state from the roster-style voice panel.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_ComputeFixedSinCos_v129": {
+        "binary": "FUN_0044be20",
+        "role": "Computes retail 16.16 fixed-point sine and cosine values for one combat angle.",
+        "xrefs": 16,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-transform-math"
+        ]
+      },
+      "Combat_ComputeArcTanDegreesFromScaledRatio_v129": {
+        "binary": "FUN_0044bed0",
+        "role": "Converts a signed slope ratio scaled by 1000 into a signed degree angle with the retail arctangent lookup table.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-terrain-contact",
+          "combat-projectile-effects"
+        ]
+      },
+      "Frame_LoadBitmapPaletteBlock_v129": {
+        "binary": "FUN_0044bf90",
+        "role": "Loads the optional palette block for one retail bitmap resource.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-visual-bootstrap"
+        ]
+      },
+      "Frame_LoadBitmapPixelPayload_v129": {
+        "binary": "FUN_0044c080",
+        "role": "Loads the variable-size pixel payload block for one retail bitmap object.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_FreeBitmapOwnedBuffers_v129": {
+        "binary": "FUN_0044c1b0",
+        "role": "Frees the palette and pixel buffers owned by one retail bitmap object and clears both pointers.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DecodeBitmapRleData_v129": {
+        "binary": "FUN_0044c1f0",
+        "role": "Expands the retail run-length encoded bitmap payload into a flat 8-bit pixel buffer.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_BlitBitmapPixels_v129": {
+        "binary": "FUN_0044c270",
+        "role": "Blits a bitmap resource's full pixel payload into the clipped destination frame rectangle.",
+        "xrefs": 8,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-visual-bootstrap",
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_CopyBitmapPixelsToBuffer_v129": {
+        "binary": "FUN_0044c330",
+        "role": "Copies a bitmap resource's full pixel payload into a caller-provided destination buffer.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_BlitBitmapWithTransparentKey_v129": {
+        "binary": "FUN_0044c3d0",
+        "role": "Blits a bitmap buffer into the destination frame rectangle while leaving source pixels that match the transparent key untouched.",
+        "xrefs": 7,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_LoadBitmapFromFile_v129": {
+        "binary": "FUN_0044c4a0",
+        "role": "Loads a retail bitmap resource from the current FILE position into a heap bitmap object.",
+        "xrefs": 100,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-visual-bootstrap",
+          "shell-picture-bootstrap",
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_FreeBitmap_v129": {
+        "binary": "FUN_0044c5e0",
+        "role": "Frees a retail heap bitmap object and any decoded pixel/palette storage it owns.",
+        "xrefs": 46,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-visual-bootstrap",
+          "shell-picture-bootstrap",
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_ApplyBitmapPalette_v129": {
+        "binary": "FUN_0044c600",
+        "role": "Copies a bitmap resource's palette into the active frame palette table and uploads the full palette.",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-heat-hud",
+          "shell-picture-bootstrap",
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_CopyBitmapPaletteToBuffer_v129": {
+        "binary": "FUN_0044c670",
+        "role": "Copies a bitmap resource's palette into a caller-provided RGB triplet buffer.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-picture-bootstrap",
+          "frame-text-rendering"
+        ]
+      },
+      "World_ResetTransientNoticeQueue_v129": {
+        "binary": "FUN_0044c6d0",
+        "role": "Clears the shared world transient-notice queue indices and active window pointer.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-transient-notice-queue"
+        ]
+      },
+      "World_QueueTransientNotice_v129": {
+        "binary": "FUN_0044c750",
+        "role": "Appends a transient notice entry into the shared 12-slot world notice queue and auto-shows it when idle.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-transient-notice-queue"
+        ]
+      },
+      "World_ShowNextTransientNotice_v129": {
+        "binary": "FUN_0044c7f0",
+        "role": "Opens the next queued world transient notice, or routes certain type-2 notices through the direct shell text path.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-transient-notice-queue"
+        ]
+      },
+      "World_RestoreTransientNoticeWindowFocus_v129": {
+        "binary": "FUN_0044cab0",
+        "role": "Restores focus to the active transient-notice popup after a travel-compass page rebuild or z-order shuffle.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-transient-notice-queue"
+        ]
+      },
+      "World_HandleTransientNoticeInput_v129": {
+        "binary": "FUN_0044cb30",
+        "role": "Handles the active world transient-notice popup input and advances the queue after dismissals.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-transient-notice-queue"
+        ]
+      },
+      "World_TransientNoticeDialog_HandleInput_v129": {
+        "binary": "FUN_0044cd50",
+        "role": "Handles the interactive transient-notice dialog choices and advances the notice queue afterward.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-transient-notice-queue"
+        ]
+      },
+      "World_Cmd29_QueueTransientNotice_v129": {
+        "binary": "FUN_0044cdf0",
+        "role": "Decodes one late-world transient notice payload and enqueues it for the shared notice window/queue.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "world-transient-notice-queue"
+        ]
+      },
+      "System_DoesRegistryKeyExist_v129": {
+        "binary": "FUN_0044cec0",
+        "role": "Checks whether the requested registry subkey exists beneath the supplied root hive.",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_CreateCurrentUserRegistryKey_v129": {
+        "binary": "FUN_0044cf00",
+        "role": "Creates the requested registry subkey beneath `HKEY_CURRENT_USER` and closes it immediately.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_DeleteRegistryKeyIfPresent_v129": {
+        "binary": "FUN_0044cf60",
+        "role": "Deletes the requested registry subkey when it exists beneath the supplied root hive.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_LoadStringResource_v129": {
+        "binary": "FUN_0044cfa0",
+        "role": "Loads one Win32 string-table resource into the shared retail scratch buffer and returns it.",
+        "xrefs": 431,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Frame_UpdateModifierKeyState_v129": {
+        "binary": "FUN_0044cfd0",
+        "role": "Updates the cached retail modifier-key state from Shift/Ctrl/Alt make-break scan codes.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Combat_TickVoiceTransmissionSpeechInState_v129": {
+        "binary": "FUN_0044d060",
+        "role": "Ticks the retail combat speech-in capture state, talkback meter, and outbound voice packet path.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-voice-transmission"
+        ]
+      },
+      "Combat_ProcessLocalMovementAndJumpInput_v129": {
+        "binary": "FUN_0044d230",
+        "role": "Local wrapper around the movement and jump-input path.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Frame_HandleCtrlShiftDebugToggleChord_v129": {
+        "binary": "FUN_0044d440",
+        "role": "Handles the retail Ctrl+Shift debug chords that arm the FPS overlay and capture-log toggles.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_TranslateKeyMessageToNormalizedKey_v129": {
+        "binary": "FUN_0044d490",
+        "role": "Translates a packed retail key message into the normalized key code used by frame callbacks and text-entry handling.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Combat_AllocateEffectTrailStripEntries_v129": {
+        "binary": "FUN_0044d750",
+        "role": "Allocates the fixed retail pool of transient trail-strip effect entries.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_FreeEffectTrailStripEntries_v129": {
+        "binary": "FUN_0044d800",
+        "role": "Frees the fixed retail pool of transient trail-strip effect entries.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_ResetEffectTrailStripEntries_v129": {
+        "binary": "FUN_0044d820",
+        "role": "Clears the active-state flags across the retail transient trail-strip pool.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_CollectVisibleEffectTrailStrips_v129": {
+        "binary": "FUN_0044d850",
+        "role": "Advances the active trail-strip effects and queues the live ones for the retail effect/render pass.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_SpawnEffectTrailStripBurst_v129": {
+        "binary": "FUN_0044d8d0",
+        "role": "Spawns a retail burst of multiple trail-strip effects around one world position.",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_SpawnEffectTrailStrip_v129": {
+        "binary": "FUN_0044d930",
+        "role": "Allocates one retail trail-strip effect entry and seeds its initial point chain, velocity, and transform.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_RenderEffectTrailStrip_v129": {
+        "binary": "FUN_0044dbe0",
+        "role": "Builds and renders the polygon strip used by retail trail-style combat effects.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_UpdateEffectTrailStripState_v129": {
+        "binary": "FUN_0044dd90",
+        "role": "Advances one active retail trail-strip effect and damps its motion until the strip collapses.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_SetAudioCue0NameVolumeAndPriority_v129": {
+        "binary": "FUN_0044e000",
+        "role": "Primes audio cue slot 0 with a KSND sound name plus optional volume and priority overrides before playback.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Combat_ClearAudioCue0RuntimeHandle_v129": {
+        "binary": "FUN_0044e070",
+        "role": "Clears the stored runtime handle for audio cue slot 0.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Combat_PlayAudioCue_v129": {
+        "binary": "FUN_0044e080",
+        "role": "Plays a combat audio cue by cue-slot id, applying any stored default volume, pitch, and priority settings.",
+        "xrefs": 50,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control",
+          "combat-presentation-controls"
+        ]
+      },
+      "Combat_StopAudioCue_v129": {
+        "binary": "FUN_0044e180",
+        "role": "Stops a combat audio cue by cue-slot id if it is currently active.",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_IsAudioCuePlaying_v129": {
+        "binary": "FUN_0044e210",
+        "role": "Checks whether a combat audio cue slot is currently active.",
+        "xrefs": 12,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_SetAudioCueVolume_v129": {
+        "binary": "FUN_0044e250",
+        "role": "Sets the volume for a combat audio cue slot.",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_SetAudioCuePan_v129": {
+        "binary": "FUN_0044e2d0",
+        "role": "Sets the stereo pan for a combat audio cue slot.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_SetAudioCuePitch_v129": {
+        "binary": "FUN_0044e350",
+        "role": "Sets the pitch for a combat audio cue slot.",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-local-control"
+        ]
+      },
+      "Combat_LoadAnimationKeyframeSet_v129": {
+        "binary": "FUN_0044e3d0",
+        "role": "Loads one retail animation keyframe-set asset from `keyframe.bin` or an `anim\\\\%04d_.bin` archive entry.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-asset-loading"
+        ]
+      },
+      "Combat_ParseAnimationKeyframeSet_v129": {
+        "binary": "FUN_0044e5b0",
+        "role": "Parses one retail animation keyframe-set record and allocates its per-state transform-animation blocks.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-asset-loading"
+        ]
+      },
+      "Combat_ParseAnimationStateTrackSet_v129": {
+        "binary": "FUN_0044e6a0",
+        "role": "Parses one animation state's track-set header and allocates the nested transform track records for that state.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-asset-loading"
+        ]
+      },
+      "Combat_ParseAnimationTransformTrackPair_v129": {
+        "binary": "FUN_0044e790",
+        "role": "Parses one nested animation transform-track pair consisting of vector samples plus frame-time arrays.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-asset-loading"
+        ]
+      },
+      "Combat_FreeAnimationKeyframeSet_v129": {
+        "binary": "FUN_0044e9c0",
+        "role": "Frees a parsed retail animation keyframe-set and all nested translation/rotation track buffers.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-asset-loading"
+        ]
+      },
+      "Combat_FreeTransformAnimation_v129": {
+        "binary": "FUN_0044eab0",
+        "role": "Frees a retail transform-animation table and all nested translation/rotation track buffers.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-pose-sampling",
+          "combat-animation-instance-lifecycle"
+        ]
+      },
+      "Combat_AllocateAssetBuffer_v129": {
+        "binary": "FUN_0044eb40",
+        "role": "Allocates an asset buffer when the requested size is non-zero.",
+        "xrefs": 11,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-asset-loading"
+        ]
+      },
+      "Combat_FreeAssetBuffer_v129": {
+        "binary": "FUN_0044eb60",
+        "role": "Frees an asset buffer when the supplied pointer is non-null.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-asset-loading"
+        ]
+      },
+      "Combat_Load3dObjectDefinition_v129": {
+        "binary": "FUN_0044eb80",
+        "role": "Loads one retail 3d object definition from `3dobj.bin` or an `anim\\\\%04d_.bin` archive entry.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-asset-loading"
+        ]
+      },
+      "Combat_Parse3dObjectDefinition_v129": {
+        "binary": "FUN_0044ed60",
+        "role": "Parses one retail 3d object definition into the in-memory node, attachment, and mesh-reference tables used by combat rendering.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-asset-loading"
+        ]
+      },
+      "Combat_Free3dObjectDefinition_v129": {
+        "binary": "FUN_0044ee80",
+        "role": "Frees a parsed retail 3d object definition and all nested attachment/model buffers.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-asset-loading"
+        ]
+      },
+      "Combat_Parse3dObjectRecordTable_v129": {
+        "binary": "FUN_0044ef80",
+        "role": "Parses the variable-length table of 3d object records embedded in a retail 3d object definition.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-asset-loading"
+        ]
+      },
+      "Combat_SeekIndexedAssetById_v129": {
+        "binary": "FUN_0044f290",
+        "role": "Looks up an asset id in a cached retail indexed-directory table and seeks the archive handle to that entry.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-asset-loading"
+        ]
+      },
+      "Combat_ReadAssetBytesExact_v129": {
+        "binary": "FUN_0044f320",
+        "role": "Reads an exact byte count from the current retail asset stream and reports failure on short reads.",
+        "xrefs": 12,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-asset-loading"
+        ]
+      },
+      "Combat_FreeIndexedAssetDirectory_v129": {
+        "binary": "FUN_0044f350",
+        "role": "Frees one cached retail indexed-directory table and its `(id, offset)` rows.",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-asset-loading"
+        ]
+      },
+      "Combat_LoadIndexedAssetDirectory_v129": {
+        "binary": "FUN_0044f380",
+        "role": "Loads the header and `(id, offset)` rows for a retail indexed asset archive after verifying the expected format id.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-asset-loading"
+        ]
+      },
+      "Combat_Parse3dObjectVertexTable_v129": {
+        "binary": "FUN_0044f450",
+        "role": "Parses the vertex table for one retail 3d object record.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-asset-loading"
+        ]
+      },
+      "Combat_Parse3dObjectFaceTable_v129": {
+        "binary": "FUN_0044f4c0",
+        "role": "Parses the face table for one retail 3d object record, including per-face index lists and optional bitmap references.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-asset-loading"
+        ]
+      },
+      "Combat_Parse3dObjectFaceGroups_v129": {
+        "binary": "FUN_0044f700",
+        "role": "Parses the eight per-record face groups that remap face indices to direct face pointers.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-asset-loading"
+        ]
+      },
+      "Combat_Parse3dObjectRecordGroups_v129": {
+        "binary": "FUN_0044f7e0",
+        "role": "Parses the eight top-level record groups in a retail 3d object definition and resolves them to direct record pointers.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-asset-loading"
+        ]
+      },
+      "Combat_LoadIndexed3dObjectRecord_v129": {
+        "binary": "FUN_0044f8c0",
+        "role": "Loads one 3d object record from a retail indexed archive using the shared cached directory table.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-asset-loading"
+        ]
+      },
+      "Combat_Parse3dObjectRecord_v129": {
+        "binary": "FUN_0044f950",
+        "role": "Parses one standalone 3d object record and its variable sections from the current archive position.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-asset-loading"
+        ]
+      },
+      "Combat_ResetIndexedAssetDirectoryCaches_v129": {
+        "binary": "FUN_0044fa90",
+        "role": "Clears the cached indexed-directory tables used by the combat animation and 3d object asset loaders.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-animation-asset-loading",
+          "combat-terrain-scenery"
+        ]
+      },
+      "Combat_RasterizeFlatPolygon_v129": {
+        "binary": "FUN_0044fad8",
+        "role": "Fills one screen-space polygon with a uniform palette index through the retail flat-polygon rasterizer.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-tactical-overlays",
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_RasterizeGouraudPolygon_v129": {
+        "binary": "FUN_0044ff84",
+        "role": "Fills one screen-space polygon while linearly interpolating an 8-bit shade value across each span.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_RasterizeDitheredGouraudPolygon_v129": {
+        "binary": "FUN_004507cf",
+        "role": "Fills one screen-space polygon while interpolating an 8-bit shade term and alternating the shade phase across adjacent scanlines.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_ApplyLookupTableToProjectedPolygon_v129": {
+        "binary": "FUN_0045107d",
+        "role": "Applies a caller-supplied 256-entry lookup table to every destination byte covered by one projected screen-space polygon.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_RasterizeAdditiveDitheredGouraudPolygon_v129": {
+        "binary": "FUN_004515d1",
+        "role": "Fills one screen-space polygon by additively accumulating an interpolated dithered shade term into the destination surface.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Frame_SetTransformedBitmapPaletteLookupTable_v129": {
+        "binary": "FUN_00451e81",
+        "role": "Loads the active 256-entry palette lookup table used by the palette-mapped transformed-bitmap span callbacks.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_BlitTransformedBitmapCore_v129": {
+        "binary": "FUN_00451ea1",
+        "role": "Scan-converts one transformed source bitmap quadrilateral into the destination frame using one of four span callbacks.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_BlitTransformedBitmapPaletteMappedTransparentSpan_v129": {
+        "binary": "FUN_004523f4",
+        "role": "Draws one transparent palette-mapped transformed-bitmap span by translating source bytes through the active lookup table and skipping translated transparent results.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_BlitTransformedBitmapPaletteMappedOpaqueSpan_v129": {
+        "binary": "FUN_0045259b",
+        "role": "Draws one opaque transformed-bitmap span after remapping each sampled palette byte through the active transformed-bitmap lookup table.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_BlitTransformedBitmapTransparentSpan_v129": {
+        "binary": "FUN_00452707",
+        "role": "Draws one transparent transformed-bitmap span by skipping sampled source bytes equal to the retail transparent key.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_BlitTransformedBitmapOpaqueSpan_v129": {
+        "binary": "FUN_00452868",
+        "role": "Draws one opaque transformed-bitmap span by sampling the source surface and writing every decoded byte directly.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_AdvanceTransformedBitmapEdgesAndDispatchSpan_v129": {
+        "binary": "FUN_0045298d",
+        "role": "Advances the active transformed-bitmap edge walkers to the next visible scanline and dispatches the selected span callback.",
+        "xrefs": 8,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_CopyCallbackStringToScratchBuffer_v129": {
+        "binary": "FUN_00452bc4",
+        "role": "Invokes a zero-argument string callback, copies the returned C string into the shared frame scratch buffer, and returns that scratch pointer.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_ZeroCountScratchCopyStub_v129": {
+        "binary": "FUN_00452bed",
+        "role": "Dead scratch-copy stub that enters the same frame scratch buffer path as Frame_CopyCallbackStringToScratchBuffer_v129 but leaves the copy count at zero.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_SetClippedPixelAndReturnPrevious_v129": {
+        "binary": "FUN_00452c0c",
+        "role": "Writes one pixel inside the clipped destination frame and returns the previous palette index from that location.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_GetClippedPixel_v129": {
+        "binary": "FUN_00452ce7",
+        "role": "Returns one pixel from a clipped destination frame region, with negative status codes for invalid or out-of-bounds requests.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DrawClippedLineCore_v129": {
+        "binary": "FUN_00452dbd",
+        "role": "Clips and rasterizes one line segment against the destination frame bounds, supporting solid-color, palette-remap, and callback-driven pixel modes.",
+        "xrefs": 73,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_FillRelativeRect_v129": {
+        "binary": "FUN_004537bf",
+        "role": "Fills one frame-local rectangle, offset relative to the owning panel clip, with a solid palette index.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_BlitTransparentBitmapCommandClipped_v129": {
+        "binary": "FUN_004538f8",
+        "role": "Blits one retail transparent bitmap command-stream entry into the destination frame with clip-rectangle handling.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_BlitTransparentBitmapCommandFast_v129": {
+        "binary": "FUN_00453cfc",
+        "role": "Blits one retail transparent bitmap command-stream entry without additional clipping checks.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_SetTransparentBitmapPaletteLookupTable_v129": {
+        "binary": "FUN_00453dc3",
+        "role": "Loads the active 256-entry palette lookup table used by the palette-mapped transparent bitmap command blitters.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_BlitPaletteMappedTransparentBitmapCommandClipped_v129": {
+        "binary": "FUN_00453de2",
+        "role": "Blits one retail transparent bitmap command-stream entry into the destination frame after remapping each source palette index through the active lookup table, with clip handling.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_BlitPaletteMappedTransparentBitmapCommandFast_v129": {
+        "binary": "FUN_004542ba",
+        "role": "Blits one palette-mapped retail transparent bitmap command-stream entry without additional clipping checks.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_BlitTransformedTransparentBitmapCommand_v129": {
+        "binary": "FUN_004543ed",
+        "role": "Blits one retail transparent bitmap command-stream entry through the transformed draw path, supporting rotation, independent x/y scale, and optional palette remapping.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_ComputeTransparentBitmapCommandBounds_v129": {
+        "binary": "FUN_00454f99",
+        "role": "Walks one retail transparent bitmap command stream entry and reports the bounding rectangle it would touch at the requested origin.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_EncodeTransparentBitmapCommandStream_v129": {
+        "binary": "FUN_00455111",
+        "role": "Scans a clipped 8-bit bitmap rect against a transparent key, computes the non-transparent bounds, and encodes the surviving rows into the retail transparent bitmap command stream.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_ApplyTransparentBitmapCommandPaletteMapInPlace_v129": {
+        "binary": "FUN_00455394",
+        "role": "Applies the active transparent-bitmap palette lookup table directly to one encoded command payload in place.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_EncodeTransparentBitmapCommandRow_v129": {
+        "binary": "FUN_00455426",
+        "role": "Encodes one bounded bitmap row into transparent-skip, literal-byte, and repeated-byte commands for the retail transparent bitmap stream.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_EmitTransparentBitmapRunCommand_v129": {
+        "binary": "FUN_004555af",
+        "role": "Appends one command to the retail transparent bitmap row stream and updates the tracked horizontal bounds for the encoded image.",
+        "xrefs": 9,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_FillRect_v129": {
+        "binary": "FUN_0045578c",
+        "role": "Fills a clipped rectangle inside a frame's backing buffer with one palette index value.",
+        "xrefs": 38,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-picture-bootstrap",
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_CopyOrFillClippedRect_v129": {
+        "binary": "FUN_0045586b",
+        "role": "Copies a clipped rectangle from a raw source pixel buffer into a destination frame rectangle, or fills that clipped region with a solid palette index.",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_ScrollClippedRectWithWrapOrFill_v129": {
+        "binary": "FUN_00455c07",
+        "role": "Shifts a clipped frame rectangle by the requested delta, then either fills the exposed area with a solid byte or wraps in pixels from a source tile buffer.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DrawEllipseOutline_v129": {
+        "binary": "FUN_00455e04",
+        "role": "Draws an ellipse outline centered at the requested point using the supplied radii and palette index.",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DrawFilledEllipse_v129": {
+        "binary": "FUN_00456145",
+        "role": "Draws a filled ellipse centered at the requested point using the supplied radii and palette index.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_GetFixedCosSinByAngle_v129": {
+        "binary": "FUN_00457257",
+        "role": "Returns the retail fixed-point cosine and sine for an angle normalized into the renderer's 0xE10-step circle.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_MultiplyFixed16_16Rounded_v129": {
+        "binary": "FUN_0045730f",
+        "role": "Multiplies two 16.16 fixed-point values and stores the rounded 16.16 result.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_TransformPointAroundPivotByAngleAndScale_v129": {
+        "binary": "FUN_00457335",
+        "role": "Rotates and non-uniformly scales one point around a pivot using the retail fixed-angle lookup tables.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_GetFontLineHeight_v129": {
+        "binary": "FUN_004573fc",
+        "role": "Returns the retail font line height from the active font descriptor.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_GetBitmapFontGlyphDescriptor_v129": {
+        "binary": "FUN_0045740f",
+        "role": "Returns the first descriptor dword for one glyph from a loaded retail TFONT blob.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DrawGlyph_v129": {
+        "binary": "FUN_0045742f",
+        "role": "Draws one retail glyph into the destination frame buffer and returns its horizontal advance.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-actor-preview",
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DrawString_v129": {
+        "binary": "FUN_004575c2",
+        "role": "Draws a null-terminated retail string one glyph at a time and advances by each glyph's rendered width.",
+        "xrefs": 8,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-actor-preview",
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_CopyClippedBitmapRowToSurface_v129": {
+        "binary": "FUN_004575f9",
+        "role": "Copies one decoded bitmap row into the destination surface while clipping against the target bounds.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_FindIffBitmapChunkByTag_v129": {
+        "binary": "FUN_00457708",
+        "role": "Walks a tagged IFF bitmap payload and returns the data pointer for the requested chunk tag.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_BlitIffBitmapToSurface_v129": {
+        "binary": "FUN_0045774a",
+        "role": "Locates the `BMHD` and `BODY` chunks in a retail IFF bitmap and blits the decoded rows into the destination surface.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_CopyIffBitmapPaletteToBuffer_v129": {
+        "binary": "FUN_00457911",
+        "role": "Copies the `CMAP` chunk from a retail IFF bitmap into a 256-color palette buffer.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_GetIffBitmapDimensions_v129": {
+        "binary": "FUN_00457942",
+        "role": "Returns the width and height stored in the `BMHD` chunk of a retail IFF bitmap.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_BlitPcxBitmapToSurface_v129": {
+        "binary": "FUN_0045796f",
+        "role": "Decodes one retail PCX bitmap payload row by row and blits the expanded palette indices into the destination surface.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_CopyPcxBitmapPaletteToBuffer_v129": {
+        "binary": "FUN_004579f1",
+        "role": "Copies the trailing 256-color PCX palette block into a caller buffer, downshifting the stored RGB bytes into the retail 6-bit palette space.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_GetPcxBitmapDimensions_v129": {
+        "binary": "FUN_00457a1c",
+        "role": "Returns the width and height stored in a retail PCX header.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_InitializeGifLzwCodeTable_v129": {
+        "binary": "FUN_00457a43",
+        "role": "Initializes the GIF/LZW code table for one retail GIF image decode pass.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_ReadGifDataSubBlockByte_v129": {
+        "binary": "FUN_00457a8b",
+        "role": "Reads the next byte from a GIF image-data sub-block stream.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_ReadGifLzwCode_v129": {
+        "binary": "FUN_00457aa4",
+        "role": "Pulls one variable-width LZW code from the current GIF image-data bitstream.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_AppendGifLzwCodeEntry_v129": {
+        "binary": "FUN_00457aea",
+        "role": "Adds one derived entry to the active GIF/LZW dictionary.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_EmitGifDecodedPixel_v129": {
+        "binary": "FUN_00457b30",
+        "role": "Appends one decoded GIF palette index to the temporary row buffer and flushes completed rows to the destination surface.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_DecodeGifImageToSurface_v129": {
+        "binary": "FUN_00457bad",
+        "role": "Decodes one GIF image descriptor and blits the resulting palette indices into the destination surface.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_CopyGifActivePaletteToBuffer_v129": {
+        "binary": "FUN_00457dc6",
+        "role": "Copies the active GIF color table into a palette buffer, downshifting the stored RGB bytes into the retail 6-bit palette space.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_GetGifImageDimensions_v129": {
+        "binary": "FUN_00457e27",
+        "role": "Returns the width and height stored in the first GIF image descriptor after the optional global color table.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_GetTransparentBitmapCommandSourceRectSize_v129": {
+        "binary": "FUN_00457e5f",
+        "role": "Returns the stored source-rect size pair from one retail transparent bitmap command-stream entry header.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_GetTransparentBitmapCommandDestinationOrigin_v129": {
+        "binary": "FUN_00457e81",
+        "role": "Returns the stored destination origin pair from one retail transparent bitmap command-stream entry header.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_GetTransparentBitmapCommandSize_v129": {
+        "binary": "FUN_00457ea4",
+        "role": "Returns the inclusive width and height of one retail transparent bitmap command-stream entry.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_GetTransparentBitmapCommandOrigin_v129": {
+        "binary": "FUN_00457ed8",
+        "role": "Returns the stored top-left origin of one retail transparent bitmap command-stream entry.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_ApplyTransparentBitmapCommandPaletteMapToBuffer_v129": {
+        "binary": "FUN_00457f02",
+        "role": "Applies one transparent-bitmap command palette-map table to a 256-color RGB buffer.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_CopyTransparentBitmapCommandPaletteMapEntries_v129": {
+        "binary": "FUN_00457f4d",
+        "role": "Copies the packed palette-map dwords from one transparent-bitmap command-set entry into caller storage.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_StoreTransparentBitmapCommandPaletteMapEntries_v129": {
+        "binary": "FUN_00457f95",
+        "role": "Stores packed palette-map dwords into the palette-map block for one transparent-bitmap command-set entry.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_GetTransparentBitmapCommandSetEntryCount_v129": {
+        "binary": "FUN_00457fdf",
+        "role": "Returns the entry count stored in one transparent-bitmap command set header.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_CountUniqueTransparentBitmapCommandEntries_v129": {
+        "binary": "FUN_00457ff2",
+        "role": "Counts the distinct command-entry payload offsets referenced by one transparent-bitmap command set.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_CountUniqueTransparentBitmapCommandPaletteMaps_v129": {
+        "binary": "FUN_00458054",
+        "role": "Counts the distinct palette-map payload offsets referenced by one transparent-bitmap command set.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Frame_FadeBitmapPaletteTowardTarget_v129": {
+        "binary": "FUN_004583a9",
+        "role": "Animates the palette entries actually used by one bitmap toward a target RGB palette buffer over the requested retail delay budget.",
+        "xrefs": 7,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-picture-bootstrap"
+        ]
+      },
+      "Frame_CollectBitmapRectUniquePaletteIndices_v129": {
+        "binary": "FUN_0045852f",
+        "role": "Scans one bitmap sub-rect and returns the distinct palette indices it contains.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "frame-text-rendering"
+        ]
+      },
+      "Combat_TransformPointListByMatrix4x4_v129": {
+        "binary": "FUN_004585bc",
+        "role": "Transforms a strided list of retail combat points through a 4x4 fixed-point matrix.",
+        "xrefs": 20,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-transform-math"
+        ]
+      },
+      "Combat_TransformTerrainSceneryObjectVertices_v129": {
+        "binary": "FUN_00458695",
+        "role": "Transforms one terrain-scenery object's cached vertex list into the shared render scratch buffer.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-tactical-overlays"
+        ]
+      },
+      "Combat_TransformVectorByMatrix3x3_v129": {
+        "binary": "FUN_00458744",
+        "role": "Transforms one retail xyz vector by the rotational 3x3 basis of a fixed-point matrix.",
+        "xrefs": 26,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-transform-math"
+        ]
+      },
+      "Combat_SetSharedRenderLimitGlobals_v129": {
+        "binary": "FUN_00469e29",
+        "role": "Stores the shared render-limit globals consumed by the retail combat projection and backdrop passes.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-visual-bootstrap"
+        ]
+      },
+      "Combat_DispatchProjectedPolygon_v129": {
+        "binary": "FUN_00469e46",
+        "role": "Submits one already projected screen-space polygon directly to the retail solid-polygon render callback table.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-environment-backdrop",
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_ComputeRoundedShift30Quotient_v129": {
+        "binary": "FUN_00469eb8",
+        "role": "Computes the signed rounded quotient `(numerator << 30) / denominator`.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_ComputeRoundedShift46Reciprocal_v129": {
+        "binary": "FUN_00469ef0",
+        "role": "Computes the signed rounded reciprocal `(1 << 46) / value`.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_ClipAndDispatchProjectedPolygon_v129": {
+        "binary": "FUN_00469f3c",
+        "role": "Clips one projected screen-space polygon to the active viewport rectangle and dispatches the surviving polygon to the retail solid render path.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-environment-backdrop",
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_SoftwareRasterizerTexturedSpan_v129": {
+        "binary": "FUN_0046a764",
+        "role": "Root self-patching textured-span kernel used by the retail software rasterizer.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-environment-backdrop",
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_SoftwareRasterizerAmbientGroundDetailSpan_v129": {
+        "binary": "FUN_0046ae0e",
+        "role": "Caller-specific self-patching textured-span kernel used by the GRD ambient ground-detail pass.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-environment-backdrop"
+        ]
+      },
+      "Combat_SoftwareRasterizerPaletteMapped16BitTexturedSpan_v129": {
+        "binary": "FUN_0046b50b",
+        "role": "Self-patching textured-span kernel that maps each sampled texel through a 256-entry duplicated-16-bit color table before writing one word per destination pixel.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_SoftwareRasterizerPaletteMapped16BitDoubleWideTexturedSpan_v129": {
+        "binary": "FUN_0046bcf4",
+        "role": "Self-patching textured-span kernel that expands each sampled texel into two adjacent 16-bit destination pixels through the active color lookup table.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_SoftwareRasterizerClippedTexturedSpan_v129": {
+        "binary": "FUN_0046c253",
+        "role": "Textured-span kernel that pre-applies the current left/right clip offsets before dispatching the generic 8-bit software rasterizer path.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_SoftwareRasterizerClippedPaletteMapped16BitTexturedSpan_v129": {
+        "binary": "FUN_0046c98a",
+        "role": "Clipped 16-bit palette-mapped textured-span kernel that advances into the surviving span before emitting one looked-up destination word per texel.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_SoftwareRasterizerClippedPaletteMapped16BitDoubleWideTexturedSpan_v129": {
+        "binary": "FUN_0046d210",
+        "role": "Clipped double-wide 16-bit textured-span kernel that expands each sampled texel into a duplicated 16-bit pair after the span start is clip-adjusted.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "System_GetSoftwareRasterizerSpanCodeSize_v129": {
+        "binary": "FUN_0046d80f",
+        "role": "Returns the byte size of the self-patching software-rasterizer span-code block.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "Combat_SoftwareRasterizerSpanCodeDeadLoop_v129": {
+        "binary": "FUN_0046d827",
+        "role": "Unreachable infinite-loop sentinel left at the tail of the unlocked software-rasterizer span-code block.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_RasterizeTexturedPolygonToSurface_v129": {
+        "binary": "FUN_0046d8a8",
+        "role": "Thin wrapper that extracts a destination surface's pitch and pixel pointer before invoking the retail textured polygon rasterizer.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-projectile-effects"
+        ]
+      },
+      "Combat_RasterizeTexturedPolygon_v129": {
+        "binary": "FUN_0046d8f4",
+        "role": "Rasterizes one linked textured polygon into the destination surface using the retail software span-walker path.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "combat-environment-backdrop",
+          "combat-projectile-effects"
+        ]
+      },
+      "KSND_SpeechOutData": {
+        "binary": "FUN_0046de5c",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "audio-runtime"
+        ]
+      },
+      "KSND_SpeechInCleanupPacket": {
+        "binary": "FUN_0046de62",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "audio-runtime"
+        ]
+      },
+      "KSND_SpeechInData": {
+        "binary": "FUN_0046de68",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "audio-runtime"
+        ]
+      },
+      "KSND_C_update": {
+        "binary": "FUN_0046de6e",
+        "role": "Per-frame update tick for the retail KSND audio runtime.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "audio-runtime"
+        ]
+      },
+      "KSND_C_setParamSnd": {
+        "binary": "FUN_0046de74",
+        "role": "Sets the sound payload or identifier for a KSND parameter slot.",
+        "xrefs": 24,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "audio-runtime"
+        ]
+      },
+      "KSND_C_play": {
+        "binary": "FUN_0046de7a",
+        "role": "Plays a named/parameterized retail sound slot.",
+        "xrefs": 17,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "audio-runtime"
+        ]
+      },
+      "KSND_C_panic": {
+        "binary": "FUN_0046de80",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "KSND_C_readKDT": {
+        "binary": "FUN_0046de86",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "KSND_C_init": {
+        "binary": "FUN_0046de8c",
+        "role": "Initializes the retail KSND sound runtime.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "audio-runtime"
+        ]
+      },
+      "KSND_C_shutdown": {
+        "binary": "FUN_0046de92",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "audio-runtime"
+        ]
+      },
+      "KSND_C_statusSnd": {
+        "binary": "FUN_0046de98",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "audio-runtime"
+        ]
+      },
+      "KSND_C_shiftParamSnd": {
+        "binary": "FUN_0046de9e",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "audio-runtime"
+        ]
+      },
+      "KSND_C_getParamSnd": {
+        "binary": "FUN_0046dea4",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "audio-runtime"
+        ]
+      },
+      "KSND_C_stopSnd": {
+        "binary": "FUN_0046deaa",
+        "role": "Stops a currently active retail sound slot.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "audio-runtime"
+        ]
+      },
+      "KSND_SpeechInStart": {
+        "binary": "FUN_0046deb0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "audio-runtime"
+        ]
+      },
+      "KSND_SpeechInStop": {
+        "binary": "FUN_0046deb6",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "audio-runtime"
+        ]
+      },
+      "KSND_C_setParamName": {
+        "binary": "FUN_0046debc",
+        "role": "Sets the logical name for a KSND parameter slot.",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "audio-runtime"
+        ]
+      },
+      "KSND_C_shiftParamName": {
+        "binary": "FUN_0046dec2",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "audio-runtime"
+        ]
+      },
+      "KSND_C_getParamName": {
+        "binary": "FUN_0046dec8",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "audio-runtime"
+        ]
+      },
+      "KSND_C_stopName": {
+        "binary": "FUN_0046dece",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "audio-runtime"
+        ]
+      },
+      "KSND_C_statusName": {
+        "binary": "FUN_0046ded4",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "audio-runtime"
+        ]
+      },
+      "SetInternet": {
+        "binary": "FUN_0046deda",
+        "role": "Stores the 'internet' address/login field from redirect or launch data.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "aries-login-runtime"
+        ]
+      },
+      "SetUserEmailHandle": {
+        "binary": "FUN_0046dee0",
+        "role": "Stores the retail email/handle login field.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "aries-login-runtime"
+        ]
+      },
+      "SetServerIdent": {
+        "binary": "FUN_0046dee6",
+        "role": "Stores the retail server-ident field in the login block.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "aries-login-runtime"
+        ]
+      },
+      "SetProductCode": {
+        "binary": "FUN_0046deec",
+        "role": "Stores the retail product/server-port code in the login block.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "aries-login-runtime"
+        ]
+      },
+      "MakeTCPConnection": {
+        "binary": "FUN_0046def2",
+        "role": "Opens the primary lobby ARIES TCP connection.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "aries-login-runtime"
+        ]
+      },
+      "SetUserPassword": {
+        "binary": "FUN_0046def8",
+        "role": "Stores the retail login password field.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "aries-login-runtime"
+        ]
+      },
+      "SetUserName": {
+        "binary": "FUN_0046defe",
+        "role": "Stores the retail login username field.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "aries-login-runtime"
+        ]
+      },
+      "SendTCPSound": {
+        "binary": "FUN_0046df04",
+        "role": "Low-level retail TCP sound/voice transport helper.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "aries-login-runtime"
+        ]
+      },
+      "CEShutDown": {
+        "binary": "FUN_0046df0a",
+        "role": "Kesmai communication-engine shutdown/runtime teardown entry.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "aries-login-runtime"
+        ]
+      },
+      "MakeSocketWindow": {
+        "binary": "FUN_0046df10",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "SendTCPData": {
+        "binary": "FUN_0046df16",
+        "role": "Low-level retail TCP send helper after CRC/frame assembly.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "aries-login-runtime"
+        ]
+      },
+      "init_aries": {
+        "binary": "FUN_0046df1c",
+        "role": "Initializes the ARIES communication layer used by the retail client.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "aries-login-runtime"
+        ]
+      },
+      "DirectDrawCreate": {
+        "binary": "FUN_0046df22",
+        "role": "DirectDraw runtime import used by the original Win32 renderer.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "_sprintf": {
+        "binary": "FUN_0046df30",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 211,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_FreeHeapBlock_v129": {
+        "binary": "FUN_0046dfa0",
+        "role": "Frees one retail heap block when the supplied pointer is non-null.",
+        "xrefs": 125,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_AllocateHeapBlock_v129": {
+        "binary": "FUN_0046dfc0",
+        "role": "Allocates one retail heap block using the default retry/failure-handler mode.",
+        "xrefs": 98,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_AllocateHeapBlockWithRetry_v129": {
+        "binary": "FUN_0046dfe0",
+        "role": "Attempts a retail heap allocation and optionally retries after invoking the allocation-failure handler.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_AllocateHeapBlockRaw_v129": {
+        "binary": "FUN_0046e020",
+        "role": "Calls `HeapAlloc` on the cached retail process heap handle for one requested size.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_SplitPathComponents_v129": {
+        "binary": "FUN_0046e040",
+        "role": "Splits one path string into retail drive, directory, filename, and extension buffers.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_CloseFileStream_v129": {
+        "binary": "FUN_0046e1a0",
+        "role": "Flushes, closes, and tears down one retail `FILE*` stream.",
+        "xrefs": 33,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "FID_conflict:_fwprintf": {
+        "binary": "FUN_0046e210",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 12,
+        "source": "retail_function_catalog.gd"
+      },
+      "_ctime": {
+        "binary": "FUN_0046e250",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd"
+      },
+      "_time": {
+        "binary": "FUN_0046e270",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 14,
+        "source": "retail_function_catalog.gd"
+      },
+      "__fsopen": {
+        "binary": "FUN_0046e380",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_OpenFileStream_v129": {
+        "binary": "FUN_0046e3b0",
+        "role": "Opens one retail file stream with the requested mode string and the shared frontend file-sharing policy.",
+        "xrefs": 24,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "_strncmp": {
+        "binary": "FUN_0046e3d0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 7,
+        "source": "retail_function_catalog.gd"
+      },
+      "_sscanf": {
+        "binary": "FUN_0046e410",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd"
+      },
+      "_strchr": {
+        "binary": "FUN_0046e470",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 12,
+        "source": "retail_function_catalog.gd"
+      },
+      "_strrchr": {
+        "binary": "FUN_0046e530",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_SetCrtRandomSeed_v129": {
+        "binary": "FUN_0046e560",
+        "role": "Stores the seed used by the retail CRT `_rand` generator.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "_rand": {
+        "binary": "FUN_0046e570",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 70,
+        "source": "retail_function_catalog.gd"
+      },
+      "_strncpy": {
+        "binary": "FUN_0046e5a0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 60,
+        "source": "retail_function_catalog.gd"
+      },
+      "_atol": {
+        "binary": "FUN_0046e6a0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd"
+      },
+      "_atoi": {
+        "binary": "FUN_0046e750",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "__isctype": {
+        "binary": "FUN_0046e760",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 30,
+        "source": "retail_function_catalog.gd"
+      },
+      "__ftol": {
+        "binary": "FUN_0046e7f4",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 17,
+        "source": "retail_function_catalog.gd"
+      },
+      "__fpmath": {
+        "binary": "FUN_0046e820",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_InitializeFpmathDispatchTable_v129": {
+        "binary": "FUN_0046e850",
+        "role": "Initializes the retail floating-point helper dispatch table used by the CRT fpmath runtime.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_ReallocateHeapBlock_v129": {
+        "binary": "FUN_0046e890",
+        "role": "Reallocates one retail heap block, allocating on null and freeing on zero size.",
+        "xrefs": 14,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "_fread": {
+        "binary": "FUN_0046e900",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 26,
+        "source": "retail_function_catalog.gd"
+      },
+      "__filbuf": {
+        "binary": "FUN_0046ea50",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd"
+      },
+      "_fseek": {
+        "binary": "FUN_0046eb40",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_AllocateZeroedHeapBlock_v129": {
+        "binary": "FUN_0046ebe0",
+        "role": "Allocates one zero-initialized retail heap block sized as `count * bytes_per_item`.",
+        "xrefs": 9,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "_clock": {
+        "binary": "FUN_0046ec40",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "FID_conflict:_vfwprintf": {
+        "binary": "FUN_0046ec90",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "FID_conflict:_memcpy": {
+        "binary": "FUN_0046ecd0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "_fwrite": {
+        "binary": "FUN_0046ee20",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd"
+      },
+      "__flsbuf": {
+        "binary": "FUN_0046efa0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd"
+      },
+      "_fgets": {
+        "binary": "FUN_0046f0f0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd"
+      },
+      "_rewind": {
+        "binary": "FUN_0046f160",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "FID_conflict:__toupper_lk": {
+        "binary": "FUN_0046f2b0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_ConvertIntegerDifferenceToExtendedFloat80_v129": {
+        "binary": "FUN_0046f3a0",
+        "role": "Subtracts one 32-bit integer from another and returns the difference as an 80-bit extended-float value.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_QuickSort_v129": {
+        "binary": "FUN_0046f3c0",
+        "role": "Sorts an array of fixed-size records with the retail quicksort implementation.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_ShortSort_v129": {
+        "binary": "FUN_0046f520",
+        "role": "Sorts a tiny fixed-size record range with the retail short-sort fallback used by quicksort.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "swap": {
+        "binary": "FUN_0046f580",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd"
+      },
+      "_fgetc": {
+        "binary": "FUN_0046f5b0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd"
+      },
+      "_strstr": {
+        "binary": "FUN_0046f5e0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "__makepath": {
+        "binary": "FUN_0046f660",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "__filelength": {
+        "binary": "FUN_0046f700",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_CloseFileDescriptor_v129": {
+        "binary": "FUN_0046f790",
+        "role": "Closes one retail low-level file descriptor and clears its CRT descriptor-table slot.",
+        "xrefs": 23,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_ReadFileDescriptorBytes_v129": {
+        "binary": "FUN_0046f860",
+        "role": "Reads bytes from one retail low-level file descriptor into a caller buffer.",
+        "xrefs": 8,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_SeekFileDescriptor_v129": {
+        "binary": "FUN_0046fad0",
+        "role": "Moves one retail low-level file descriptor to a new byte offset.",
+        "xrefs": 19,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_OpenFileDescriptor_v129": {
+        "binary": "FUN_0046fb90",
+        "role": "Opens one retail low-level file descriptor with the default share mode used by raw asset readers.",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_OpenFileDescriptorWithShareMode_v129": {
+        "binary": "FUN_0046fbb0",
+        "role": "Creates one retail low-level file descriptor from a path, open flags, share mode, and permission bits.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "__cinit": {
+        "binary": "FUN_0046ffd0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_ExitProcess_v129": {
+        "binary": "FUN_00470000",
+        "role": "Runs the retail shutdown sequence with the default flags and then terminates the process with one exit code.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "__exit": {
+        "binary": "FUN_00470020",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_RunExitSequence_v129": {
+        "binary": "FUN_00470040",
+        "role": "Runs the retail CRT shutdown sequence and optionally terminates the process.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "__initterm": {
+        "binary": "FUN_004700f0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd"
+      },
+      "entry": {
+        "binary": "FUN_00470110",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "__amsg_exit": {
+        "binary": "FUN_004702a0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_FormatPrintfCore_v129": {
+        "binary": "FUN_004702d0",
+        "role": "Shared retail printf-style format engine used by the CRT string and stream formatting wrappers.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "write_char": {
+        "binary": "FUN_00470cb0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd"
+      },
+      "write_multi_char": {
+        "binary": "FUN_00470d00",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd"
+      },
+      "write_string": {
+        "binary": "FUN_00470d40",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_ReadVarArg32_v129": {
+        "binary": "FUN_00470d80",
+        "role": "Reads one 32-bit value from the retail vararg cursor and advances the cursor.",
+        "xrefs": 10,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_ReadVarArg64_v129": {
+        "binary": "FUN_00470d90",
+        "role": "Reads one 64-bit value from the retail vararg cursor and advances the cursor.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_ReadVarArg16_v129": {
+        "binary": "FUN_00470db0",
+        "role": "Reads one 16-bit value from the retail vararg cursor while consuming one aligned argument slot.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_InitializeProcessHeap_v129": {
+        "binary": "FUN_00470dc0",
+        "role": "Creates the dedicated retail process heap used by the shared allocation wrappers.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_InvokeAllocationFailureHandler_v129": {
+        "binary": "FUN_00470de0",
+        "role": "Invokes the retail allocation-failure callback for one requested heap size.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "__mbsnbcpy": {
+        "binary": "FUN_00470e00",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd"
+      },
+      "__setmbcp": {
+        "binary": "FUN_00470e90",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "getSystemCP": {
+        "binary": "FUN_00471070",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "_CPtoLCID": {
+        "binary": "FUN_004710c0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "setSBCS": {
+        "binary": "FUN_00471120",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "___initmbctable": {
+        "binary": "FUN_00471150",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "__freebuf": {
+        "binary": "FUN_00471160",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "_fflush": {
+        "binary": "FUN_004711a0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "__flush": {
+        "binary": "FUN_004711f0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 7,
+        "source": "retail_function_catalog.gd"
+      },
+      "flsall": {
+        "binary": "FUN_00471270",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "__stbuf": {
+        "binary": "FUN_00471300",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "__ftbuf": {
+        "binary": "FUN_004713a0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "_asctime": {
+        "binary": "FUN_004713f0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "store_dt": {
+        "binary": "FUN_004714b0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd"
+      },
+      "_localtime": {
+        "binary": "FUN_004714e0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd"
+      },
+      "___loctotime_t": {
+        "binary": "FUN_004716b0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "__openfile": {
+        "binary": "FUN_004717a0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_AllocateFileStreamSlot_v129": {
+        "binary": "FUN_004719b0",
+        "role": "Claims or reuses one retail `FILE` stream structure from the shared stream table.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_ScanFormatCore_v129": {
+        "binary": "FUN_00471a30",
+        "role": "Shared retail scanf-style parsing core used by the CRT scan wrappers.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "__hextodec": {
+        "binary": "FUN_004726d0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "__inc": {
+        "binary": "FUN_00472710",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 18,
+        "source": "retail_function_catalog.gd"
+      },
+      "__un_inc": {
+        "binary": "FUN_00472740",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 9,
+        "source": "retail_function_catalog.gd"
+      },
+      "__whiteout": {
+        "binary": "FUN_00472760",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "___crtGetStringTypeA": {
+        "binary": "FUN_00472790",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "__setdefaultprecision": {
+        "binary": "FUN_004728c0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "__ms_p5_test_fdiv": {
+        "binary": "FUN_004728e0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_TestFdivAcrossProcessors_v129": {
+        "binary": "FUN_00472930",
+        "role": "Runs the retail Pentium FDIV/self-test across the available processor affinity masks.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "__cftoe": {
+        "binary": "FUN_00472bc0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "__cftof": {
+        "binary": "FUN_00472d00",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "__cftog": {
+        "binary": "FUN_00472e00",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "__cftoe_g": {
+        "binary": "FUN_00472eb0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "__cftof_g": {
+        "binary": "FUN_00472ee0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "__shift": {
+        "binary": "FUN_00472f80",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_InitializeFileDescriptorTable_v129": {
+        "binary": "FUN_00472fb0",
+        "role": "Builds the retail CRT file-descriptor table from startup info and standard handles.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "__getbuf": {
+        "binary": "FUN_00473190",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd"
+      },
+      "_ftell": {
+        "binary": "FUN_004731e0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "__ftime": {
+        "binary": "FUN_00473390",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_WriteFileDescriptorBytes_v129": {
+        "binary": "FUN_00473440",
+        "role": "Writes bytes from one caller buffer into a retail low-level file descriptor.",
+        "xrefs": 5,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "__isatty": {
+        "binary": "FUN_00473670",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_CloseAllFileStreams_v129": {
+        "binary": "FUN_004736a0",
+        "role": "Closes every retail `FILE` stream beyond the standard stdin/stdout/stderr trio.",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_MapLocaleStringA_v129": {
+        "binary": "FUN_00473720",
+        "role": "Applies locale-aware `LCMapStringA`-style transforms to a multibyte source string.",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "_strncnt": {
+        "binary": "FUN_00473950",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "also_at": [
+          {
+            "binary": "FUN_004779c0",
+            "xrefs": 2
+          }
+        ]
+      },
+      "__mbsdec": {
+        "binary": "FUN_00473980",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_MapWin32ErrorToRuntimeError_v129": {
+        "binary": "FUN_004739e0",
+        "role": "Maps one Win32 `GetLastError` code into the retail runtime error globals.",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_AllocateFileDescriptorSlot_v129": {
+        "binary": "FUN_00473a50",
+        "role": "Claims one free retail file-descriptor slot, growing the descriptor table on demand.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "__set_osfhnd": {
+        "binary": "FUN_00473b10",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_ClearFileDescriptorSlot_v129": {
+        "binary": "FUN_00473bc0",
+        "role": "Clears one retail file-descriptor slot after its OS handle has been closed or detached.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "__get_osfhandle": {
+        "binary": "FUN_00473c50",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 6,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_SetFileDescriptorLength_v129": {
+        "binary": "FUN_00473ca0",
+        "role": "Truncates or extends one retail low-level file descriptor to a caller-selected byte length.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "__global_unwind2": {
+        "binary": "FUN_00473e08",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "__local_unwind2": {
+        "binary": "FUN_00473e4a",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd"
+      },
+      "__NLG_Notify": {
+        "binary": "FUN_00473ede",
+        "role": "CRT unwind-notification helper that snapshots the current unwind callback context for the debugger/runtime globals.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "__ismbblead": {
+        "binary": "FUN_00474090",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "x_ismbbtype": {
+        "binary": "FUN_004740b0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_InitializeEnvironmentPointerTable_v129": {
+        "binary": "FUN_004740f0",
+        "role": "Builds the retail `environ` pointer table from the copied process environment block.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "__setargv": {
+        "binary": "FUN_004741d0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "parse_cmdline": {
+        "binary": "FUN_00474270",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_LoadEnvironmentStringsA_v129": {
+        "binary": "FUN_00474450",
+        "role": "Loads the process environment block as a heap-owned ANSI string bundle.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "__seh_longjmp_unwind@4": {
+        "binary": "FUN_004746a9",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 0,
+        "source": "retail_function_catalog.gd"
+      },
+      "__FF_MSGBANNER": {
+        "binary": "FUN_004746d0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_ReportRuntimeErrorMessage_v129": {
+        "binary": "FUN_00474710",
+        "role": "Reports one retail CRT runtime-error message to stderr or a modal dialog.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "_wctomb": {
+        "binary": "FUN_00474900",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd"
+      },
+      "__aulldiv": {
+        "binary": "FUN_004749a0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "__aullrem": {
+        "binary": "FUN_00474a10",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_CommitFileDescriptor_v129": {
+        "binary": "FUN_00474a90",
+        "role": "Commits one retail file descriptor by flushing its underlying OS handle buffers.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "___tzset": {
+        "binary": "FUN_00474b00",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_RefreshTimeZoneState_v129": {
+        "binary": "FUN_00474b20",
+        "role": "Refreshes the retail timezone offset, DST bias, and timezone-name caches from `TZ` or Win32.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_IsTmInDaylightSavingTime_v129": {
+        "binary": "FUN_00474dd0",
+        "role": "Checks whether one broken-down local `tm` record falls inside the cached daylight-saving interval.",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "cvtdate": {
+        "binary": "FUN_00475030",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd"
+      },
+      "_gmtime": {
+        "binary": "FUN_004751c0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd"
+      },
+      "__allmul": {
+        "binary": "FUN_00475310",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "_mbtowc": {
+        "binary": "FUN_00475350",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "_isspace": {
+        "binary": "FUN_00475460",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "FID_conflict:_ungetc": {
+        "binary": "FUN_00475490",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "__control87": {
+        "binary": "FUN_00475520",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "__controlfp": {
+        "binary": "FUN_00475560",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "__abstract_cw": {
+        "binary": "FUN_00475580",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "__hw_cw": {
+        "binary": "FUN_00475630",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_ReportFloatingPointSupportNotLoaded_v129": {
+        "binary": "FUN_004756c0",
+        "role": "Raises the retail CRT fatal error for missing floating-point runtime support.",
+        "xrefs": 10,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "_tolower": {
+        "binary": "FUN_004756d0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd"
+      },
+      "__ZeroTail": {
+        "binary": "FUN_004757c0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "__IncMan": {
+        "binary": "FUN_00475830",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "__RoundMan": {
+        "binary": "FUN_004758a0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "__CopyMan": {
+        "binary": "FUN_00475950",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "__FillZeroMan": {
+        "binary": "FUN_00475970",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd"
+      },
+      "__IsZeroMan": {
+        "binary": "FUN_00475980",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "__ShrMan": {
+        "binary": "FUN_004759a0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 4,
+        "source": "retail_function_catalog.gd"
+      },
+      "__ld12cvt": {
+        "binary": "FUN_00475a50",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "FID_conflict:__ld12tod": {
+        "binary": "FUN_00475c20",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "also_at": [
+          {
+            "binary": "FUN_00475c40",
+            "xrefs": 1
+          }
+        ]
+      },
+      "FID_conflict:__atodbl": {
+        "binary": "FUN_00475c60",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "also_at": [
+          {
+            "binary": "FUN_00475ca0",
+            "xrefs": 1
+          }
+        ]
+      },
+      "__fptostr": {
+        "binary": "FUN_00475ce0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd"
+      },
+      "__fltout": {
+        "binary": "FUN_00475d70",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd"
+      },
+      "___dtold": {
+        "binary": "FUN_00475de0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "_mktime": {
+        "binary": "FUN_00475ea0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "__make_time_t": {
+        "binary": "FUN_00475eb0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "__setmode": {
+        "binary": "FUN_00476110",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_ProbeStackPages_v129": {
+        "binary": "FUN_00476190",
+        "role": "Touches each intervening stack page before a large retail stack allocation commits.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_GetWideStringLength_v129": {
+        "binary": "FUN_004761c0",
+        "role": "Returns the character length of one NUL-terminated wide string.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "___crtMessageBoxA": {
+        "binary": "FUN_004761e0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_ConvertWideStringToMultiByte_v129": {
+        "binary": "FUN_00476280",
+        "role": "Converts one wide-character string into the active multibyte code page with CRT-style bounds handling.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "System_CountWideCharsWithLimit_v129": {
+        "binary": "FUN_004764f0",
+        "role": "Counts wide characters up to one caller-supplied limit, including the terminator when it fits.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "FID_conflict:__getenv_lk": {
+        "binary": "FUN_00476530",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "___addl": {
+        "binary": "FUN_004765d0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 7,
+        "source": "retail_function_catalog.gd"
+      },
+      "___add_12": {
+        "binary": "FUN_00476600",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd"
+      },
+      "___shl_12": {
+        "binary": "FUN_00476670",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 9,
+        "source": "retail_function_catalog.gd"
+      },
+      "___shr_12": {
+        "binary": "FUN_004766b0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "___mtold12": {
+        "binary": "FUN_004766f0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "___strgtold12": {
+        "binary": "FUN_004767e0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "$I10_OUTPUT": {
+        "binary": "FUN_00476f30",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "__mbsnbicoll": {
+        "binary": "FUN_004772d0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "___wtomb_environ": {
+        "binary": "FUN_00477310",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_MultiplyExtendedFloat80_v129": {
+        "binary": "FUN_004773a0",
+        "role": "Multiplies two 80-bit extended-float values and stores the normalized result in place.",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "___multtenpow12": {
+        "binary": "FUN_00477650",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      },
+      "___crtCompareStringA": {
+        "binary": "FUN_004776d0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "System_PutEnvironmentStringA_v129": {
+        "binary": "FUN_004779f0",
+        "role": "Applies one ANSI `NAME=VALUE` environment assignment to the retail CRT environment tables.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd",
+        "subsystems": [
+          "shell-state-dispatch"
+        ]
+      },
+      "findenv": {
+        "binary": "FUN_00477c40",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "copy_environ": {
+        "binary": "FUN_00477ca0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "__mbschr": {
+        "binary": "FUN_00477d20",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "__strdup": {
+        "binary": "FUN_00477db0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 3,
+        "source": "retail_function_catalog.gd"
+      },
+      "_strlen": {
+        "binary": "FUN_00477de0",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "FID_conflict:__mbscpy": {
+        "binary": "FUN_00477e60",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "RtlUnwind": {
+        "binary": "FUN_00477f50",
+        "role": "Windows runtime unwind support symbol.",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "__strlwr": {
+        "binary": "FUN_00477f60",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 1,
+        "source": "retail_function_catalog.gd"
+      },
+      "__strcmpi": {
+        "binary": "FUN_00478020",
+        "role": "Retail v1.29 custom-named function imported from the saved Ghidra function catalog",
+        "xrefs": 2,
+        "source": "retail_function_catalog.gd"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Synchronizes `symbols.json` with the current retail v1.29 reverse-engineering catalogs and adds the matching `RESEARCH.md` note that points readers at the new machine-readable symbol section. The update adds a dedicated `MPBTWIN.EXE v1.29` section with imported function names, image-offset addresses, command/helper summaries, duplicate-name address preservation, and subsystem tags from the client research catalog files.

## Related Issue

Closes #161

## Type of Change

- [ ] Bug fix
- [ ] Feature / enhancement
- [x] Research finding / protocol update
- [x] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Chore (dependencies, CI, config)

## Implementation Notes

- Adds `1,290` source rows from `retail_function_catalog.gd` as `1,285` unique v1.29 function names.
- Preserves the five duplicate-name address rows with `also_at` entries.
- Pulls summaries from `retail_command_catalog.gd` and `retail_helper_catalog.gd` where available.
- Adds subsystem membership from `retail_subsystem_catalog.gd` for `1,114` functions.
- Adds a `RESEARCH.md` note tying the v1.29 catalog alignment section to the new `symbols.json` section.
- Leaves the older generic `MPBTWIN.EXE` and `MPBTWIN.EXE v1.23` symbol sections untouched.

## Testing

- `node -e "const s=JSON.parse(require('fs').readFileSync('symbols.json','utf8')); const sec=s['MPBTWIN.EXE v1.29']; console.log('valid JSON; rows=' + sec.source_rows + '; unique=' + sec.unique_names + '; subsystemTagged=' + sec.subsystem_tagged_functions);"`
- Verified the upstream PR branch diff contains only `RESEARCH.md` and `symbols.json`.
- Did not run `npm run build` locally in the temporary upstream worktree because this is a research/symbols documentation update and that worktree does not have `node_modules` installed.

## Checklist

- [x] Branch is based on `master`
- [x] Commit messages follow `type: description` convention (e.g. `fix: correct CRC seed`)
- [ ] TypeScript builds cleanly (`npm run build`)
- [x] No debug `console.log` left in production code paths
- [x] `RESEARCH.md` updated if this reflects a new RE finding
- [x] `symbols.json` updated if new canonical names were introduced
- [x] This PR is ready for review (not a draft)